### PR TITLE
Add blog post about the new version of git-cliff

### DIFF
--- a/draft/2021-12-15-this-week-in-rust.md
+++ b/draft/2021-12-15-this-week-in-rust.md
@@ -27,6 +27,8 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 
 * [SixtyFPS (GUI crate): Changelog for 12th of December 2021](https://sixtyfps.io/thisweek/2021-12-13.html)
 
+* [git-cliff 0.5.0 (changelog generator)](https://orhun.dev/blog/git-cliff-0.5.0/)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
Hello!

I'm the maintainer of [git-cliff](https://github.com/orhun/git-cliff), a changelog generator tool written in Rust. I recently released the new version of this tool and I also published a blog post about its new features. I think featuring this blog post in This Week In Rust would help about finding potential contributors to the project as well as announcing the new features.

Thank you! :bear:

