### PR TITLE
draft template: remove leftover RFC link

### DIFF
--- a/tools/DRAFT_TEMPLATE
+++ b/tools/DRAFT_TEMPLATE
@@ -75,7 +75,7 @@ If you are a Rust project owner and are looking for contributors, please submit 
 Changes to Rust follow the Rust [RFC (request for comments) process](https://github.com/rust-lang/rfcs#rust-rfcs). These
 are the RFCs that were approved for implementation this week:
 
-* [Cargo authenticating users without sending secrets over the network](https://github.com/rust-lang/rfcs/pull/3231)
+<!-- Approved RFCs go here -->
 
 ### Final Comment Period
 


### PR DESCRIPTION
The template was built from a previous issue, and I forgot to remove a link in the Approved RFCs section.

This addresses the error that @nellshamrell noticed [here](https://github.com/rust-lang/this-week-in-rust/pull/3124#issuecomment-1104598581).
