### PR TITLE
Add link to Why Not Inheritance

### DIFF
--- a/draft/2022-02-09-this-week-in-rust.md
+++ b/draft/2022-02-09-this-week-in-rust.md
@@ -25,6 +25,7 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 ### Research
 
 ### Observations/Thoughts
+* [ZH] [为什么 Rust 没有继承？](https://fengliang.io/RustWHY/design_choices/why_not_inheritance.html) A thought on the design choice that Rust made and is questioned by many programmers from other object-oriented languages. Why does Rust not have inheritance?
 
 ### Rust Walkthroughs
 

--- a/draft/2022-02-09-this-week-in-rust.md
+++ b/draft/2022-02-09-this-week-in-rust.md
@@ -25,7 +25,7 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 ### Research
 
 ### Observations/Thoughts
-* [ZH] [为什么 Rust 没有继承？](https://fengliang.io/RustWHY/design_choices/why_not_inheritance.html) A thought on the design choice that Rust made and is questioned by many programmers from other object-oriented languages. Why does Rust not have inheritance?
+* [ZH] [为什么 Rust 没有继承？Why doesn't Rust have inheritance?](https://fengliang.io/RustWHY/design_choices/why_not_inheritance.html)
 
 ### Rust Walkthroughs
 


### PR DESCRIPTION
Add a link to a blog talking about why Rust does not have inheritance like other OO languages do.