### PR TITLE
add a script to create the issue draft

### DIFF
--- a/tools/DRAFT_TEMPLATE
+++ b/tools/DRAFT_TEMPLATE
@@ -1,0 +1,138 @@
+Title: This Week in Rust $twir_issue_number
+Number: $twir_issue_number
+Date: $twir_issue_date
+Category: This Week in Rust
+
+Hello and welcome to another issue of *This Week in Rust*!
+[Rust](https://www.rust-lang.org/) is a programming language empowering everyone to build reliable and efficient software.
+This is a weekly summary of its progress and community.
+Want something mentioned? Tweet us at [@ThisWeekInRust](https://twitter.com/ThisWeekInRust) or [send us a pull request](https://github.com/rust-lang/this-week-in-rust).
+Want to get involved? [We love contributions](https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md).
+
+*This Week in Rust* is openly developed [on GitHub](https://github.com/rust-lang/this-week-in-rust).
+If you find any errors in this week's issue, [please submit a PR](https://github.com/rust-lang/this-week-in-rust/pulls).
+
+## Updates from Rust Community
+
+<!--
+
+Dear community contributors:
+Please read README.md for guidance on submissions.
+Each submitted link should be of the form:
+
+* [Title of the Linked Page](https://example.com/my_article)
+
+If you don't know which category to use, feel free to submit a PR anyway
+and just ask the editors to select the category.
+
+-->
+
+### Official
+
+### Foundation
+
+### Newsletters
+
+### Project/Tooling Updates
+
+### Observations/Thoughts
+
+### Rust Walkthroughs
+
+### Research
+
+### Miscellaneous
+
+## Crate of the Week
+
+<!-- COTW goes here -->
+
+[Please submit your suggestions and votes for next week][submit_crate]!
+
+[submit_crate]: https://users.rust-lang.org/t/crate-of-the-week/2704
+
+## Call for Participation
+
+Always wanted to contribute to open-source projects but didn't know where to start?
+Every week we highlight some tasks from the Rust community for you to pick and get started!
+
+Some of these tasks may also have mentors available, visit the task page for more information.
+
+If you are a Rust project owner and are looking for contributors, please submit tasks [here][guidelines].
+
+[guidelines]: https://users.rust-lang.org/t/twir-call-for-participation/4821
+
+## Updates from the Rust Project
+
+<!-- Rust updates go here -->
+
+### Rust Compiler Performance Triage
+
+<!-- Perf results go here -->
+
+### [Approved RFCs](https://github.com/rust-lang/rfcs/commits/master)
+
+Changes to Rust follow the Rust [RFC (request for comments) process](https://github.com/rust-lang/rfcs#rust-rfcs). These
+are the RFCs that were approved for implementation this week:
+
+* [Cargo authenticating users without sending secrets over the network](https://github.com/rust-lang/rfcs/pull/3231)
+
+### Final Comment Period
+
+Every week [the team](https://www.rust-lang.org/team.html) announces the
+'final comment period' for RFCs and key PRs which are reaching a
+decision. Express your opinions now.
+
+#### [RFCs](https://github.com/rust-lang/rfcs/labels/final-comment-period)
+
+#### [Tracking Issues & PRs](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Afinal-comment-period+sort%3Aupdated-desc)
+
+### [New and Updated RFCs](https://github.com/rust-lang/rfcs/pulls)
+
+
+## Upcoming Events
+
+Rusty Events between $twir_issue_date - $twir_events_end_date 🦀
+
+### Virtual
+
+### Europe
+
+### North America
+
+### Oceania
+
+If you are running a Rust event please add it to the [calendar] to get
+it mentioned here. Please remember to add a link to the event too.
+Email the [Rust Community Team][community] for access.
+
+[calendar]: https://www.google.com/calendar/embed?src=apd9vmbc22egenmtu5l6c5jbfc%40group.calendar.google.com
+[community]: mailto:community-team@rust-lang.org
+
+# Rust Jobs
+
+<!--
+
+New jobs can be posted here.
+
+They should be of the form:
+
+**Company Name**
+
+* [Job Title (Location)](https://example.com/my-job-link)
+
+-->
+
+*Tweet us at [@ThisWeekInRust](https://twitter.com/ThisWeekInRust) to get your job offers listed here!*
+
+# Quote of the Week
+
+<!-- QOTW goes here -->
+
+[Please submit quotes and vote for next week!](https://users.rust-lang.org/t/twir-quote-of-the-week/328)
+
+*This Week in Rust is edited by: [nellshamrell](https://github.com/nellshamrell), [llogiq](https://github.com/llogiq), [cdmistman](https://github.com/cdmistman), [ericseppanen](https://github.com/ericseppanen), [extrawurst](https://github.com/extrawurst), [andrewpollack](https://github.com/andrewpollack), [U007D](https://github.com/U007D), [kolharsam](https://github.com/kolharsam), [joelmarcey](https://github.com/joelmarcey), [mariannegoldin](https://github.com/mariannegoldin).*
+
+*Email list hosting is sponsored by [The Rust Foundation](https://foundation.rust-lang.org/)*
+
+<small>[Discuss on r/rust](REDDIT_LINK_HERE)</small>

--- a/tools/create_draft.py
+++ b/tools/create_draft.py
@@ -1,0 +1,98 @@
+#!/usr/bin/python3
+
+"""
+Create a draft of a new issue.
+"""
+
+import argparse
+import datetime
+import logging
+import os
+import string
+import sys
+
+TEMPLATE_FILE = 'tools/DRAFT_TEMPLATE'
+
+LOG = logging.getLogger(__name__)
+LOG.setLevel(logging.INFO)
+
+
+def default_date():
+    """ Returns a datetime.date, that is the estimated next issue date. """
+    # If no input date is specified, we assume that this will be run ~7 days
+    # before the next issue is released. Just in case an issue comes out early
+    # or late, we'll pick the Wednesday that is between 4 and 10 days in the
+    # future.
+    starting_day = datetime.date.today()
+    # Compute the number of days until the next Wednesday.
+    # weekday() returns 0(Monday)..6(Sunday). We want 2.
+    delta = (2 - starting_day.weekday()) % 7
+    date = starting_day + datetime.timedelta(delta)
+    return date
+
+
+def compute_issue_number(date):
+    # 2022-01-05 is issue 424; we can calculate number of weeks since then.
+    ref_date = datetime.date(2022, 1, 5)
+    delta = date - ref_date
+    if delta.days % 7 == 0:
+        return 424 + int(delta.days / 7)
+    raise Exception('failed to compute issue number')
+
+
+def create_draft(date):
+    """ Return a new issue draft based on the template file. """
+    # Events listing ends on issue_date + 28 days.
+    end_date = date + datetime.timedelta(28)
+
+    params = {
+        'twir_issue_number': compute_issue_number(date),
+        'twir_issue_date': date.isoformat(),
+        'twir_events_end_date': end_date.isoformat(),
+    }
+
+    template = open(TEMPLATE_FILE).read()
+    template = string.Template(template)
+    return template.substitute(params)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--date', default=None,
+                        help='draft date (defaults to Wednesday ~7 days away)')
+    parser.add_argument('--dry-run', action='store_true',
+                        help="don't write the file; print it to stdout")
+    parser.add_argument('--debug', action='store_true',
+                        help='be more verbose')
+    args = parser.parse_args()
+    if args.debug:
+        LOG.setLevel(logging.DEBUG)
+    LOG.debug(f'command-line arguments: {args}')
+
+    # Compute the issue date.
+    if args.date:
+        date = datetime.date.fromisoformat(args.date)
+    else:
+        date = default_date()
+    LOG.debug(f'issue date {date}')
+
+    # Create the draft filename: draft/YYYY-MM-DD-this-week-in-rust.md
+    filename = date.isoformat() + '-this-week-in-rust.md'
+    filename = os.path.join('draft', filename)
+
+    # Create the draft text, and either write it to a file, or to stdout.
+    draft = create_draft(date)
+    if args.dry_run:
+        print(draft)
+    else:
+        open(filename, 'x').write(draft)
+
+
+def setup_logging():
+    log_stdout = logging.StreamHandler(sys.stdout)
+    logging.getLogger('').addHandler(log_stdout)
+
+
+if __name__ == "__main__":
+    setup_logging()
+    main()


### PR DESCRIPTION
This creates a draft issue from a template file, filling in basic things like the issue number, date, etc.

The script will create a new file in `draft/` unless the `--dry-run` flag is specified. It will fail if the file already exists.

I left html comments in a few places to mark where the content should go. Some of the comments are directed at contributors; feedback on this strategy is welcome as "how we communicate to contributors" is a separate issue from "how we create the draft file".

None of the sections are populated with content from the previous issue; I assume this would be desirable in some cases (events, probably?) but feedback on how to do it would be welcome. Maybe just copy/paste everything under `## Upcoming Events`?