### PR TITLE
Add next Compiler Adventures episode to walkthroughs

### DIFF
--- a/draft/2022-02-23-this-week-in-rust.md
+++ b/draft/2022-02-23-this-week-in-rust.md
@@ -25,6 +25,7 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 ### Observations/Thoughts
 
 ### Rust Walkthroughs
+* [Compiler Adventures, part 2: Constant Propagation](https://medium.com/@predrag.gruevski/compiler-adventures-part-2-constant-propagation-c6f2e67d9881)
 
 ### Miscellaneous
 


### PR DESCRIPTION
A beginner-friendly intro to compilers blog series written in Rust.

Episode 1 was part of This Week in Rust 429: https://github.com/rust-lang/this-week-in-rust/blame/master/content/2022-02-09-this-week-in-rust.md#L70