### PR TITLE
Restore full content inside RSS feed

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -27,6 +27,7 @@ FEED_ALL_RSS = 'rss.xml'
 FEED_MAX_ITEMS = 4
 CATEGORY_FEED_ATOM = 'categories/{slug}/atom.xml'
 CATEGORY_FEED_RSS = 'categories/{slug}/rss.xml'
+RSS_FEED_SUMMARY_ONLY = False
 
 DEFAULT_PAGINATION = 10
 


### PR DESCRIPTION
Hi,

Having all the links directly inside the feed allow me to add links to Pocket without leaving my RSS reader.

I don't know if I'm the only one with this workflow, but since there is no ad in the main website, I don't think there is a reason to force the reader to go to the main website to read the links?

This was the behavior before the update a few weeks ago.

Best regards,
Thibaud