### PR TITLE
add link to Calling Rust from Python using PyO3

### DIFF
--- a/draft/2021-11-24-this-week-in-rust.md
+++ b/draft/2021-11-24-this-week-in-rust.md
@@ -24,6 +24,7 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 
 ### Rust Walkthroughs
 
+* [Calling Rust from Python using PyO3](https://saidvandeklundert.net/learn/2021-11-18-calling-rust-from-python-using-pyo3/)
 ### Miscellaneous
 
 ## Crate of the Week


### PR DESCRIPTION
I wrote a blog on how you can use PyO3 to call Rust directly from Python and would like to add a link to the post to the "Rust Walkthroughs" section.