### PR TITLE
Add RFC2906 to Pre-Stabilization

### DIFF
--- a/draft/2022-05-18-this-week-in-rust.md
+++ b/draft/2022-05-18-this-week-in-rust.md
@@ -78,7 +78,11 @@ An important step for RFC implementation is for people to experiment with the
 implementation and give feedback, especially before stabilization.  The following
 RFCs are at point where user testing is needed before moving forward:
 
-<!-- Pre-Stabilization RFCs go here -->
+Pre-Stabilization
+- [RFC 2906 - Workspace Inheritance](https://github.com/rust-lang/rfcs/pull/2906)
+  - [Tracking Issue](https://github.com/rust-lang/cargo/issues/8415)
+  - [Testing steps](https://github.com/rust-lang/cargo/blob/master/src/doc/src/reference/unstable.md#testing-notes)
+
 
 <!-- RFC and FCP sections go here -->
 


### PR DESCRIPTION
This adds [RFC 2906](https://github.com/rust-lang/rfcs/pull/2906) to the Pre-Stabilization section that was added in [this PR](https://github.com/rust-lang/this-week-in-rust/pull/3249).

There was not much to go on the exact structure for this section so I went with something that seemed natural to read while including all of the relevant information. Including the RFC, the tracking issue, and testing steps, it gives all the information in one easy place.