### PR TITLE
Add Minority Game Demo video

### DIFF
--- a/draft/2021-12-15-this-week-in-rust.md
+++ b/draft/2021-12-15-this-week-in-rust.md
@@ -24,6 +24,8 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 
 ### Rust Walkthroughs
 
+* [video] [Building a networked Web and Native app using BonsaiDb and Gooey](https://youtu.be/yIkUWT4QXCA)
+
 ### Miscellaneous
 
 ## Crate of the Week


### PR DESCRIPTION
Added a video showing building a networked application using two early-in-development crates we've been working on. The demo being built was for yesterday's Rust Gamedev Meetup.

I believe this was the best section to place it based on similar videos in previous newsletter entries.