### PR TITLE
What's new in SeaORM 0.6.0

### DIFF
--- a/draft/2022-02-09-this-week-in-rust.md
+++ b/draft/2022-02-09-this-week-in-rust.md
@@ -20,6 +20,8 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 
 ### Project/Tooling Updates
 
+* [What's new in SeaORM 0.6.0](https://www.sea-ql.org/SeaORM/blog/2022-02-07-whats-new-in-0.6.0/)
+
 ### Newsletters
 
 ### Research


### PR DESCRIPTION
Release notes for [SeaORM 0.6.0](https://github.com/SeaQL/sea-orm/releases/tag/0.6.0)