### PR TITLE
include Dec 10 Rust DC event

### DIFF
--- a/draft/2020-12-9-this-week-in-rust.md
+++ b/draft/2020-12-9-this-week-in-rust.md
@@ -124,6 +124,7 @@ decision. Express your opinions now.
 * [December 8, Seattle, WA, US - Monthly meetup - Seattle Rust Meetup](https://www.meetup.com/Seattle-Rust-Meetup/events/gskksrybcqblb/)
 * [December 10, Stuttgart, DE - Hack & Learn - Directions for 2021 - Rust Community Stuttgart](https://www.meetup.com/de-DE/Rust-Community-Stuttgart/events/274892215/)
 * [December 10, San Diego, CA, US - San Diego Rust December 2020 Tele-Meetup - San Diego Rust](https://www.meetup.com/San-Diego-Rust/events/274757235/)
+* [December 10, Washington, DC, US - How oso built a runtime reflection system for Rust—Rust DC](https://www.meetup.com/RustDC/events/274460587)
 
 ### North America
 * [December 9, Atlanta, GA, US - Grab a beer with fellow Rustaceans - Rust Atlanta](https://www.meetup.com/Rust-ATL/events/qxqdgrybcqbmb/)


### PR DESCRIPTION
Had put it in the community calendar, but it was missed somehow. (Maybe due to it originally having been scheduled for November?)