### PR TITLE
Walkthrough about using wgpu-rs for image filters

### DIFF
--- a/draft/2022-02-16-this-week-in-rust.md
+++ b/draft/2022-02-16-this-week-in-rust.md
@@ -26,6 +26,8 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 
 ### Rust Walkthroughs
 
+* [Computing image filters with wgpu-rs](https://blog.redwarp.app/image-filters/)
+
 ### Miscellaneous
 
 ## Crate of the Week


### PR DESCRIPTION
I just published this blog post, it's a walkthrough about using wgpu-rs and compute shaders to do some image filtering.
In it, I explain step by step how to create a grayscale version of an image, using your GPU.