### PR TITLE
Add blog post "Mononym: Type-Level Named Values in Rust"

### DIFF
--- a/draft/2021-11-17-this-week-in-rust.md
+++ b/draft/2021-11-17-this-week-in-rust.md
@@ -18,6 +18,8 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 
 ### Project/Tooling Updates
 
+* [Mononym: Type-Level Named Values in Rust](https://maybevoid.com/blog/mononym-part-1/)
+
 ### Newsletter
 
 ### Observations/Thoughts


### PR DESCRIPTION
I recently released the [`mononym`](https://github.com/maybevoid/mononym) crate and written an [introductory blog post](https://maybevoid.com/blog/mononym-part-1/) for it. I hope this is of interest for the Rust community.