### PR TITLE
2021-09-15: add dhcproto link

### DIFF
--- a/draft/2021-09-15-this-week-in-rust.md
+++ b/draft/2021-09-15-this-week-in-rust.md
@@ -22,6 +22,7 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 
 * [Announcing Sycamore v0.6.0: Faster and faster with plenty of fixes and features…](https://sycamore-rs.netlify.app/news/announcing-v0.6.0)
 * [SixtyFPS (GUI crate) weekly report 12th of September](https://sixtyfps.io/thisweek/2021-09-13.html)
+* [Introducing DHCProto](https://leshow.github.io/post/dhcproto/)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
For your consideration, a new crate for DHCP