### PR TITLE
Add Rust Los Angeles events

### DIFF
--- a/draft/2021-11-10-this-week-in-rust.md
+++ b/draft/2021-11-10-this-week-in-rust.md
@@ -177,8 +177,10 @@ decision. Express your opinions now.
 * [November 9, 2021, Berlin, DE - Rust Hack and Learn - Berline.rs](https://berline.rs/)
 * [November 9, 2021, Seattle, WA, US - Monthly Meetup - Seattle Rust Meetup](https://www.meetup.com/Seattle-Rust-Meetup/events/gskksryccpbmb/)
 * [November 10, 2021, Malaysia - Rust Meetup - Rust Malaysia](https://discord.gg/9Xj8H2EXTD)
+* [November 10, 2021, Los Angeles, CA, US - Rust Los Angeles: Live Coding Session - Mob Programming a Rust Code Kata](https://www.meetup.com/Rust-Los-Angeles/events/281944639/)
 * [November 11, 2021 - Rust For Linux: Writing Safe Abstractions & Drivers - The Linux Foundation](https://linuxfoundation.org/webinars/rust-for-linux-writing-abstractions-and-drivers/)
 * [November 17, 2021, Vancouver, BC, CA - Borrowing and Lifetimes through Metaphors - Vancouver Rust](https://www.meetup.com/Vancouver-Rust/events/zkqvjsyccpbwb/)
+* [December 8, 2021, Los Angeles, CA, US - Rust Los Angeles: Rust Computer Vision Project with Geordon Worley](https://www.meetup.com/Rust-Los-Angeles/events/281944671/)
 
 ### North America
 


### PR DESCRIPTION
Putting in the next event and the one after.

BTW, do events that aren't past hang on from week to week? We added our December event, as well as next week's. Do we need to add this again next week?

Thank you for this awesome resource!