### PR TITLE
Fix (already-published) link to nailing-cargo 1.0.0 blog post

### DIFF
--- a/content/2021-08-18-this-week-in-rust.md
+++ b/content/2021-08-18-this-week-in-rust.md
@@ -24,7 +24,7 @@ In the case of this newsletter, 404 is indeed found!
 * [This week in Fluvio #2: the programmable streaming platform](https://www.fluvio.io/news/this-week-in-fluvio-0002/)
 * [This Week In TensorBase 15](https://tensorbase.io/thisweek/2021-08-11-tw_15/)
 * [This week in Datafuse #2](https://datafuselabs.github.io/weekly/2021-08-11-datafuse-weekly/) & [This week in Datafuse #3](https://datafuselabs.github.io/weekly/2021-08-18-datafuse-weekly/)
-* [nailing-cargo 1.0.0 - cargo wrapper for privsep, and for unpublished dependencies](https://diziet.dreamwidth.org/)
+* [nailing-cargo 1.0.0 - cargo wrapper for privsep, and for unpublished dependencies](https://diziet.dreamwidth.org/8848.html)
 * [wgpu: Release of a Pure-Rust v0.10 and a Call For Testing](https://gfx-rs.github.io/2021/08/18/release-0.10.html)
 * [video] [rg3d game engine v0.22 - feature highlights](https://www.reddit.com/r/rust/comments/p2x38x/media_rg3d_game_engine_v022_feature_highlights/)
 


### PR DESCRIPTION
This should link to the specific post, not my blog in general.
Sorry for the extra work.