### PR TITLE
Add link to blog post on merge queues

### DIFF
--- a/draft/2021-11-24-this-week-in-rust.md
+++ b/draft/2021-11-24-this-week-in-rust.md
@@ -22,9 +22,9 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 
 ### Observations/Thoughts
 
-### Rust Walkthroughs
-
 - [Merge Queues with Bors](https://kflansburg.com/posts/merge-queues/)
+
+### Rust Walkthroughs
 
 ### Miscellaneous
 

--- a/draft/2021-11-24-this-week-in-rust.md
+++ b/draft/2021-11-24-this-week-in-rust.md
@@ -24,6 +24,8 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 
 ### Rust Walkthroughs
 
+- [Merge Queues with Bors](https://kflansburg.com/posts/merge-queues/)
+
 ### Miscellaneous
 
 ## Crate of the Week


### PR DESCRIPTION
Not Rust-specific, but merge queues can be very helpful for Rust projects (due to longer build times), and this post covers the usage of Bors, which new contributors to `rustc` may find useful. 