### PR TITLE
Added two related blog posts

### DIFF
--- a/draft/2021-11-24-this-week-in-rust.md
+++ b/draft/2021-11-24-this-week-in-rust.md
@@ -29,10 +29,12 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 * [Rust Packages vs Crates](https://jeffa.io/rust_packages_vs_crates)
 - [Merge Queues with Bors](https://kflansburg.com/posts/merge-queues/)
 * [Stack-safety for free?](https://hurryabit.github.io/blog/stack-safety-for-free/)
+* [Intrusive Smart Pointers + Heap Only Types = 💞](https://blog.schichler.dev/intrusive-smart-pointers-heap-only-types-ckvzj2thw0caoz2s1gpmi1xm8)
 
 ### Rust Walkthroughs
 
 * [Calling Rust from Python using PyO3](https://saidvandeklundert.net/learn/2021-11-18-calling-rust-from-python-using-pyo3/)
+* [Pinning in plain English](https://blog.schichler.dev/pinning-in-plain-english-ckwdq3pd0065zwks10raohh85)
 ### Miscellaneous
 
 ## Crate of the Week


### PR DESCRIPTION
I wrote two mutually related blog posts last and this week that are probably interesting. I hope I got the categories right:

[Intrusive Smart Pointers + Heap Only Types = 💞](https://blog.schichler.dev/intrusive-smart-pointers-heap-only-types-ckvzj2thw0caoz2s1gpmi1xm8) is sort of in walkthrough format, but it's on a topic that I haven't seen before like this at all in a Rust context. I put it into *Observations/Thoughts* since it's an independent discovery, even though it turns out that pattern actually has [standard library support in C++](https://en.cppreference.com/w/cpp/memory/enable_shared_from_this).

[Pinning in plain English](https://blog.schichler.dev/pinning-in-plain-english-ckwdq3pd0065zwks10raohh85) is the post I wrote this week and offers context/explanations on exactly why I laid out my intrusive pointer API the way I did. I hadn't found any intro texts on that topic that could answer questions I got in response to the first post, so I wrote one, but it's mostly just a (hopefully) thorough look at what the stable pinning API is capable of, with little content I haven't seen in some form elsewhere. It's also aimed more at beginner Rust developers or those unfamiliar with the language. I assume the *Rust Walkthroughs* category is a good fit due to that, but please correct me if I'm wrong (on either account!).


Thanks for running this newsletter! (and hopefully late-including the first post isn't an issue.)