### PR TITLE
Language tweak in new `Call for Testing` section

### DIFF
--- a/tools/DRAFT_TEMPLATE
+++ b/tools/DRAFT_TEMPLATE
@@ -74,7 +74,7 @@ If you are a Rust project owner and are looking for contributors, please submit 
 
 An important step for RFC implementation is for people to experiment with the
 implementation and give feedback, especially before stabilization.  The following
-RFCs are at point where user testing is needed before moving forward:
+RFCs would benefit from user testing before moving forward:
 
 <!-- Pre-Stabilization RFCs go here -->
 


### PR DESCRIPTION
Tweaked the language of the last sentence to avoid implying that the feature development would block on user testing.