### PR TITLE
Add "Broken Encapsulation" blog post

### DIFF
--- a/draft/2021-09-08-this-week-in-rust.md
+++ b/draft/2021-09-08-this-week-in-rust.md
@@ -19,6 +19,7 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 ### Project/Tooling Updates
 
 ### Observations/Thoughts
+[Broken Encapsulation](https://blog.sunfishcode.online/broken-encapsulation/)
 
 ### Rust Walkthroughs
 


### PR DESCRIPTION
This adds an interesting blog post from sunfishcode about what boundaries Rust's safety guarantees should have.