### PR TITLE
Custom Rust Toolchain for AVR

### DIFF
--- a/draft/2022-04-06-this-week-in-rust.md
+++ b/draft/2022-04-06-this-week-in-rust.md
@@ -18,6 +18,8 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 
 ### Project/Tooling Updates
 
+[Custom Rust Toolchain for AVR](https://www.reddit.com/r/rust/comments/tvtxpv/custom_rust_toolchain_for_avr/)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
Implements a compiler bug fix proposal.
Un-reverts the llvm_asm! removal.

To get a workable Rust for AVR microcontrollers.