### PR TITLE
remove tracking parameters from link in 2021-11-24 issue

### DIFF
--- a/content/2021-11-24-this-week-in-rust.md
+++ b/content/2021-11-24-this-week-in-rust.md
@@ -29,7 +29,7 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 
 ### Observations/Thoughts
 
-* [mod team resignation](https://github.com/rust-lang/team/pull/671?utm_source=thenewstack&utm_medium=website&utm_campaign=platform)
+* [mod team resignation](https://github.com/rust-lang/team/pull/671)
 * [My Path to Magma: How I slowly became convinced we absolutely have to build a proof checker and bring formal verification to the mainstream.](https://blainehansen.me/post/my-path-to-magma/)
 * [Rust Packages vs Crates](https://jeffa.io/rust_packages_vs_crates)
 * [Merge Queues with Bors](https://kflansburg.com/posts/merge-queues/)


### PR DESCRIPTION
I think we have reached a consensus that tracking parameters on links are undesirable and should be removed.