### PR TITLE
create_draft: copy events from previous issue

### DIFF
--- a/tools/DRAFT_TEMPLATE
+++ b/tools/DRAFT_TEMPLATE
@@ -94,13 +94,7 @@ decision. Express your opinions now.
 
 Rusty Events between $twir_issue_date - $twir_events_end_date 🦀
 
-### Virtual
-
-### Europe
-
-### North America
-
-### Oceania
+$twir_events_list
 
 If you are running a Rust event please add it to the [calendar] to get
 it mentioned here. Please remember to add a link to the event too.


### PR DESCRIPTION
The create_draft script will now search for a previous issue (under draft and content) and then search that file for a range of lines that look like the events list, and copy those lines over to the new draft file.

If it has trouble finding the previous issue file, or can't find the events list, it will print a warning and then leave a placeholder comment in the draft issue where the events list should go.

Fixes #3171.