### PR TITLE
Use bullets for "Approved RFCs"

### DIFF
--- a/content/2021-11-24-this-week-in-rust.md
+++ b/content/2021-11-24-this-week-in-rust.md
@@ -185,8 +185,8 @@ Revision range: [934624fe..22c2d9dd](https://perf.rust-lang.org/?start=934624fe5
 Changes to Rust follow the Rust [RFC (request for comments) process](https://github.com/rust-lang/rfcs#rust-rfcs). These
 are the RFCs that were approved for implementation this week:
 
-[Constrained Naked Functions](https://github.com/rust-lang/rfcs/pull/2972)
-[Cargo --crate-type CLI Argument](https://github.com/rust-lang/rfcs/pull/3180)
+* [Constrained Naked Functions](https://github.com/rust-lang/rfcs/pull/2972)
+* [Cargo --crate-type CLI Argument](https://github.com/rust-lang/rfcs/pull/3180)
 
 ### Final Comment Period
 


### PR DESCRIPTION
There are two entries - but they appear on one line making it a little less visible.
Turning it into a bulleted list to make it clear that there are 2 Approved RFC's.