### PR TITLE
Add a "Papers and Research Projects" section

### DIFF
--- a/draft/2021-03-10-this-week-in-rust.md
+++ b/draft/2021-03-10-this-week-in-rust.md
@@ -26,6 +26,9 @@ No newsletters this week.
 
 ### Papers and Research Projects
 
+* [Creusot is a tool for deductive verification of Rust code](https://github.com/xldenis/creusot)
+* [egg, a Rust library for e-graphs and equality saturation](https://egraphs-good.github.io/)
+
 ### Miscellaneous
 
 # Crate of the Week

--- a/draft/2021-03-10-this-week-in-rust.md
+++ b/draft/2021-03-10-this-week-in-rust.md
@@ -24,6 +24,8 @@ No newsletters this week.
 
 ### Rust Walkthroughs
 
+### Papers and Research Projects
+
 ### Miscellaneous
 
 # Crate of the Week
@@ -43,7 +45,7 @@ Every week we highlight some tasks from the Rust community for you to pick and g
 
 Some of these tasks may also have mentors available, visit the task page for more information.
 
-*No calls for participation this week*
+[Our own "Papers and Research Projects" section needs filling!](https://github.com/rust-lang/this-week-in-rust/)
 
 If you are a Rust project owner and are looking for contributors, please submit tasks [here][guidelines].
 


### PR DESCRIPTION
This PR adds a new "Paper and Research Projects" section where authors can present their projects. As all other sections, these are titles and links.

For this weekend, I'm volunteering to do all the work for y'all: you post links in the comments below and I will add them to this PR, up to the next edition.
