### PR TITLE
Make content warning more prominent

### DIFF
--- a/content/2021-06-16-this-week-in-rust.md
+++ b/content/2021-06-16-this-week-in-rust.md
@@ -15,7 +15,8 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 ## Updates from Rust Community
 
 **Highlight**
-CW: Suicide, Mental Health
+
+*Content warning: Suicide, Mental Health*
 
 The following post mourns the death of somebody in the Rust community.
 This is a very sensitive topic, and it's hard to truly do justice to the loss of human life.


### PR DESCRIPTION
`CW` doesn't seem to be that common of an abbreviation [based on reddit comments](https://www.reddit.com/r/rust/comments/o1l0xo/this_week_in_rust_395/h22i1mo/?utm_source=reddit&utm_medium=web2x&context=3). This commit writes it out, emphasizes it and puts it on a separate line (seems like it was on the same line as `**Highlight**` by accident).