### PR TITLE
update Rust description

### DIFF
--- a/draft/2021-07-14-this-week-in-rust.md
+++ b/draft/2021-07-14-this-week-in-rust.md
@@ -4,7 +4,7 @@ Date: 2021-07-14
 Category: This Week in Rust
 
 Hello and welcome to another issue of *This Week in Rust*!
-[Rust](http://rust-lang.org) is a systems language pursuing the trifecta: safety, concurrency, and speed.
+[Rust](http://rust-lang.org) is a programming language language empowering everyone to build reliable and efficient software.
 This is a weekly summary of its progress and community.
 Want something mentioned? Tweet us at [@ThisWeekInRust](https://twitter.com/ThisWeekInRust) or [send us a pull request](https://github.com/rust-lang/this-week-in-rust).
 Want to get involved? [We love contributions](https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md).

--- a/draft/2021-07-14-this-week-in-rust.md
+++ b/draft/2021-07-14-this-week-in-rust.md
@@ -4,7 +4,7 @@ Date: 2021-07-14
 Category: This Week in Rust
 
 Hello and welcome to another issue of *This Week in Rust*!
-[Rust](http://rust-lang.org) is a programming language language empowering everyone to build reliable and efficient software.
+[Rust](http://rust-lang.org) is a programming language empowering everyone to build reliable and efficient software.
 This is a weekly summary of its progress and community.
 Want something mentioned? Tweet us at [@ThisWeekInRust](https://twitter.com/ThisWeekInRust) or [send us a pull request](https://github.com/rust-lang/this-week-in-rust).
 Want to get involved? [We love contributions](https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md).


### PR DESCRIPTION
Make the brief blurb about the Rust language match the one from the official language page.

I actually don't feel strongly one way or another about this change but I figured I'd point it out in case it was a genuine oversight.
