### PR TITLE
add link to Rustacean Station ep058 transcript

### DIFF
--- a/draft/2022-03-16-this-week-in-rust.md
+++ b/draft/2022-03-16-this-week-in-rust.md
@@ -25,6 +25,8 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 
 ### Observations/Thoughts
 
+* [Transcript: What's New in Rust 1.58 and 1.59](https://rustacean-station.org/transcript/058-rust-1.58-1.59/)
+
 ### Rust Walkthroughs
 
 * [Rust WebAssembly OCR experiments](https://hugopeixoto.net/articles/rust-wasm-ocr-experiments.html)


### PR DESCRIPTION
This is a link to a text transcript of the Rustacean Station episode "What's New in Rust 1.58 and 1.59".

While this is the same content as the audio podcast, I'd like to call attention to the text transcript, as it's more accessible to those with limited English skills.

I'm certain that distinction is important enough to justify inclusion, so I'll leave this PR for @nellshamrell as the final word.