### PR TITLE
adds doc on assembling sections

### DIFF
--- a/docs/assembling_twir.md
+++ b/docs/assembling_twir.md
@@ -1,0 +1,63 @@
+# Assembling This Week in Rust
+
+Every week your editors assemble a collection of links, quotes, crates, and more for Rustaceans around the globe.
+
+This documents the general process for assembling each of the sections.
+
+## Updates from the Rust Community
+
+[@nellshamrell](https://github.com/nellshamrell) currently covers this section, but would welcome help from additional editors!
+
+(Thank you to [@cdmistman](https://github.com/cdmistman) for covering this section so long! We look forward to when you can return!)
+
+Many of the links featured in this section come from pull requests to this GitHub repo and tweets to the [@ThisWeekInRust](https://twitter.com/ThisWeekInRust).
+
+Others, however, come from editors scanning various places that people tend to post Rust links. These include:
+
+* [r/rust](https://www.reddit.com/r/rust/)
+* [Hacker News](https://news.ycombinator.com/)
+* [dev.to](https://dev.to/)
+
+Any link included in This Week in Rust should follow the guidelines in [What do we look for when considering whether to include something in This Week in Rust?](https://github.com/rust-lang/this-week-in-rust#what-do-we-look-for-when-considering-whether-to-include-something-in-this-week-in-rust).
+
+## Crate of the Week
+
+[@llogiq](https://github.com/llogiq) covers this section.
+
+The crates are nominated and voted on in [this forums thread](https://users.rust-lang.org/t/crate-of-the-week/2704/784).
+
+## Quote of the Week
+
+[@llogiq](https://github.com/llogiq) covers this section.
+
+The quotes are nominated and voted on in [this forums thread](https://users.rust-lang.org/t/twir-quote-of-the-week/328).
+
+## Call for Participation Links
+
+[@nellshamrell](https://github.com/nellshamrell) covers this section.
+
+These are submitted in [this forums thread](https://users.rust-lang.org/t/twir-call-for-participation/4821).
+
+## Updates from Rust Core
+
+[@llogiq](https://github.com/llogiq) covers this section and has scripts that collect these links.
+
+## RFCs and FCP Issues/Pull Requests
+
+[@nellshamrell](https://github.com/nellshamrell) currently covers this section, but would welcome help from additional editors!
+
+These are collected using GitHub queries:
+* [Recently approved RFCs](https://github.com/rust-lang/rfcs/commits/master)
+* [RFCs in Final Comment Period](https://github.com/rust-lang/rfcs/labels/final-comment-period)
+* [Issues/PRs in Final Comment Period](https://github.com/rust-lang/rust/labels/final-comment-period)
+* [New RFCs](https://github.com/rust-lang/rfcs/pulls)
+
+## Events
+
+[@nellshamrell](https://github.com/nellshamrell) currently covers this section, but would welcome help from additional editors!
+
+These are collected from the [Rust Community Calendar](https://calendar.google.com/calendar/u/0/embed?src=apd9vmbc22egenmtu5l6c5jbfc@group.calendar.google.com). We generally only feature events that are upcoming in the next 14 days.
+
+## Jobs
+
+This section is currently filled by requests on Twitter and incoming pull requests into this repo.

--- a/docs/assembling_twir.md
+++ b/docs/assembling_twir.md
@@ -58,6 +58,8 @@ These are collected using GitHub queries:
 
 These are collected from the [Rust Community Calendar](https://calendar.google.com/calendar/u/0/embed?src=apd9vmbc22egenmtu5l6c5jbfc@group.calendar.google.com). We generally only feature events that are upcoming in the next 14 days.
 
+Most events include a meetup link, it's important to follow the link and check the date on the meetup page. If the date on the meetup page is different from the date on the calendar, the date on the meetup page should take precedence.
+
 ## Jobs
 
 This section is currently filled by requests on Twitter and incoming pull requests into this repo.


### PR DESCRIPTION
This adds documentation on how we currently assemble each section. I will be looking for additional editors soon (likely through creating a form for people to apply like @nasa42 did a couple of years ago) and this documentation will hopefully help!

[Rendered](https://github.com/rust-lang/this-week-in-rust/blob/7d9ee62dacd0f14482056acab4744a1f4c1cf099/docs/assembling_twir.md)

Signed-off-by: Nell Shamrell <nellshamrell@gmail.com>