### PR TITLE
Add link to "Making slow Rust code fast" blog post

### DIFF
--- a/draft/2021-10-20-this-week-in-rust.md
+++ b/draft/2021-10-20-this-week-in-rust.md
@@ -25,6 +25,7 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 ### Rust Walkthroughs
 
 * [Custom Logging in Rust using tracing and tracing-subscriber](https://burgers.io/custom-logging-in-rust-using-tracing)
+* [Making slow Rust code fast - performance tuning using Criterion.rs and flamegraphs](https://patrickfreed.github.io/rust/2021/10/15/making-slow-rust-code-fast.html)
 
 ### Miscellaneous
 


### PR DESCRIPTION
I recently published a blog post about performance benchmarking and tuning in Rust and would love to have it included in next weeks newsletter if the content makes sense for it. Thanks!

link to post: https://patrickfreed.github.io/rust/2021/10/15/making-slow-rust-code-fast.html