### PR TITLE
Add about SeaORM  in observations section

### DIFF
--- a/draft/2021-10-06-this-week-in-rust.md
+++ b/draft/2021-10-06-this-week-in-rust.md
@@ -28,6 +28,7 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 * [Does the published crate match the upstream source?](https://codeandbitters.com/published-crate-analysis/)
 * [video] [Talks from Rust Computer Vision Meetup 2021-09-29 (YouTube playlist)](https://www.youtube.com/watch?v=k023OIxlzpA&list=PL85XCvVPmGQgWcpd230SUixObnBoL9cif)
 * [Measuring power consumption: sync vs. async](https://tweedegolf.nl/blog/62/measuring-power-consumption-sync-vs-async)
+* [[ZH] Rust Web Eco Watch｜ SeaORM: To be the Rust version of ActiveRecord ](https://zhuanlan.zhihu.com/p/417431284)
 
 ### Rust Walkthroughs
 * [Exporting Test Mocks Across Crates](https://nrxus.github.io/faux/guide/exporting-mocks.html)


### PR DESCRIPTION
Rust Web Eco Watch｜ SeaORM: To be the Rust version of ActiveRecord 

* [[ZH] Rust Web Eco Watch｜ SeaORM: To be the Rust version of ActiveRecord ](https://zhuanlan.zhihu.com/p/417431284)