### PR TITLE
add RustTalk

### DIFF
--- a/draft/2022-02-02-this-week-in-rust.md
+++ b/draft/2022-02-02-this-week-in-rust.md
@@ -27,6 +27,7 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 ### Rust Walkthroughs
 
 ### Miscellaneous
+* [Podcast RustTalk 001. 与 Folyd 聊他的 Rust 使用经历](https://rusttalk.github.io/podcast/001/)
 
 ## Crate of the Week
 


### PR DESCRIPTION
RustTalk is a Chinese interview-style Podcast focused on Rust Hackers.
- Twitter: https://twitter.com/RustTalk