### PR TITLE
Use the more accurate wording of 'Rust project' for the PR updates section

### DIFF
--- a/draft/2021-09-29-this-week-in-rust.md
+++ b/draft/2021-09-29-this-week-in-rust.md
@@ -55,7 +55,7 @@ If you are a Rust project owner and are looking for contributors, please submit 
 
 [guidelines]: https://users.rust-lang.org/t/twir-call-for-participation/4821
 
-## Updates from Rust Core
+## Updates from the Rust Project
 
 256 pull requests were [merged in the last week][merged]
 


### PR DESCRIPTION
This wording is a more accurate reflection of the terms used in the project since these are not changes from the core team but the project as a whole. 