### PR TITLE
Add a Content Contribution section to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,18 @@ env SASS_BIN=$HOME/.gem/ruby/*/bin/sass pelican content -s pelicanconf.py
   ```
 * Copy the HTML and inline CSS at http://zurb.com/ink/inliner.php - (MailChimp's inliner doesn't remove the CSS from `<head>`).
 * Send the newsletter (we currently use MailChimp).
+
+##  Contributing Content
+
+To propose content for inclusion in the next newsletter (found in the `drafts/`
+folder), create a new [Pull Request][pr] updating the relevant section in the 
+draft.
+
+Some guidelines for contributions:
+
+- Avoid duplicating recent posts
+- Keep it relevant to the Rust community
+- Make sure content abides by the [Rust Code of Conduct][RCoC]
+
+[pr]: https://github.com/cmr/this-week-in-rust/pulls
+[RCoC]: https://www.rust-lang.org/policies/code-of-conduct

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Alternately use GitHub search:
 https://github.com/rust-lang/rust/pulls?q=is%3Apr+is%3Amerged+updated%3A2014-11-03..2014-11-10
 ```
 
-## How I get new contributors:
+## How I get new contributors to Rust:
 
 Use the included `new_contribs.sh` script:
 


### PR DESCRIPTION
Following on from @nasa42's comment on #1003, this adds a *Contributing Content* section to the README to help give us guidelines on how to review contributions.

---

Previous conversation from https://github.com/cmr/this-week-in-rust/pull/1003#issuecomment-534965457:

> Most of the PRs are about adding articles to "News & Blog Posts" section, and a review to determine if the article is worth including to newsletter or not would be quite helpful. Though I need to come up with some rough guidelines first to help determine that.