### PR TITLE
Add this week in Databend 39

### DIFF
--- a/draft/2022-04-27-this-week-in-rust.md
+++ b/draft/2022-04-27-this-week-in-rust.md
@@ -43,6 +43,7 @@ and just ask the editors to select the category.
 * [Slint (UI crate) weekly update](https://slint-ui.com/thisweek/2022-04-25.html)
 * [Hello, Robyn!](https://www.sanskar.me/hello_robyn.html)
 * [gitoxide - Rich repository information & blazingly fast clone-checkouts](https://github.com/Byron/gitoxide/discussions/398)
+* [This week in Databend #39: A Modern Cloud Data Warehouse for Everyone](https://weekly.databend.rs/2022-04-27-databend-weekly/)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
ty! 

Let's learn a weekly tip from Databend.

---

### Load Data from MySQL

Databend now supports loading data into Databend from MySQL using `mysqldump`

**Dump MySQL table schema and data to file**

```
mysqldump --single-transaction --compact -uroot -proot book_db books > dumpbooks.sql
```

**Load Data into Databend from the sql File**

```
mysql -uroot -h127.0.0.1 -proot -P3307 < dumpbook.sql
```

Check out https://databend.rs/doc/load-data/mysql to learn more.