### PR TITLE
add article "Learning Rust: static trait bounds"

### DIFF
--- a/draft/2020-12-23-this-week-in-rust.md
+++ b/draft/2020-12-23-this-week-in-rust.md
@@ -21,6 +21,7 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 ### Tooling
 
 ### Observations/Thoughts
+* [Learning Rust: static trait bounds](https://codeandbitters.com/static-trait-bound/)
 
 ### Rust Walkthroughs
 


### PR DESCRIPTION
A discussion of what it means when we need `'static` on a generic type, even when no references are present in the code.

This is something that seemed a bit mysterious to me at first, and I couldn't find a satisfying explanation-- so I thought I'd try to write one.