### PR TITLE
add blog post about faux v0.1

### DIFF
--- a/draft/2021-04-21-this-week-in-rust.md
+++ b/draft/2021-04-21-this-week-in-rust.md
@@ -22,6 +22,8 @@ No papers/research projects this week.
 
 ### Project/Tooling Updates
 
+- [faux: a struct mocking library - landing v0.1](https://nrxus.github.io/faux/blog/landing-v-0-1.html)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
A blog post about the first non-alpha release for the faux mocking library