### PR TITLE
Adding Slight Software Engineer core team job role

### DIFF
--- a/draft/2021-04-14-this-week-in-rust.md
+++ b/draft/2021-04-14-this-week-in-rust.md
@@ -171,6 +171,10 @@ Email the [Rust Community Team][community] for access.
 
 # Rust Jobs
 
+**Slight**
+
+* [Software Engineer - Core Team, Rust (Remote)](https://www.slight.co/jobs/software-engineer-core)
+
 *Tweet us at [@ThisWeekInRust](https://twitter.com/ThisWeekInRust) to get your job offers listed here!*
 
 # Quote of the Week


### PR DESCRIPTION
Adding our Job Description page: it's for a Rust role at an early stage start up. I assume I shouldn't add a description here (based on what I've seen in the past).

Thanks for maintaining this project!