### PR TITLE
Fix link in 2021-01-27 issue

### DIFF
--- a/content/2021-01-27-this-week-in-rust.md
+++ b/content/2021-01-27-this-week-in-rust.md
@@ -26,7 +26,7 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 * [The RustyHermit Unikernel](https://rust-osdev.com/showcase/rusty-hermit/)
 * [Introducing usb-ids.rs](https://blog.yossarian.net/2021/01/21/Introducing-usb-ids-rs)
 * ⚡️ [Dotenv-linter v3.0.0: Overview](https://evrone.com/dotenv-linter-v300) 🦀
-* 🧮 [An Auto-Increment Crate for Rust][https://jeffa.io/an_auto-increment_crate_for_rust]
+* 🧮 [An Auto-Increment Crate for Rust](https://jeffa.io/an_auto-increment_crate_for_rust)
 
 ### Observations/Thoughts
 * [Porting a serverless chatbot from Python to Rust](https://blog.console.dev/porting-a-python-azure-serverless-function-to-rust/)


### PR DESCRIPTION
The markdown was incorrect causing this to render in plaintext rather than as an HTML link