### PR TITLE
add inspect_markdown to github action

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,7 +1,7 @@
 name: Correctness Checks
 on: [push, pull_request]
 jobs:
-  Run-Link-Checker:
+  Run-Markdown-Checks:
     runs-on: ubuntu-20.04
     steps:
       - name: checkout
@@ -13,4 +13,7 @@ jobs:
           update-pip: "false"
           update-setuptools: "false"
           update-wheel: "false"
-      - run: python3 tools/inspect_links.py --num-warn 5
+      - name: inspect_links
+        run: python3 tools/inspect_links.py --num-warn 5
+      - name: inspect_markdown
+        run: python3 tools/inspect_markdown.py --num-recent 5


### PR DESCRIPTION
Rename the job since it's no longer just link-checking.

Add a step that examines the 5 most recent issues (including any in /draft) for common markdown problems.

I tested the job on my fork and it passed.

(This is a duplicate of #2789, which got auto-closed accidentally while I was cleaning up old branches.)