### PR TITLE
Make tables more beautiful

### DIFF
--- a/themes/rusted/static/css/_base.scss
+++ b/themes/rusted/static/css/_base.scss
@@ -147,6 +147,28 @@ pre {
 }
 
 
+/**
+ * Tables
+ */
+table {
+    border-collapse: collapse;
+    margin: 1em 0;
+
+    td, th {
+        border: 1px solid #d2d2d2;
+        padding: 2px 8px;
+    }
+
+    th {
+        background-color: #eeeeee;
+    }
+
+    tr:nth-child(even) td {
+        background-color: #f7f7f7;
+    }
+}
+
+
 
 /**
  * Wrapper


### PR DESCRIPTION
Once the table markdown is fixed (#3221), tables are rendered like this with this PR:

![bobby-tables](https://user-images.githubusercontent.com/15658558/167027054-bc985e6c-11f8-4afd-90d9-b2005ddb7086.png)
