### PR TITLE
improve duplicate link detection

### DIFF
--- a/content/2022-01-05-this-week-in-rust.md
+++ b/content/2022-01-05-this-week-in-rust.md
@@ -19,7 +19,7 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 
 ### Project/Tooling Updates
 * [rust-analyzer in 2021](https://rust-analyzer.github.io/blog/2021/12/30/2021-recap.html)
-* [rust-analyzer changelog #110](https://rust-analyzer.github.io//thisweek/2022/01/03/changelog-110.html)
+* [rust-analyzer changelog #110](https://rust-analyzer.github.io/thisweek/2022/01/03/changelog-110.html)
 * [The year 2021 in Dimforge and our objectives for 2022](https://dimforge.com/blog/2022/01/02/the-year-2021-in-dimforge/)
 * [This week in Fluvio #18: the programmable streaming platform](https://www.fluvio.io/news/this-week-in-fluvio-0018/)
 * [What's new in SeaORM 0.5.0](https://www.sea-ql.org/SeaORM/blog/2022-01-01-whats-new-in-0.5.0)

--- a/content/2022-01-12-this-week-in-rust.md
+++ b/content/2022-01-12-this-week-in-rust.md
@@ -34,7 +34,7 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 * [The engine was renamed to Fyrox](https://rg3d.rs/general/2022/01/11/fyrox.html)
 
 ### Observations/Thoughts
-* [Dyn async traits, part 7: a design emerges?](https://smallcultfollowing.com/babysteps//blog/2022/01/07/dyn-async-traits-part-7/)
+* [Dyn async traits, part 7: a design emerges?](https://smallcultfollowing.com/babysteps/blog/2022/01/07/dyn-async-traits-part-7/)
 * [Rust in 2022](https://www.ncameron.org/blog/rust-in-2022-2/)
 * [Bringing include_dir Into the Modern Era](https://adventures.michaelfbryan.com/posts/bringing-include_dir-into-the-modern-era/)
 * [Rust Async and the Terrible, Horrible, No Good, Very Bad Day](https://kevinhoffman.medium.com/rust-async-and-the-terrible-horrible-no-good-very-bad-day-348ebc836274)

--- a/content/2022-02-02-this-week-in-rust.md
+++ b/content/2022-02-02-this-week-in-rust.md
@@ -28,7 +28,7 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 * [Fornjot 0.5.0 - Code-CAD in Rust](https://www.fornjot.app/blog/fornjot-0-5-0/)
 * [BonsaiDb January update: Alpha Next Week](https://bonsaidb.io/blog/january-2022-update/)
 * [rustc_codegen_gcc: Progress Report #8](https://blog.antoyo.xyz/rustc_codegen_gcc-progress-report-8)
-* [Rust Analyzer Changelog #114](https://rust-analyzer.github.io//thisweek/2022/01/31/changelog-114.html)
+* [Rust Analyzer Changelog #114](https://rust-analyzer.github.io/thisweek/2022/01/31/changelog-114.html)
 * [IntelliJ Rust Changelog #164](https://intellij-rust.github.io/2022/01/31/changelog-164.html)
 * [This week in Databend #27: an elastic and reliable cloud warehouse](https://weekly.databend.rs/2022-02-02-databend-weekly/)
 
@@ -45,7 +45,7 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 * [Part 2: Improving crypto code in Rust using LLVM’s optnone](https://blog.trailofbits.com/2022/02/01/part-2-rusty-crypto/)
 * [Writing the fastest GBDT library in Rust](https://www.tangram.dev/blog/writing_the_fastest_gbdt_library_in_rust/)
 * [Async Rust vs RTOS showdown!](https://tweedegolf.nl/en/blog/65/async-rust-vs-rtos-showdown)
-* [Panics vs cancellation, part 1](https://smallcultfollowing.com/babysteps//blog/2022/01/27/panics-vs-cancellation-part-1/)
+* [Panics vs cancellation, part 1](https://smallcultfollowing.com/babysteps/blog/2022/01/27/panics-vs-cancellation-part-1/)
 * [Rust extension traits, greppability and IDEs](https://eli.thegreenplace.net/2022/rust-extension-traits-greppability-and-ides/)
 * [The Curious Absence of Lifetimes](https://ivkov.me/absence-of-lifetimes/)
 * [Rust has a small standard library (and that's ok)](https://blog.nindalf.com/posts/rust-stdlib/)


### PR DESCRIPTION
When checking for duplicate links:
- Assume http and https links to be the same.
- Ignore consecutive slashes and trailing slashes.

Consecutive slashes in the URL will trigger a warning; trailing slashes or http links will not.