### PR TITLE
Add an event that missed the publication deadline

### DIFF
--- a/content/2021-03-10-this-week-in-rust.md
+++ b/content/2021-03-10-this-week-in-rust.md
@@ -160,6 +160,7 @@ decision. Express your opinions now.
 * [March 17, Vancouver, BC, US - Rust Study/Hack/Hang-out night](https://www.meetup.com/Vancouver-Rust/events/npqfbsyccfbwb/)
 * [March 18, Manchester, UK - Rust Manchester Opening Night - Rust Manchester](https://www.meetup.com/rust-manchester/events/276567843/)
 * [March 18, Berlin, DE - Rust Hack and Learn - Berline.rs](https://www.meetup.com/opentechschool-berlin/events/txcprryccfbxb/)
+* [March 18, Florence, IT - Rewriting of a small component from C to Rust - RustLab 2021](https://rustlab.it/en/agenda/from-c-to-rust/)
 * [March 23, Berlin, DE - Rust and Tell - 2021 Kickoff - Berline.rs](https://berline.rs/2021/03/23/rust-and-tell.html)
 * [March 25. Barcelona, ES - BcnRust Meetup](https://www.meetup.com/es-ES/BcnRust/events/276796209/).
 


### PR DESCRIPTION
We missed the deadline for 381 :cry:  but wed better stay with other events in the same date range.

If not possible, I'll update the PR to be included in the next draft.

Thanks!