### PR TITLE
Add link to Why Associated Type

### DIFF
--- a/draft/2022-02-16-this-week-in-rust.md
+++ b/draft/2022-02-16-this-week-in-rust.md
@@ -23,6 +23,7 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 ### Newsletters
 
 ### Observations/Thoughts
+* [ZH] [为什么我们要Associated Type？Why do we need Associated Type?](https://fengliang.io/RustWHY/engineering_features/why_associated_type.html)
 
 ### Rust Walkthroughs
 


### PR DESCRIPTION
Add link to Why Associated Type, which is my thought on the design of Associated Type. It's not about How, but Why, so I'd rather like to place it under Thoughts, not Walkthroughs.