### PR TITLE
Remove non-rfc from list of new rfcs

### DIFF
--- a/content/2021-06-02-this-week-in-rust.md
+++ b/content/2021-06-02-this-week-in-rust.md
@@ -168,7 +168,7 @@ decision. Express your opinions now.
 
 ## New RFCs
 
-* [Switch from travis to github actions.](https://github.com/rust-lang/rfcs/pull/3136)
+*No new RFCs were proposed this week.*
 
 # Upcoming Events
 


### PR DESCRIPTION
rust-lang/rfcs#3136 contains no RFC.