### PR TITLE
Try to get the performance triage table to render correctly

### DIFF
--- a/content/2022-05-04-this-week-in-rust.md
+++ b/content/2022-05-04-this-week-in-rust.md
@@ -134,6 +134,7 @@ Triage done by **@simulacrum**.
 Revision range: [1c988cfa..468492](https://perf.rust-lang.org/?start=1c988cfa0b7f4d3bc5b1cb40dc5002f5adbfb9ad&end=468492c2af3993f18b1fe98052200575c4a2e678&absolute=false&stat=instructions%3Au)
 
 **Summary**:
+
 |            | Regressions 😿 <br />(primary) | Regressions 😿 <br />(secondary) | Improvements 🎉 <br />(primary) | Improvements 🎉 <br />(secondary) | All 😿 🎉 <br />(primary) |
 |:----------:|:------------------------------:|:--------------------------------:|:-------------------------------:|:---------------------------------:|:------------------------:|
 | count      | 13                             | 1                                | 78                              | 29                                | 91                       |


### PR DESCRIPTION
I think the rendering problems in #3220 are due to a quirk of the python Markdown implementation, and I think this can be avoided by putting a blank line before the table begins.

@nellshamrell I'm not 100% confident that this fixes the problem, but I am confident it won't make anything worse.... would it be possible to just deploy this change to the site and see if the table rendering is fixed?