### PR TITLE
fix some unescaped angle brackets and broken backtick pairs

### DIFF
--- a/content/2020-03-17-this-week-in-rust.md
+++ b/content/2020-03-17-this-week-in-rust.md
@@ -122,7 +122,7 @@ decision. Express your opinions now.
 
 * [disposition: merge] [Allow obtaining &mut OsStr](https://github.com/rust-lang/rust/pull/70048).
 * [disposition: merge] [`is_x86_feature_detected!("avx512f")` fails to build on beta and nightly](https://github.com/rust-lang/rust/issues/68905).
-* [disposition: merge] [impl From<[T; N]> for Vec<T>](https://github.com/rust-lang/rust/pull/68692).
+* [disposition: merge] [`impl From<[T; N]> for Vec<T>`](https://github.com/rust-lang/rust/pull/68692).
 * [disposition: merge] [Amend Rc/Arc::from_raw() docs regarding unsafety](https://github.com/rust-lang/rust/pull/68099).
 
 ## New RFCs

--- a/content/2020-03-24-this-week-in-rust.md
+++ b/content/2020-03-24-this-week-in-rust.md
@@ -111,7 +111,7 @@ decision. Express your opinions now.
 
 * [disposition: merge] [Tracking issue for `{f32,f64}::approx_unchecked_to` methods](https://github.com/rust-lang/rust/issues/67058).
 * [disposition: merge] [Allow obtaining &mut OsStr](https://github.com/rust-lang/rust/pull/70048).
-* [disposition: merge] [impl From<[T; N]> for Vec<T>](https://github.com/rust-lang/rust/pull/68692).
+* [disposition: merge] [`impl From<[T; N]> for Vec<T>`](https://github.com/rust-lang/rust/pull/68692).
 * [disposition: merge] [Implement Hash for Infallible](https://github.com/rust-lang/rust/pull/70281).
 
 ## New RFCs

--- a/content/2020-05-12-this-week-in-rust.md
+++ b/content/2020-05-12-this-week-in-rust.md
@@ -127,7 +127,7 @@ decision. Express your opinions now.
 
 * [disposition: merge] [Stablilize saturating_abs and saturating_neg](https://github.com/rust-lang/rust/pull/71886)
 * [disposition: merge] [Tweak and stabilize AtomicN::fetch_update](https://github.com/rust-lang/rust/pull/71843)
-* [disposition: merge] [impl From<Cow> for Box, Rc, and Arc](https://github.com/rust-lang/rust/pull/71447)
+* [disposition: merge] [impl `From<Cow>` for Box, Rc, and Arc](https://github.com/rust-lang/rust/pull/71447)
 * [disposition: merge] [Stabilize fn-like proc macros in expression, pattern and statement positions](https://github.com/rust-lang/rust/pull/68717)
 * [disposition: merge] [Tracking issue for Weak::into_raw/from_raw & similar](https://github.com/rust-lang/rust/issues/60728)
 * [disposition: clone] [Tracking issue for non_static_type_id](https://github.com/rust-lang/rust/issues/41875)

--- a/content/2020-05-27-this-week-in-rust.md
+++ b/content/2020-05-27-this-week-in-rust.md
@@ -65,7 +65,7 @@ Some of these tasks may also have mentors available, visit the task page for mor
 * [ruma: Replace impl_enum! with strum derives](https://github.com/ruma/ruma-events/issues/90)
 * [time-rs: Revamped parsing/formatting](https://github.com/time-rs/time/issues/236)
 * [http-types: Request::query should match Tide's behavior](https://github.com/http-rs/http-types/issues/154)
-* [http-types: Status should take TryInto<StatusCode/>](https://github.com/http-rs/http-types/issues/155)
+* [http-types: Status should take `TryInto<StatusCode>`](https://github.com/http-rs/http-types/issues/155)
 * [http-types: Expose method shorthands for Request constructor](https://github.com/http-rs/http-types/issues/156)
 
 

--- a/content/2020-06-30-this-week-in-rust.md
+++ b/content/2020-06-30-this-week-in-rust.md
@@ -112,7 +112,7 @@ If you are a Rust project owner and are looking for contributors, please submit 
 * [shortcuts for min/max on ordinary BTreeMap/BTreeSet iterators](https://github.com/rust-lang/rust/pull/73627)
 * [add `TryFrom<{int}>` for `NonZero{int}`](https://github.com/rust-lang/rust/pull/72717)
 * [add a fast path for `std::thread::panicking`.](https://github.com/rust-lang/rust/pull/72617)
-* [add `[T]::partition_point`](https://github.com/rust-lang/rust/pull/73577)
+* [add `[T]::partition_point`](https://github.com/rust-lang/rust/pull/73577) &nbsp;
 * [add unstable `core::mem::variant_count` intrinsic](https://github.com/rust-lang/rust/pull/73418)
 * [added io forwarding methods to the stdio structs](https://github.com/rust-lang/rust/pull/72705)
 * [stabilize `leading_trailing_ones`](https://github.com/rust-lang/rust/pull/73032)

--- a/content/2020-08-18-this-week-in-rust.md
+++ b/content/2020-08-18-this-week-in-rust.md
@@ -119,7 +119,7 @@ If you are a Rust project owner and are looking for contributors, please submit 
 * [detect JS-style `===` and `!==` and recover](https://github.com/rust-lang/rust/pull/75321)
 * [detect likely `for foo of bar` JS syntax](https://github.com/rust-lang/rust/pull/75320)
 * [move stack size check to `const_eval` machine](https://github.com/rust-lang/rust/pull/75338)
-* [add `array` lang item and `[T; N]::map(f: FnMut(T) -> S)`](https://github.com/rust-lang/rust/pull/75212)
+* [add `array` lang item and `[T; N]::map(f: FnMut(T) -> S)`](https://github.com/rust-lang/rust/pull/75212) &nbsp;
 * [remove branch in optimized `is_ascii`](https://github.com/rust-lang/rust/pull/74562)
 * [constified `str::from_utf8_unchecked`](https://github.com/rust-lang/rust/pull/75157)
 * [hard way to respect `BTreeMap`'s minimum node length](https://github.com/rust-lang/rust/pull/75105)

--- a/content/2020-09-09-this-week-in-rust.md
+++ b/content/2020-09-09-this-week-in-rust.md
@@ -115,7 +115,7 @@ If you are a Rust project owner and are looking for contributors, please submit 
 * [stabilize `deque_make_contiguous`](https://github.com/rust-lang/rust/pull/74559)
 * [add `slice::check_range`](https://github.com/rust-lang/rust/pull/75207)
 * [BTreeMap: introduce marker::ValMut and reserve Mut for unique access](https://github.com/rust-lang/rust/pull/75200)
-* [add `[T; N]::as_[mut_]slice`](https://github.com/rust-lang/rust/pull/76120)
+* [add `[T; N]::as_[mut_]slice`](https://github.com/rust-lang/rust/pull/76120) &nbsp;
 * [implement `Seek::stream_position()` for `BufReader`](https://github.com/rust-lang/rust/pull/74366)
 * [`impl Rc::new_cyclic`](https://github.com/rust-lang/rust/pull/75994)
 * [make `cow_is_borrowed` methods const](https://github.com/rust-lang/rust/pull/76139)

--- a/content/2020-09-23-this-week-in-rust.md
+++ b/content/2020-09-23-this-week-in-rust.md
@@ -141,7 +141,7 @@ If you are a Rust project owner and are looking for contributors, please submit 
 * [miri: support non-rlib extern files](https://github.com/rust-lang/miri/pull/1557)
 * [add `as_str()` to `string::Drain`](https://github.com/rust-lang/rust/pull/76525)
 * [make all methods of `Duration` unstably const](https://github.com/rust-lang/rust/pull/76335)
-* [add `[T; N]: TryFrom<Vec<T>>`](https://github.com/rust-lang/rust/pull/76310)
+* [add `[T]: TryFrom<Vec<T>>`](https://github.com/rust-lang/rust/pull/76310) &nbsp;
 * [stabilize some `Result` methods as const](https://github.com/rust-lang/rust/pull/76136)
 * [stabilize some `Option` methods as const](https://github.com/rust-lang/rust/pull/76135)
 * [avoid useless `sift_down` when `std::collections::binary_heap::PeekMut` is never mutably dereferenced](https://github.com/rust-lang/rust/pull/75974)

--- a/content/2020-12-30-this-week-in-rust.md
+++ b/content/2020-12-30-this-week-in-rust.md
@@ -87,7 +87,7 @@ If you are a Rust project owner and are looking for contributors, please submit 
 * [prevent caching normalization results with a cycle](https://github.com/rust-lang/rust/pull/80246)
 * [fix ICE when lookup method in trait for type that have bound vars](https://github.com/rust-lang/rust/pull/80170)
 * [remove `DefPath` from `Visibility` and calculate it on demand](https://github.com/rust-lang/rust/pull/80099)
-* [`rustc_query_system : reduce dependency graph memory usage](https://github.com/rust-lang/rust/pull/79589)
+* [`rustc_query_system`: reduce dependency graph memory usage](https://github.com/rust-lang/rust/pull/79589)
 * [add `impl Div<NonZeroU*> for u*` which cannot panic](https://github.com/rust-lang/rust/pull/79134)
 * [deprecate atomic `compare_and_swap` method](https://github.com/rust-lang/rust/pull/79261)
 * [stabilize `core::slice::fill`](https://github.com/rust-lang/rust/pull/79213)

--- a/content/2021-01-20-this-week-in-rust.md
+++ b/content/2021-01-20-this-week-in-rust.md
@@ -109,7 +109,7 @@ If you are a Rust project owner and are looking for contributors, please submit 
 * [add `MaybeUninit` method `array_assume_init`](https://github.com/rust-lang/rust/pull/80600)
 * [change `BinaryHeap::append` rebuild heuristic](https://github.com/rust-lang/rust/pull/77435)
 * [implement `ptr::write` without dedicated intrinsic](https://github.com/rust-lang/rust/pull/80290)
-* [introduce {`Ref`, `RefMut`}`::try_map' for optional projections in `RefCell`](https://github.com/rust-lang/rust/pull/78455)
+* [introduce {`Ref`, `RefMut`}`::try_map` for optional projections in `RefCell`](https://github.com/rust-lang/rust/pull/78455)
 * [re-stabilize `Weak::as_ptr` and friends for unsized T](https://github.com/rust-lang/rust/pull/80764)
 * [add `Iterator::intersperse_with`](https://github.com/rust-lang/rust/pull/80567)
 * [`TrustedRandomAaccess` specialization composes incorrectly for nested `iter::Zips`](https://github.com/rust-lang/rust/pull/80670)

--- a/content/2021-04-21-this-week-in-rust.md
+++ b/content/2021-04-21-this-week-in-rust.md
@@ -156,7 +156,7 @@ decision. Express your opinions now.
 
 * [disposition: merge] [Cautiously add IntoIterator for arrays by value](https://github.com/rust-lang/rust/pull/84147)
 * [disposition: merge] [Stabilize Duration::MAX](https://github.com/rust-lang/rust/pull/84120)
-* [disposition: merge] [Stabilize `impl From<[(K, V); N]`> for HashMap`](https://github.com/rust-lang/rust/pull/84111)
+* [disposition: merge] [Stabilize `impl From<[(K, V); N]`> for `HashMap`](https://github.com/rust-lang/rust/pull/84111)
 * [disposition: merge] [Allow setting `target_family` to multiple values, and implement `target_family="wasm"`](https://github.com/rust-lang/rust/pull/84072)
 * [disposition: close] [Exiting a process calls exit() which isn’t thread-safe](https://github.com/rust-lang/rust/issues/83994)
 * [disposition: merge] [Stabilize `:pat_param` but leave :pat2021 gated](https://github.com/rust-lang/rust/pull/83386)

--- a/content/2021-04-28-this-week-in-rust.md
+++ b/content/2021-04-28-this-week-in-rust.md
@@ -98,7 +98,7 @@ If you are a Rust project owner and are looking for contributors, please submit 
 * [add coverage to `continue` statements](https://github.com/rust-lang/rust/pull/84295)
 * [further split up `const_fn` feature flag](https://github.com/rust-lang/rust/pull/84310)
 * [various const parameter defaults improvements](https://github.com/rust-lang/rust/pull/84299)
-* [tweak trait not `use d suggestion](https://github.com/rust-lang/rust/pull/84499)
+* [tweak trait not `use`d suggestion](https://github.com/rust-lang/rust/pull/84499)
 * [on stable, suggest removing `#![feature]` for features that have been stabilized](https://github.com/rust-lang/rust/pull/83722)
 * [improve diagnostics for function passed when a type was expected](https://github.com/rust-lang/rust/pull/84520)
 * [add suggestion to "use break" when attempting to implicit-break a loop](https://github.com/rust-lang/rust/pull/84516)

--- a/content/2021-07-14-this-week-in-rust.md
+++ b/content/2021-07-14-this-week-in-rust.md
@@ -112,7 +112,7 @@ If you are a Rust project owner and are looking for contributors, please submit 
 * [account for capture kind in auto traits migration](https://github.com/rust-lang/rust/pull/86869)
 * [stop generating `alloca`s & `memcmp` for simple short array equality](https://github.com/rust-lang/rust/pull/85828)
 * [inline `Iterator as IntoIterator`](https://github.com/rust-lang/rust/pull/84560)
-* [optimize unchecked indexing into `chunks` and 'chunks_mut`](https://github.com/rust-lang/rust/pull/86823)
+* [optimize unchecked indexing into `chunks` and `chunks_mut`](https://github.com/rust-lang/rust/pull/86823)
 * [add `Integer::log` variants](https://github.com/rust-lang/rust/pull/80918)
 * [special case for integer log10](https://github.com/rust-lang/rust/pull/86930)
 * [cargo: unify cargo and rustc's error reporting](https://github.com/rust-lang/cargo/pull/9655)

--- a/content/2021-07-21-this-week-in-rust.md
+++ b/content/2021-07-21-this-week-in-rust.md
@@ -144,7 +144,7 @@ If you are a Rust project owner and are looking for contributors, please submit 
 * [some perf optimizations and logging](https://github.com/rust-lang/rust/pull/87203)
 * [update Rust Float-Parsing to use the Eisel-Lemire algorithm](https://github.com/rust-lang/rust/pull/86761)
 * [stabilize `[T; N]::map(_)`](https://github.com/rust-lang/rust/pull/87174)
-* [split `MaybeUninit::write' into new feature gate and stabilize it](https://github.com/rust-lang/rust/pull/86344)
+* [split `MaybeUninit::write` into new feature gate and stabilize it](https://github.com/rust-lang/rust/pull/86344)
 * [mark Option::insert as `must_use`](https://github.com/rust-lang/rust/pull/87196)
 * [added `Arc::try_pin`](https://github.com/rust-lang/rust/pull/85579)
 * [hashbrown: replace some custom unsafe code with `array::map`](https://github.com/rust-lang/hashbrown/pull/281)

--- a/content/2021-07-21-this-week-in-rust.md
+++ b/content/2021-07-21-this-week-in-rust.md
@@ -143,7 +143,7 @@ If you are a Rust project owner and are looking for contributors, please submit 
 * [perf: noise and variance](https://github.com/rust-lang/rustc-perf/pull/902)
 * [some perf optimizations and logging](https://github.com/rust-lang/rust/pull/87203)
 * [update Rust Float-Parsing to use the Eisel-Lemire algorithm](https://github.com/rust-lang/rust/pull/86761)
-* [stabilize `[T; N]::map(_)`](https://github.com/rust-lang/rust/pull/87174)
+* [stabilize `[T; N]::map(_)`](https://github.com/rust-lang/rust/pull/87174) &nbsp;
 * [split `MaybeUninit::write` into new feature gate and stabilize it](https://github.com/rust-lang/rust/pull/86344)
 * [mark Option::insert as `must_use`](https://github.com/rust-lang/rust/pull/87196)
 * [added `Arc::try_pin`](https://github.com/rust-lang/rust/pull/85579)

--- a/content/2021-10-06-this-week-in-rust.md
+++ b/content/2021-10-06-this-week-in-rust.md
@@ -106,7 +106,7 @@ If you are a Rust project owner and are looking for contributors, please submit 
 
 * [make *const (), *mut () okay for FFI](https://github.com/rust-lang/rust/pull/84267)
 * [resolve: cache module loading for all foreign modules](https://github.com/rust-lang/rust/pull/89239)
-* [improve error message for missing angle brackets in `[_]::method`](https://github.com/rust-lang/rust/pull/89447)
+* [improve error message for missing angle brackets in `[_]::method`](https://github.com/rust-lang/rust/pull/89447) &nbsp;
 * [avoid nondeterminism in `trimmed_def_paths`](https://github.com/rust-lang/rust/pull/89408)
 * [improve error message for printf-style format strings](https://github.com/rust-lang/rust/pull/89340)
 * [pick one possible lifetime in case there are multiple choices](https://github.com/rust-lang/rust/pull/89327)

--- a/content/2021-11-03-this-week-in-rust.md
+++ b/content/2021-11-03-this-week-in-rust.md
@@ -123,7 +123,7 @@ If you are a Rust project owner and are looking for contributors, please submit 
 * [clippy: move `if_then_panic` to pedantic and rename to `manual_assert`](https://github.com/rust-lang/rust-clippy/pull/7810)
 * [clippy: fix false positive in `match_overlapping_arm`](https://github.com/rust-lang/rust-clippy/pull/7847)
 * [clippy: fix `question_mark` false positive on custom error type](https://github.com/rust-lang/rust-clippy/pull/7860)
-* [clippy: add `unit-hash  lint](https://github.com/rust-lang/rust-clippy/pull/7875)
+* [clippy: add `unit-hash` lint](https://github.com/rust-lang/rust-clippy/pull/7875)
 * [clippy: new lint: `string-slice`](https://github.com/rust-lang/rust-clippy/pull/7878)
 * [clippy: ignore references to type aliases in `ptr_arg`](https://github.com/rust-lang/rust-clippy/pull/7890)
 * [clippy: fix ICE in `undocumented_unsafe_blocks`](https://github.com/rust-lang/rust-clippy/pull/7891)

--- a/content/2021-12-22-this-week-in-rust.md
+++ b/content/2021-12-22-this-week-in-rust.md
@@ -92,7 +92,7 @@ If you are a Rust project owner and are looking for contributors, please submit 
 * [perf: manually implement `Hash` for `DefId`](https://github.com/rust-lang/rust/pull/91660)
 * [enable `#[thread_local]` for all windows-msvc targets](https://github.com/rust-lang/rust/pull/92042)
 * [add entry_ref API to HashMap](https://github.com/rust-lang/hashbrown/pull/301)
-* [add `[T]::as_simd(_mut)`](https://github.com/rust-lang/rust/pull/91479)
+* [add `[T]::as_simd(_mut)`](https://github.com/rust-lang/rust/pull/91479) &nbsp;
 * [add `BinaryHeap::try_reserve` and `BinaryHeap::try_reserve_exact`](https://github.com/rust-lang/rust/pull/91529)
 * [add `io::Error::other`](https://github.com/rust-lang/rust/pull/91947)
 * [avoid sorting in hash map stable hashing](https://github.com/rust-lang/rust/pull/91837)

--- a/content/2021-12-22-this-week-in-rust.md
+++ b/content/2021-12-22-this-week-in-rust.md
@@ -109,7 +109,7 @@ If you are a Rust project owner and are looking for contributors, please submit 
 * [futures: add `StreamExt::count` method](https://github.com/rust-lang/futures-rs/pull/2495)
 * [futures: limit `FuturesUnordered` max value of `yield_every`](https://github.com/rust-lang/futures-rs/pull/2527)
 * [cargo: detect filesystem loop during walking the projects](https://github.com/rust-lang/cargo/pull/10188)
-* [cargo: display alias target on 'cargo help <alias>`](https://github.com/rust-lang/cargo/pull/10193)
+* [cargo: display alias target on `cargo help <alias>`](https://github.com/rust-lang/cargo/pull/10193)
 * [rustdoc: fix source code page sidebar on mobile](https://github.com/rust-lang/rust/pull/91905)
 * [clippy: add `unnecessary_to_owned` lint](https://github.com/rust-lang/rust-clippy/pull/7978)
 * [clippy: don't emit `return_self_not_must_use` lint if `Self` already is marked as `#[must_use]`](https://github.com/rust-lang/rust-clippy/pull/8146)

--- a/draft/2022-01-12-this-week-in-rust.md
+++ b/draft/2022-01-12-this-week-in-rust.md
@@ -163,7 +163,7 @@ Email the [Rust Community Team][community] for access.
 >
 > ----
 >
-> Well, it really is Vec<T, A>, pronounced Veck-tah. 😛
+> Well, it really is `Vec<T, A>`, pronounced Veck-tah. 😛
 >
 > ----
 >


### PR DESCRIPTION
These are incorrectly interpreted as html tags.

This commit only fixes bad tag-like brackets since 2020 as found by #2783.