### PR TITLE
2021-09-08: Add How to avoid lifetime annotations in Rust

### DIFF
--- a/draft/2021-09-08-this-week-in-rust.md
+++ b/draft/2021-09-08-this-week-in-rust.md
@@ -25,6 +25,8 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 
 ### Rust Walkthroughs
 
+* [How to avoid lifetime annotations in Rust (and write clean code)](https://kerkour.com/blog/rust-avoid-lifetimes/)
+
 ### Miscellaneous
 
 * [Rust on RISC-V BL602: Rhai Scripting](https://lupyuen.github.io/articles/rhai)


### PR DESCRIPTION
Hi,

I've rewritten the introduction of my post "How to avoid lifetime annotations in Rust (and write clean code)" which was too offensive.

I've removed all the exaggerations and opinions that may create polarization, to focus on outlining the real problem, which is, in my opinion, code clarity.

I'm making this PR as a separate one, so if the post needs more edits, the other one can still be accepted :)

Sylvain ✌️ 