### PR TITLE
Add this week in Databend 41

### DIFF
--- a/draft/2022-05-11-this-week-in-rust.md
+++ b/draft/2022-05-11-this-week-in-rust.md
@@ -52,6 +52,7 @@ and just ask the editors to select the category.
 * [RepliByte - An open-source tool to seed your dev database with real data](https://www.reddit.com/r/rust/comments/ukmnow/an_opensource_tool_to_seed_your_dev_database_with/)
 * [Introducing Crane: Composable and Cacheable Builds with Cargo and Nix](https://ipetkov.dev/blog/introducing-crane/)
 * [The run-up to v1.0 for Postcard](https://jamesmunns.com/blog/postcard-1-0-run/)
+* [This week in Databend #41: A Modern Cloud Data Warehouse for Everyone](https://weekly.databend.rs/2022-05-11-databend-weekly/)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
Ty!

---

### Start a Databend Cluster

Databend has been designed from day one to be a cloud-native and distributed data warehouse.

The new databend-query node only needs to register itself to the databend-meta with the same `cluster_id`, they will autodiscovery and formed into a cluster.

![Cluster Arch](https://datafuse-1253727613.cos.ap-hongkong.myqcloud.com/deploy-minio-cluster.png)

Read the following article to start your first Databend cluster:

- [Start a Local Query Cluster](https://databend.rs/doc/deploy/cluster-minio)
- [Start a Query Cluster on Kubernetes](https://databend.rs/doc/deploy/cluster-k8s-minio)

**Note**

- Databend Cluster mode only works on shared storage(AWS S3 or MinIO s3-like storage).
- This cluster mainly used for testing purpose, it is not targeted for production use.