### PR TITLE
remove duplicate links from 2021_12_15 issue

### DIFF
--- a/content/2021-12-15-this-week-in-rust.md
+++ b/content/2021-12-15-this-week-in-rust.md
@@ -40,9 +40,6 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 * [This week in Databend #20: an elastic and reliable cloud warehouse](https://weekly.databend.rs/2021-12-15-databend-weekly/)
 * [This week in Fluvio #16: the programmable streaming platform](https://www.fluvio.io/news/this-week-in-fluvio-0016/)
 * [git-cliff 0.5.0 (changelog generator)](https://orhun.dev/blog/git-cliff-0.5.0/)
-* [Announcing Enzyme for Rust](https://www.reddit.com/r/rust/comments/reo75u/enzyme_towards_stateoftheart_autodiff_in_rust/)
-* [This week in Databend #20: an elastic and reliable cloud warehouse](https://weekly.databend.rs/2021-12-15-databend-weekly/)
-* [This week in Fluvio #16: the programmable streaming platform](https://www.fluvio.io/news/this-week-in-fluvio-0016/)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
Not sure how these happened, but 3 links are duplicated in this issue's "Project/Tooling Updates" section.

Fixes #2708.