### PR TITLE
Update template for RFC & FCP sections to new format

### DIFF
--- a/tools/DRAFT_TEMPLATE
+++ b/tools/DRAFT_TEMPLATE
@@ -70,25 +70,7 @@ If you are a Rust project owner and are looking for contributors, please submit 
 
 <!-- Perf results go here -->
 
-### [Approved RFCs](https://github.com/rust-lang/rfcs/commits/master)
-
-Changes to Rust follow the Rust [RFC (request for comments) process](https://github.com/rust-lang/rfcs#rust-rfcs). These
-are the RFCs that were approved for implementation this week:
-
-<!-- Approved RFCs go here -->
-
-### Final Comment Period
-
-Every week [the team](https://www.rust-lang.org/team.html) announces the
-'final comment period' for RFCs and key PRs which are reaching a
-decision. Express your opinions now.
-
-#### [RFCs](https://github.com/rust-lang/rfcs/labels/final-comment-period)
-
-#### [Tracking Issues & PRs](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Afinal-comment-period+sort%3Aupdated-desc)
-
-### [New and Updated RFCs](https://github.com/rust-lang/rfcs/pulls)
-
+<!-- RFC and FCP sections go here -->
 
 ## Upcoming Events
 


### PR DESCRIPTION
It's easier (and less error-prone--ask me how!) to replace a single-line comment with the RFC & FCP content each week.  Thanks @ericseppanen for the template upgrade!