### PR TITLE
Add "rkyv is faster than {...}" blog post

### DIFF
--- a/draft/2021-03-17-this-week-in-rust.md
+++ b/draft/2021-03-17-this-week-in-rust.md
@@ -28,6 +28,8 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 
 ### Miscellaneous
 
+[rkyv is faster than {bincode, capnp, cbor, flatbuffers, postcard, prost, serde_json}](https://davidkoloski.me/blog/rkyv-is-faster-than/)
+
 # Crate of the Week
 
 This week's crate is [Sorceress](https://crates.io/crates/sorceress), a Rust environment for sound synthesis and algorithmic composition.


### PR DESCRIPTION
The title is a reference to [burntsushi's famous ripgrep post](https://blog.burntsushi.net/ripgrep/), hopefully it's not considered offensive.

This blog post is mostly about a serialization benchmark suite I made and the results from it. Many of the serialization library maintainers (prost, bincode, postcard) have been excited to have a thorough benchmark to use for performance testing.