### PR TITLE
Update 2020-12-16-this-week-in-rust.md -- duplicate "Why Rust Has a Bright Future in the Cloud"

### DIFF
--- a/content/2020-12-16-this-week-in-rust.md
+++ b/content/2020-12-16-this-week-in-rust.md
@@ -74,7 +74,6 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 * [Authors of "Programming Rust 2nd Edition" have a sense of humor](https://www.reddit.com/r/rust/comments/kcou9c/authors_of_programming_rust_2nd_edition_have_a/)
 * [Rotating the compiler team leads](https://smallcultfollowing.com/babysteps/blog/2020/12/11/rotating-the-compiler-team-leads/)
 * [Debug Rust on PineCone BL602 with VSCode and GDB](https://lupyuen.github.io/articles/debug)
-* [Why Rust Has a Bright Future in the Cloud](https://www.qovery.com/blog/why-rust-has-a-bright-future-in-the-cloud)
 * [RU] [audio] [SitCast#32 - Эх, Rust, да ещё Rust…](https://www.youtube.com/watch?v=w99C9heBWHE&feature=youtu.be)
 
 # Crate of the Week


### PR DESCRIPTION
Remove duplicate link: `Why Rust Has a Bright Future in the Cloud`.

The link shows up on both `Miscellaneous` and `Observations/Thoughts`:

![this-week-in-rust org_blog_2020_12_16_this-week-in-rust-369_](https://user-images.githubusercontent.com/87983/102574733-76a7b180-412c-11eb-9c2d-a03b71841426.jpg)
