### PR TITLE
Added link to Warp interview

### DIFF
--- a/draft/2022-04-20-this-week-in-rust.md
+++ b/draft/2022-04-20-this-week-in-rust.md
@@ -26,7 +26,7 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 
 ### Observations/Thoughts
 
-* [Building a new terminal - from Electron to Rust, and using macOS Metal APIs for UI rendering (interview with Warp)](https://console.dev/interviews/warp-zach-lloyd/)
+* [Building a new terminal - using macOS Metal APIs for UI rendering (interview with Warp)](https://console.dev/interviews/warp-zach-lloyd/)
 
 ### Rust Walkthroughs
 

--- a/draft/2022-04-20-this-week-in-rust.md
+++ b/draft/2022-04-20-this-week-in-rust.md
@@ -26,6 +26,8 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 
 ### Observations/Thoughts
 
+* [Building a new terminal - from Electron to Rust, and using macOS Metal APIs for UI rendering (interview with Warp)](https://console.dev/interviews/warp-zach-lloyd/)
+
 ### Rust Walkthroughs
 
 ### Miscellaneous


### PR DESCRIPTION
Added interview with Warp CEO at https://console.dev/interviews/warp-zach-lloyd/ which discusses building their new terminal product in Rust, why they switched to Rust from Electron and some of the challenges of building a UI renderer using the macOS Metal APIs.