### PR TITLE
Formal verification for dummies and mikino

### DIFF
--- a/draft/2021-10-06-this-week-in-rust.md
+++ b/draft/2021-10-06-this-week-in-rust.md
@@ -21,6 +21,7 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 
 ### Research and Papers
 * [SyRust: automatic testing of Rust libraries with semantic-aware program synthesis](https://dl.acm.org/doi/abs/10.1145/3453483.3454084)
+* [Verification for dummies: SMT and Induction](https://ocamlpro.github.io/verification_for_dummies/) using the [mikino](https://github.com/OCamlPro/mikino_bin) model-checker
 
 * [SixtyFPS (GUI crate) weekly update for 3rd of October 2021](https://sixtyfps.io/thisweek/2021-10-04.html)
 
@@ -34,7 +35,6 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 * [series] [Build Your Text Editor With Rust!](https://medium.com/@otukof/build-your-text-editor-with-rust-678a463f968b)
 
 ### Miscellaneous
-* [Verification for dummies: SMT and Induction](https://ocamlpro.github.io/verification_for_dummies/) using the [mikino](https://github.com/OCamlPro/mikino_bin) model-checker
 
 ## Crate of the Week
 


### PR DESCRIPTION
Link to the [Verification for dummies: SMT and Induction](https://ocamlpro.github.io/verification_for_dummies) tutorial series in **Misc**. Uses the [mikino](https://github.com/OCamlPro/mikino_bin) model-checker in Rust, also available as a [library](https://github.com/OCamlPro/mikino).

Could arguably be in the **Research and Papers** as formal verification/SMT/induction are pretty research-y.