### PR TITLE
Add dhcpm link

### DIFF
--- a/draft/2022-03-23-this-week-in-rust.md
+++ b/draft/2022-03-23-this-week-in-rust.md
@@ -20,6 +20,8 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 
 ### Project/Tooling Updates
 
+* [Rust superpowered DHCP cli with Rhai scripts](https://leshow.github.io/post/dhcpm/)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
blog post about a dig-like tool for dhcp called `dhcpm` that has an embedded scripting engine in rhai