### PR TITLE
Added link to wrapping a rust crate in a python package

### DIFF
--- a/draft/2021-04-01-this-week-in-rust.md
+++ b/draft/2021-04-01-this-week-in-rust.md
@@ -23,6 +23,7 @@ No newsletters this week.
 ### Observations/Thoughts
 
 ### Rust Walkthroughs
+* [How we built our Python Client that's mostly Rust](https://www.fluvio.io/blog/2021/03/python-client/)
 
 ### Papers and Research Projects
 


### PR DESCRIPTION
Hi there,

I recently authored a post on setting up a rust-wrapped-python package.

I put this in the `Rust Walkthroughs` section but it might be better in the `Miscellaneous`. Thoughts?

Thanks.