### PR TITLE
2021-09-22 Introducing SeaORM

### DIFF
--- a/draft/2021-09-22-this-week-in-rust.md
+++ b/draft/2021-09-22-this-week-in-rust.md
@@ -20,6 +20,8 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 
 ### Project/Tooling Updates
 
+* [Introducing SeaORM: An async & dynamic ORM for Rust](https://www.sea-ql.org/SeaORM/blog/2021-09-20-introducing-sea-orm)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
We have been developing [SeaORM](https://github.com/SeaQL/sea-orm) for almost a year now. We are pleased to introduce SeaORM `0.2.2` to the Rust community today!