### PR TITLE
Add "Stack-safety for free?" blog post

### DIFF
--- a/draft/2021-11-24-this-week-in-rust.md
+++ b/draft/2021-11-24-this-week-in-rust.md
@@ -22,6 +22,8 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 
 ### Observations/Thoughts
 
+* [Stack-safety for free?](https://hurryabit.github.io/blog/stack-safety-for-free/)
+
 ### Rust Walkthroughs
 
 ### Miscellaneous


### PR DESCRIPTION
I wrote a blog post demonstrating how to (ab)use Rust's generators to transform any recursive function into an iterative function with nearly zero code changes.

I would like to add a link to the post to the "Observations/Thoughts" section.