### PR TITLE
Add github action workflow for link-checker script

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -13,4 +13,4 @@ jobs:
           update-pip: "false"
           update-setuptools: "false"
           update-wheel: "false"
-      - run: python3 tools/inspect_links.py
+      - run: python3 tools/inspect_links.py --num-warn 5

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,16 @@
+name: Correctness Checks
+on: [push, pull_request]
+jobs:
+  Run-Link-Checker:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: Install Python dependencies
+        uses: py-actions/py-dependency-install@v3
+        with:
+          path: "tools/requirements.txt"
+          update-pip: "false"
+          update-setuptools: "false"
+          update-wheel: "false"
+      - run: python3 tools/inspect_links.py

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,2 +1,2 @@
 beautifulsoup4==4.10.0
-Markdown==3.3.5
+Markdown==3.3.6


### PR DESCRIPTION
When a push or PR happens, run the link-checker script.
- look back through 25 most recent issues (in /draft and /content)
- warn only for errors that exist in the 5 most recent issues (to allow for correction PRs that arrive after an issue is published).

This also upgrades Markdown from 3.3.5 to 3.3.6, because 3.3.5 seems to have been yanked for non-security reasons, and the github dependency script refuses to install yanked versions.

