### PR TITLE
Add fcp v0.2.0 release announcement

### DIFF
--- a/draft/2021-07-07-this-week-in-rust.md
+++ b/draft/2021-07-07-this-week-in-rust.md
@@ -27,6 +27,7 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 * [MoonZoon Dev News (5): Chat example, MoonZoon Cloud](https://dev.to/martinkavik/moonzoon-dev-news-5-chat-example-moonzoon-cloud-5de4)
 * [Fluvio: The Programmable Data Platform](https://www.infinyon.com/blog/2021/06/introducing-fluvio/)
 * [butido - a Linux Package Building Tool in Rust](https://beyermatthias.de/butido-a-linux-package-building-tool-in-rust)
+* [`fcp` 0.2.0 released - A significantly faster alternative to `cp`](https://github.com/Svetlitski/fcp)
 
 ### Observations/Thoughts
 * [Walking through "The Java Tutorials" with Rust - 'What Is an Interface?' and specialization](https://rust-java-tutorials.netlify.app/blog/6-interfaces/)


### PR DESCRIPTION
I released the 0.2.0 version of [`fcp`](https://github.com/Svetlitski/fcp) today with a number of improvements, and would like to announce this in the newsletter.