### PR TITLE
Added walkthrough for rust in electron

### DIFF
--- a/draft/2021-07-21-this-week-in-rust.md
+++ b/draft/2021-07-21-this-week-in-rust.md
@@ -31,6 +31,7 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 ### Rust Walkthroughs
 
 * [Host a Wasm module easily on Raspberry Pi Part 2](https://blog.knoldus.com/host-a-wasm-module-easily-on-raspberry-pi-part-2/)
+* [Run rust wasm in electron app](https://domtac.github.io/rust/webassembly/electron/2021/07/20/Run-rust-in-electron.html)
 
 ### Papers
 


### PR DESCRIPTION
Noted the steps necessary to setup a wasm with wasm-pack in a electron app derived  from electron_boiler_plate project