### PR TITLE
Add section titled Call For Testing

### DIFF
--- a/draft/2022-05-18-this-week-in-rust.md
+++ b/draft/2022-05-18-this-week-in-rust.md
@@ -70,6 +70,14 @@ If you are a Rust project owner and are looking for contributors, please submit 
 
 <!-- Perf results go here -->
 
+### Call for Testing
+
+An important step for RFC implementation is for people to experiment with the
+implementation and give feedback, especially before stabilization.  The following
+RFCs are at point where user testing is needed before moving forward:
+
+<!-- Pre-Stabilization RFCs go here -->
+
 <!-- RFC and FCP sections go here -->
 
 ## Upcoming Events

--- a/tools/DRAFT_TEMPLATE
+++ b/tools/DRAFT_TEMPLATE
@@ -70,6 +70,14 @@ If you are a Rust project owner and are looking for contributors, please submit 
 
 <!-- Perf results go here -->
 
+### Call for Testing
+
+An important step for RFC implementation is for people to experiment with the
+implementation and give feedback, especially before stabilization.  The following
+RFCs are at point where user testing is needed before moving forward:
+
+<!-- Pre-Stabilization RFCs go here -->
+
 <!-- RFC and FCP sections go here -->
 
 ## Upcoming Events


### PR DESCRIPTION
It was suggested in #3236 to add a section titled "Call For Testing". This was suggested as a way to increase the number of people testing "Pre-Stabilization" features. By adding this section there is a higher chance that people will see a feature is ready for testing and try it out.

Where this is meant section is meant to be placed can be moved around but it [was suggested](https://github.com/rust-lang/this-week-in-rust/issues/3236#issuecomment-1124144309) to put it before "Final Comment Period". As for the overall design of this section, I tried to make it match as best as I could while still making it readable. I am happy to tweak it to fit better if there are issues.