### PR TITLE
Add link to raw BSON blog post

### DIFF
--- a/draft/2022-04-27-this-week-in-rust.md
+++ b/draft/2022-04-27-this-week-in-rust.md
@@ -56,6 +56,7 @@ and just ask the editors to select the category.
 ### Rust Walkthroughs
 
 * [DevLog[0]: Building a serverless platform for Rust in 4 weeks](https://www.shuttle.rs/blog/2022/04/22/dev-log-0)
+* [Unlocking greater performance in the MongoDB Rust Driver via raw BSON and zero copy deserialization](https://patrickfreed.github.io/rust/2022/04/27/unlocking-greater-performance-in-the-mongodb-rust-driver-via-raw-bson-and-zero-copy-deserialization.html)
 
 ### Research
 


### PR DESCRIPTION
I recently published a blog post about how to use the recently added raw BSON support in the `mongodb` and `bson` crates to speed up your MongoDB queries and would love to see it included in the next newsletter. Thanks!

link to post: https://patrickfreed.github.io/rust/2022/04/27/unlocking-greater-performance-in-the-mongodb-rust-driver-via-raw-bson-and-zero-copy-deserialization.html