### PR TITLE
add guide on how to export mocks across crates

### DIFF
--- a/draft/2021-10-06-this-week-in-rust.md
+++ b/draft/2021-10-06-this-week-in-rust.md
@@ -21,6 +21,7 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 ### Observations/Thoughts
 
 ### Rust Walkthroughs
+* [Exporting Test Mocks Across Crates](https://nrxus.github.io/faux/guide/exporting-mocks.html)
 
 ### Miscellaneous
 


### PR DESCRIPTION
Adds a guide on how to export test mocks across crates. The guide itself focuses on the library `faux` but the solution is library-agnostic. 