### PR TITLE
Adding annoncement for StoffelMPC

### DIFF
--- a/draft/2022-04-27-this-week-in-rust.md
+++ b/draft/2022-04-27-this-week-in-rust.md
@@ -34,6 +34,7 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
+- [StoffelMPC: An MPC as a sidechain framework for building MPC-enabled blockchain applications](https://write.as/hashcloaks-blog/announcing-stoffelmpc-an-mpc-as-a-sidechain-framework)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
At HashCloak, we are building a framework for writing MPC applications to enable blockchain developers to integrate confidentiality into their programs. This framework is called StoffelMPC. The blog post contains a short intro to the project and other useful information.