### PR TITLE
Link to 'Procedural macros under the hood: Part I'

### DIFF
--- a/draft/2022-03-23-this-week-in-rust.md
+++ b/draft/2022-03-23-this-week-in-rust.md
@@ -23,6 +23,7 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 ### Observations/Thoughts
 
 ### Rust Walkthroughs
+* [Procedural macros under the hood: Part I](https://blog.jetbrains.com/rust/2022/03/18/procedural-macros-under-the-hood-part-i/)
 
 ### Miscellaneous
 * [Cross-platform Brainfuck Interpreter implementation in Rust - Part 1](https://rtoch.com/posts/brainfuck-interpreter-implementation-part-1/)


### PR DESCRIPTION
Hello, please add a link to this post from IntelliJ Rust's blog: https://blog.jetbrains.com/rust/2022/03/18/procedural-macros-under-the-hood-part-i/. It's the first part of the series on procedural macros, based on the talk our team member gave at a Rust conference a while ago. I've put it under 'Rust Walkthroughts', hope that's the right place) Thank you!