### PR TITLE
Add link to Semantic FFI Bindings in Rust - Reactivating the Borrow Checker

### DIFF
--- a/draft/2020-11-4-this-week-in-rust.md
+++ b/draft/2020-11-4-this-week-in-rust.md
@@ -19,6 +19,7 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 ### Tooling
 
 ### Observations/Thoughts
+* [Semantic FFI Bindings in Rust - Reactivating the Borrow Checker](https://blog.schichler.dev/semantic-ffi-bindings-in-rust-reactivating-the-borrow-checker-ckgxtoxo8057pwrs174dqhcsi)
 
 ### Learn Rust
 


### PR DESCRIPTION
Hopefully I'm doing this right.

I recently put Rust on my wristwatch (custom target, i.e. easier on Nightly) and ended up writing a bit about (mostly) extern types.
I think the blog post would be interesting to the wider Rust community, in that I haven't seen anyone previously write about the patterns this feature enables in practice (beyond also theoretically correct raw pointer types).