### PR TITLE
Add new walkthrough for end-to-end encryption using ockam crate

### DIFF
--- a/draft/2021-08-04-this-week-in-rust.md
+++ b/draft/2021-08-04-this-week-in-rust.md
@@ -25,6 +25,7 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 
 ### Rust Walkthroughs
 * [Implementing Base64 from scratch with Rust](https://dev.to/tiemen/implementing-base64-from-scratch-in-rust-kb1)
+* [How I built End-to-End Encrypted Messaging in 51 lines of Rust, using the Ockam crate](https://github.com/ockam-network/ockam/tree/develop/documentation/use-cases/end-to-end-encryption-with-rust#readme)
 
 ### Research
 


### PR DESCRIPTION
Hello!

This PR adds a [new walk-through](https://github.com/ockam-network/ockam/tree/develop/documentation/use-cases/end-to-end-encryption-with-rust#readme) that we just published, showing how to build end to end encrypted channels using the ockam crate.

Cheers,
Jared