### PR TITLE
add link to SyRust paper

### DIFF
--- a/draft/2021-10-06-this-week-in-rust.md
+++ b/draft/2021-10-06-this-week-in-rust.md
@@ -23,6 +23,7 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 ### Rust Walkthroughs
 
 ### Miscellaneous
+* [SyRust: automatic testing of Rust libraries with semantic-aware program synthesis](https://dl.acm.org/doi/abs/10.1145/3453483.3454084)
 
 ## Crate of the Week
 

--- a/draft/2021-10-06-this-week-in-rust.md
+++ b/draft/2021-10-06-this-week-in-rust.md
@@ -18,12 +18,14 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 
 ### Project/Tooling Updates
 
+### Research and Papers
+* [SyRust: automatic testing of Rust libraries with semantic-aware program synthesis](https://dl.acm.org/doi/abs/10.1145/3453483.3454084)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs
 
 ### Miscellaneous
-* [SyRust: automatic testing of Rust libraries with semantic-aware program synthesis](https://dl.acm.org/doi/abs/10.1145/3453483.3454084)
 
 ## Crate of the Week
 


### PR DESCRIPTION
added a link the SyRust paper.  I expect that Miscellaneous is the right section but feel free to move it to another if there's a better one.