### PR TITLE
Added talk on pdqsort

### DIFF
--- a/draft/2022-03-02-this-week-in-rust.md
+++ b/draft/2022-03-02-this-week-in-rust.md
@@ -22,6 +22,8 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 
 ### Research
 
+* [video] [Talk on Pattern-defeating Quicksort, the algorithm behind `sort_unstable`](https://www.youtube.com/watch?v=jz-PBiWwNjc) 
+
 ### Observations/Thoughts
 
 * [video] [Rust's Vision in 2022](https://www.youtube.com/watch?v=zYrudh-dsX8)


### PR DESCRIPTION
I recently held a talk on Pattern-defeating Quicksort at my research institute, which is the sorting algorithm I made that is also used for `sort_unstable` in Rust. The talk mainly focuses on the C++ implementation as that is what I benchmark, but I figured it might still be interested for Rustaceans.