### PR TITLE
Shouldn't Blackhat be in "Rust Walkthroughs'" section

### DIFF
--- a/content/2021-12-01-this-week-in-rust.md
+++ b/content/2021-12-01-this-week-in-rust.md
@@ -20,7 +20,6 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 
 ### Project/Tooling Updates
 * [Rust Analyzer Changelog #105](https://rust-analyzer.github.io//thisweek/2021/11/29/changelog-105.html)
-* [Black Hat Week (Black Hat Rust is out 🍾)](https://kerkour.com/black-hat-rust-week-2021/)
 * [SixtyFPS (GUI crate): Changelog for 28th of November 2021 – 0.1.15 Release](https://sixtyfps.io/thisweek/2021-11-29.html)
 * [This week in Databend #18: an elastic and reliable cloud warehouse](https://weekly.databend.rs/2021-12-01-databend-weekly/)
 * [Wasmer 2.1](https://wasmer.io/posts/wasmer-2.1)
@@ -44,6 +43,7 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 * [video] [Mats Kindahl: A C++ programmer's view on Rust](https://www.youtube.com/watch?v=DGbsHENouy4)
 
 ### Rust Walkthroughs
+* [Black Hat Week (Black Hat Rust is out 🍾)](https://kerkour.com/black-hat-rust-week-2021/)
 * [Using WebAssembly (created in Rust) for Fast React Components](https://www.joshfinnie.com/blog/using-webassembly-created-in-rust-for-fast-react-components/)
 * [Speed up Rust Builds with Cachepot](https://kflansburg.com/posts/rust-cachepot/)
 * [Rena’s Memory Model](https://veera.app/rena%27s_memory_model.html)


### PR DESCRIPTION
I think thats not the right fit for it (place to be), and must be in the **Rust Walkthroughs'** section. 

It's a project, for sure. But not such as a totally free project on rust (black hat rust - the book), neither it's a crate/tooling? - Its kinda an Article/How-to/Tutorial, so maybe: **Walktrought.."'s section then?