### PR TITLE
Adding a link to 'Blogpost on Cargo features in IntelliJ Rust' (Tooling)

### DIFF
--- a/draft/2020-11-4-this-week-in-rust.md
+++ b/draft/2020-11-4-this-week-in-rust.md
@@ -17,6 +17,7 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 ### Official
 
 ### Tooling
+* [Blogpost on Cargo features in IntelliJ Rust](https://blog.jetbrains.com/clion/2020/10/intellij-rust-new-functionality-for-cargo-features/)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
Hello, please link our recent blog post in the 'Tooling' section. It describes the new UI implemented in IntelliJ Rust for working with Cargo features. Thank you!