### PR TITLE
Add proposal for my article on collecting `Result` types

### DIFF
--- a/draft/2021-08-10-this-week-in-rust.md
+++ b/draft/2021-08-10-this-week-in-rust.md
@@ -19,6 +19,7 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 ### Project/Tooling Updates
 
 ### Observations/Thoughts
+* [On Collecting Result Types in Rust](https://diaries.vercel.app/posts/collecting-result/)
 
 ### Rust Walkthroughs
 


### PR DESCRIPTION
Proposes my article titled "On Collecting Result Types in Rust" for the upcoming issue 403.