### PR TITLE
Add a blog post on macros

### DIFF
--- a/draft/2021-02-24-this-week-in-rust.md
+++ b/draft/2021-02-24-this-week-in-rust.md
@@ -25,6 +25,7 @@ No newsletters this week.
 ### Rust Walkthroughs
 
 ### Miscellaneous
+[Macros in Rust: A tutorial with examples](https://blog.logrocket.com/macros-in-rust-a-tutorial-with-examples/)
 
 # Crate of the Week
 


### PR DESCRIPTION
"Macros in Rust: A tutorial with examples" is a blog post explaining macros in rust. It tries to give an overview of macros.