### PR TITLE
inspect_links: all logging to stdout

### DIFF
--- a/tools/inspect_links.py
+++ b/tools/inspect_links.py
@@ -246,8 +246,8 @@ def main():
 
 
 def setup_logging():
-    log_stderr = logging.StreamHandler()
-    logging.getLogger('').addHandler(log_stderr)
+    log_stdout = logging.StreamHandler(sys.stdout)
+    logging.getLogger('').addHandler(log_stdout)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In github actions, stdout and stderr are interleaved weirdly, making the output hard to read ([example](https://github.com/rust-lang/this-week-in-rust/runs/4722235297)). To fix this, don't log messages to both-- just use stdout for everything.