### PR TITLE
📝 Add link to rust-book-fr to 2020-11-11 issue.

### DIFF
--- a/draft/2020-11-11-this-week-in-rust.md
+++ b/draft/2020-11-11-this-week-in-rust.md
@@ -22,6 +22,8 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 
 ### Rust Walkthroughs
 
+* [FR] [The Rust Programming Language (translated in French)](https://jimskapt.github.io/rust-book-fr/)
+
 ### Project Updates
 
 ### Miscellaneous


### PR DESCRIPTION
Hello, there :wave: !

I've seen in the previous issue (`2020-11-04`), there is a link to translation of `The Rust Programming Language` in German.

I've also terminated the French translation a couple of months ago, and I really think it will be a great help for french-speaking beginners.

And by the way we need some proofreaders for some parts of the translation 😉

So, I think the visibility of `this is week in Rust` will be great for our project !

Thank you, cheers !