### PR TITLE
Fix disposition for option_unwrap_none

### DIFF
--- a/content/2021-02-10-this-week-in-rust.md
+++ b/content/2021-02-10-this-week-in-rust.md
@@ -153,7 +153,7 @@ decision. Express your opinions now.
 * [disposition: merge] [`impl PartialEq<Punct> for char`; symmetry for #78636](https://github.com/rust-lang/rust/pull/80595)
 * [disposition: merge] [Add an impl of Error on `Arc<impl Error>`.](https://github.com/rust-lang/rust/pull/80553)
 * [disposition: merge] [Add `NotSupported` to `std::io::ErrorKind`](https://github.com/rust-lang/rust/pull/78880)
-* [disposition: merge] [Tracking issue for `Option::expect_none(msg)` and `unwrap_none()`](https://github.com/rust-lang/rust/issues/62633)
+* [disposition: close] [Tracking issue for `Option::expect_none(msg)` and `unwrap_none()`](https://github.com/rust-lang/rust/issues/62633)
 
 ## New RFCs
 

--- a/draft/2021-02-17-this-week-in-rust.md
+++ b/draft/2021-02-17-this-week-in-rust.md
@@ -124,7 +124,7 @@ decision. Express your opinions now.
 * [disposition: merge] [`impl PartialEq<Punct> for char`; symmetry for #78636](https://github.com/rust-lang/rust/pull/80595)
 * [disposition: merge] [Add an impl of Error on `Arc<impl Error>`.](https://github.com/rust-lang/rust/pull/80553)
 * [disposition: merge] [Add `NotSupported` to `std::io::ErrorKind`](https://github.com/rust-lang/rust/pull/78880)
-* [disposition: merge] [Tracking issue for `Option::expect_none(msg)` and `unwrap_none()`](https://github.com/rust-lang/rust/issues/62633)
+* [disposition: close] [Tracking issue for `Option::expect_none(msg)` and `unwrap_none()`](https://github.com/rust-lang/rust/issues/62633)
 
 ## New RFCs
 


### PR DESCRIPTION
It looks like Option::expect_none(msg) and unwrap_none() are in fact not being stabilised: https://github.com/rust-lang/rust/issues/62633#issuecomment-777009512