### PR TITLE
add article: Does the published crate match the upstream source?

### DIFF
--- a/draft/2021-10-06-this-week-in-rust.md
+++ b/draft/2021-10-06-this-week-in-rust.md
@@ -20,6 +20,8 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 
 ### Observations/Thoughts
 
+[Does the published crate match the upstream source?](https://codeandbitters.com/published-crate-analysis/)
+
 ### Rust Walkthroughs
 
 ### Miscellaneous


### PR DESCRIPTION
I spent a few weeks researching the form of a published crate, and discovering that it can be quite difficult for many crates to find the exact released code in the upstream repository. I learned some interesting things along the way and wanted to share my findings.