### PR TITLE
Add link to translation article

### DIFF
--- a/draft/2021-06-09-this-week-in-rust.md
+++ b/draft/2021-06-09-this-week-in-rust.md
@@ -70,6 +70,7 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 * [What's your favourite under-rated Rust crate and why?](https://www.reddit.com/r/rust/comments/nuq1ix/whats_your_favourite_underrated_rust_crate_and_why/)
 * [It's not much, but I graduated from middle-school today with Rust as my language of choice](https://www.reddit.com/r/rust/comments/nrin1u/its_not_much_but_i_graduated_from_middleschool/)
 * [From Julia to Rust](https://miguelraz.github.io/blog/juliatorust/) 
+* [How To Use fastText and Rust For Instant Translations](https://instantdomainsearch.com/engineering/how-to-use-fasttext-for-instant-translations)
 
 ## Crate of the Week
 


### PR DESCRIPTION
Uses a new Rust crate under the covers (which is mentioned in the article), is that on-topic enough?

(Note: the From Julia to Rust article seems to appear twice.)