### PR TITLE
Proposed inclusion of an article about wasm.rs

### DIFF
--- a/draft/2021-02-10-this-week-in-rust.md
+++ b/draft/2021-02-10-this-week-in-rust.md
@@ -18,6 +18,8 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 
 ### Project/Tooling Updates
 
+* [Launching wasm.rs: a collection of crates, a community](https://yrashk.medium.com/launching-wasm-rs-a-collection-of-crates-a-community-4344d2ba75b3)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
wasm.rs is an umbrella for a small but growing collection of wasm-related crates and a hope for a growing community