### PR TITLE
Add link to German translation of the rust book

### DIFF
--- a/draft/2020-11-4-this-week-in-rust.md
+++ b/draft/2020-11-4-this-week-in-rust.md
@@ -21,6 +21,7 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 ### Observations/Thoughts
 
 ### Learn Rust
+* [The Rust Programming Language (translated in German)](https://rust-lang-de.github.io/rustbook-de/)
 
 ### Project Updates
 

--- a/draft/2020-11-4-this-week-in-rust.md
+++ b/draft/2020-11-4-this-week-in-rust.md
@@ -21,7 +21,7 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 ### Observations/Thoughts
 
 ### Learn Rust
-* [The Rust Programming Language (translated in German)](https://rust-lang-de.github.io/rustbook-de/)
+* [DE] [The Rust Programming Language (translated in German)](https://rust-lang-de.github.io/rustbook-de/)
 
 ### Project Updates
 


### PR DESCRIPTION
I'm happy to provide a link to a German translation of the rust book.

URL of readable book: https://rust-lang-de.github.io/rustbook-de/
URL of code repository: https://github.com/rust-lang-de/rustbook-de