### PR TITLE
add a script to inspect links and report problems

### DIFF
--- a/tools/inspect_links.py
+++ b/tools/inspect_links.py
@@ -232,7 +232,7 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--paths', default='content:draft',
                         help="Directory paths to inspect (colon separated)")
-    parser.add_argument('--num-recent', default=5, type=int,
+    parser.add_argument('--num-recent', default=25, type=int,
                         help="Number of recent files to inspect")
     parser.add_argument('--num-warn', default=1, type=int,
                         help="Number of recent files to warn about")

--- a/tools/inspect_links.py
+++ b/tools/inspect_links.py
@@ -1,0 +1,192 @@
+#!/usr/bin/python3
+
+"""
+Inspect a set of markdown files, and warn if there are:
+- duplicate links
+- malformed links
+"""
+
+import argparse
+import bs4
+import logging
+import markdown
+import os
+import re
+import sys
+import urllib
+
+LOG = logging.getLogger(__name__)
+LOG.setLevel(logging.INFO)
+
+
+class Warnings:
+    """ A singleton object for gathering warnings to be printed later. """
+    def __init__(self):
+        self.warnings = []
+
+    def warn(self, msg):
+        self.warnings.append(msg)
+
+    def get(self):
+        return self.warnings
+
+
+# The singleton object that gathers warnings, for later reporting.
+warnings = Warnings()
+
+# A regex that matches filenames to inspect.
+RE_FILENAME = re.compile(r'\d\d\d\d-\d\d-\d\d-this-week-in-rust.md')
+
+# A list of URLs that require HTTP parameters for uniqueness.
+KEEP_PARAMETERS = [
+    'www.youtube.com/watch',
+    'youtube.com/watch',
+    'www.youtube.com/playlist',
+    'youtube.com/playlist',
+    'www.phoronix.com/scan.php',
+]
+
+# A list of section titles that will trigger duplicate-tag detection.
+STRICT_TITLES = [
+    'project/tooling updates',
+    'observations/thoughts',
+    'rust walkthroughs',
+    'miscellaneous',
+]
+
+
+def is_strict_title(title):
+    """ Return True if this title is one that needs strict checks. """
+    title = str(title)
+    # .lower() doesn't necessarily handle unicode in a robust way,
+    # but the set of strings we care about is tiny, and use only ascii.
+    return title.lower() in STRICT_TITLES
+
+
+def extract_links(html):
+    """ Return a list of links from this file.
+
+    Links will only be returned if they are within a section deemed "strict".
+    This allows us to ignore links that are deliberately repeated (to this
+    github repo and twitter account, for example).
+
+    Side-effects:
+    - If links are malformed, warnings may be recorded. See `parse_url`
+      for details.
+
+    """
+    strict_mode = False
+    tags = ['a', 'h1', 'h2', 'h3', 'h4']
+    urls = []
+    for tag in bs4.BeautifulSoup(html, 'html.parser').find_all(tags):
+        if tag.name == 'a':
+            link = tag.get('href')
+            LOG.debug(f'found link tag: {link}')
+            if strict_mode:
+                trimmed_url = parse_url(link)
+                urls.append(trimmed_url)
+        else:
+            # This is the title of a section. If this title is "strict",
+            # we will check for any duplicate links inside it.
+            strict_mode = is_strict_title(tag.string)
+            LOG.debug(f'found heading tag: {tag} (strict={strict_mode})')
+
+    return urls
+
+
+def parse_url(link):
+    """ Parse a URL and return it in a stripped-down form.
+
+    This will strip HTTP parameters and anchors (in an effort to better
+    detect duplicate URLs). However, as this would break some common URLs
+    we don't strip parameters that are on the KEEP_PARAMETERS list.
+
+    Side-effects:
+    - If a link does not have a recognized protocol, we will
+      record a warning.
+    """
+    result = urllib.parse.urlparse(link)
+    if result.scheme not in ('mailto', 'http', 'https'):
+        warnings.warn(f"possibly malformed link: {link}")
+    simplified = f'{result.netloc}{result.path}'
+    if simplified in KEEP_PARAMETERS:
+        simplified += f'?{str(result.query)}'
+    return simplified
+
+
+def inspect_file(filename):
+    LOG.info(f'inspecting file {filename}')
+    md_text = open(filename).read()
+    html = markdown.markdown(md_text)
+    links = extract_links(html)
+    LOG.debug(f'examining {len(links)} links')
+    return links
+
+
+def get_recent_files(dir, count):
+    """ return a list of the N most recent markdown files in `dir`.
+
+    We assume the files are named "YYYY-MM-DD-this-week-in-rust-md".
+    """
+    LOG.debug(f'searching for {count} recent files in "{dir}"')
+    listing = os.listdir(path=dir)
+    if not listing:
+        raise Exception(f'No files found in {dir}')
+    listing = list(filter(RE_FILENAME.match, listing))
+    if not listing:
+        raise Exception(f'No matching files found in {dir}')
+    listing.sort()
+    listing = listing[-count:]
+    LOG.info(f'recent files: {listing}')
+    listing = [os.path.join(dir, f) for f in listing]
+    return listing
+
+
+def inspect_files(file_list):
+    """ Inspect a set of files, storing warnings about duplicate links. """
+    linkset = {}
+
+    for file in file_list:
+        links = inspect_file(file)
+        LOG.debug(f'found links: {links}')
+        for link in links:
+            collision = linkset.get(link)
+            if collision:
+                warnings.warn(
+                    f"possible duplicate link {link} in file {file} (also found in {collision}")
+            else:
+                linkset[link] = file
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--path', default='content',
+                        help="Directory path to inspect")
+    parser.add_argument('--num-recent', default=5, type=int,
+                        help="Number of recent files to inspect")
+    parser.add_argument('--debug', action='store_true')
+    args = parser.parse_args()
+    if args.debug:
+        LOG.setLevel(logging.DEBUG)
+    LOG.debug(f'command-line arguments: {args}')
+    file_list = get_recent_files(args.path, args.num_recent)
+    inspect_files(file_list)
+
+
+def setup_logging():
+    log_stderr = logging.StreamHandler()
+    logging.getLogger('').addHandler(log_stderr)
+
+
+if __name__ == "__main__":
+    setup_logging()
+    main()
+
+    warns = warnings.get()
+    if warns:
+        print("warnings exist:")
+        for w in warns:
+            print(w)
+        sys.exit(1)
+    else:
+        print("everything is ok!")

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,0 +1,2 @@
+beautifulsoup4==4.10.0
+Markdown==3.3.5


### PR DESCRIPTION
This is a first draft, for review/comments/etc. Fixes #2378.

This script checks for malformed and duplicated links. The goal would be
to run it in CI to save the editors from the job of noticing that a link
isn't formatted correctly, or was submitted multiple times.

Some notes:
- I wasn't sure where in the tree to put this new python script. For the moment, I just created a subdirectory `tools`.
- The general strategy is to use the python `markdown` module to format each `.md` file, and then use `bs4` to parse the resulting html and extract links.
- Some parts of the document always contain duplicate links, so right now the script also parses html heading tags and only scans the links within specific "sections". This is a little fragile because it requires the list in this script to match what's actually in the issues. Alternatively, it could have a list of URLs that are always ignored?
- Sometimes identical links don't look identical because they have tracking metadata attached (e.g. `?utm_source=reddit`, etc.) so I strip those. That's also a little fragile, and requires an allowlist of sites that need http parameters (e.g. youtube). Maybe this was a dumb idea to begin with, and it would have been simpler to just leave the links alone.
- At present it will report issues on all inspected files. If we don't want to go back in time and fix those issues, we may need some date-threshold that allows errors in old files to not be reported.

For anyone who's curious how often duplicate links occur, here is the output of the script against the last 40 issues:
```text
possible duplicate link adventures.michaelfbryan.com/posts/ffi-safe-polymorphism-in-rust/ in file content/2020-12-16-this-week-in-rust.md (also found in content/2020-12-16-this-week-in-rust.md
possible duplicate link www.abetterinternet.org/post/memory-safe-tls-apache/ in file content/2021-02-10-this-week-in-rust.md (also found in content/2021-02-03-this-week-in-rust.md
possible duplicate link blog.logrocket.com/macros-in-rust-a-tutorial-with-examples/ in file content/2021-02-24-this-week-in-rust.md (also found in content/2021-02-03-this-week-in-rust.md
possible duplicate link blog.stephenmarz.com/2021/02/22/writing-pong-in-rust/ in file content/2021-03-17-this-week-in-rust.md (also found in content/2021-03-10-this-week-in-rust.md
possible duplicate link jduchniewicz.com/posts/2021/02/c-to-rust-or-how-to-render-your-mindset/ in file content/2021-03-17-this-week-in-rust.md (also found in content/2021-03-03-this-week-in-rust.md
possible duplicate link youtube.com/playlist?list=PLfllocyHVgsRwLkTAhG0E-2QxCf-ozBkk in file content/2021-04-07-this-week-in-rust.md (also found in content/2021-02-24-this-week-in-rust.md
possible duplicate link blog.jetbrains.com/rust/2021/04/08/intellij-rust-updates-for-2021-1/ in file content/2021-04-14-this-week-in-rust.md (also found in content/2021-04-07-this-week-in-rust.md
possible duplicate link blainehansen.me/post/red-blue-functions-are-actually-good/ in file content/2021-04-28-this-week-in-rust.md (also found in content/2021-04-21-this-week-in-rust.md
possible duplicate link ferrous-systems.com/blog/gdb-and-defmt/ in file content/2021-05-05-this-week-in-rust.md (also found in content/2021-05-05-this-week-in-rust.md
possible duplicate link blog.knoldus.com/why-rust-for-embedded-development/ in file content/2021-05-19-this-week-in-rust.md (also found in content/2021-05-12-this-week-in-rust.md
possible duplicate link youtu.be/Ys7ma3au5m0 in file content/2021-05-19-this-week-in-rust.md (also found in content/2021-05-12-this-week-in-rust.md
possible duplicate link redpoll.ai/blog/imm-with-rv-12/ in file content/2021-05-26-this-week-in-rust.md (also found in content/2021-05-19-this-week-in-rust.md
possible duplicate link plume.benboeckel.net/~/JustAnotherBlog/designing-rust-bindings-for-rest-ap-is in file content/2021-06-09-this-week-in-rust.md (also found in content/2021-06-02-this-week-in-rust.md
possible duplicate link adventures.michaelfbryan.com/posts/deserializing-binary-data-files/ in file content/2021-06-30-this-week-in-rust.md (also found in content/2021-06-23-this-week-in-rust.md
possible duplicate link www.cmyr.net/blog/keypaths.html in file content/2021-06-30-this-week-in-rust.md (also found in content/2021-06-23-this-week-in-rust.md
possible duplicate link oswalt.dev/2021/06/polymorphism-in-rust/ in file content/2021-06-30-this-week-in-rust.md (also found in content/2021-06-23-this-week-in-rust.md
possible duplicate link cprimozic.net/blog/speeding-up-webcola-with-webassembly/ in file content/2021-07-07-this-week-in-rust.md (also found in content/2021-06-16-this-week-in-rust.md
possible duplicate link jbarszczewski.com/rust-tauri-svelte-tutorial in file content/2021-07-21-this-week-in-rust.md (also found in content/2021-07-14-this-week-in-rust.md
possible duplicate link dev.to/mapoulos/rust-first-thoughts-7l0 in file content/2021-08-04-this-week-in-rust.md (also found in content/2021-07-28-this-week-in-rust.md
possible duplicate link blog.jetbrains.com/rust/2021/08/04/what-s-new-in-intellij-rust-for-the-2021-2-release-cycle/ in file content/2021-08-10-this-week-in-rust.md (also found in content/2021-08-04-this-week-in-rust.md
possible duplicate link blog.guillaume-gomez.fr/articles/2021-07-29+Interacting+with+data+from+FFI+in+Rust in file content/2021-08-10-this-week-in-rust.md (also found in content/2021-08-04-this-week-in-rust.md
possible duplicate link owengage.com/writing/ in file content/2021-08-18-this-week-in-rust.md (also found in content/2021-07-28-this-week-in-rust.md
```