### PR TITLE
Add my GitHub profile generator blog post

### DIFF
--- a/draft/2022-03-30-this-week-in-rust.md
+++ b/draft/2022-03-30-this-week-in-rust.md
@@ -22,6 +22,9 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 
 ### Observations/Thoughts
 
+* [Yet Another GitHub Profile Generator
+](https://blog.urth.org/2022/03/28/yet-another-github-profile-generator/)
+
 ### Rust Walkthroughs
 
 * [Introducing "High Assurance Rust": a FREE systems software security book!](https://highassurance.rs/)


### PR DESCRIPTION
The profile generator is in Rust. I put this in Observations/Thoughts because I don't walk through the source code in the post.