### PR TITLE
 Adding the Brazilian unofficial translation 🇧🇷 

### DIFF
--- a/draft/2021-12-08-this-week-in-rust.md
+++ b/draft/2021-12-08-this-week-in-rust.md
@@ -24,7 +24,7 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 ### Rust Walkthroughs
 
 ### Miscellaneous
-
+[BR-pt][Esta Semana em Rust #419](https://github.com/luisvonmuller/Esta-Semana-Em-Rust/blob/main/%23419.md)
 ## Crate of the Week
 
 This week's crate is [poem-openapi](https://crates.io/crates/poem-openapi), a framework to implement OpenAPI services.

--- a/draft/2021-12-08-this-week-in-rust.md
+++ b/draft/2021-12-08-this-week-in-rust.md
@@ -17,7 +17,6 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 ### Official
 
 ### Project/Tooling Updates
-[Updates in IntelliJ Rust for 2021.3](https://blog.jetbrains.com/rust/2021/12/06/updates-in-intellij-rust-for-2021-3/)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
First things first, as always.
This translation idea came from getting people interested in The Rust programming language. And by that I mean there is no reason by now to translate things like RFC's, rust's PR's, English Events and others like (as well jobs, by now).

This is just a small step for the rust community, but **the** big step for the Brazilian's Rust Community. :)  

The right way maybe should be "PT-BR" - but I'll just change to this when Portugal give us our gold and "Pau Brasil" back.