### PR TITLE
Add this week in Databend 44

### DIFF
--- a/draft/2022-06-01-this-week-in-rust.md
+++ b/draft/2022-06-01-this-week-in-rust.md
@@ -42,6 +42,7 @@ and just ask the editors to select the category.
 * [Slint UI crate weekly updates](https://slint-ui.com/thisweek/2022-05-30.html)
 * [Fornjot (code-first CAD in Rust) - Weekly Dev Log - 2022-W21](https://www.fornjot.app/blog/weekly-dev-log/2022-w21/)
 * [IntelliJ Rust Changelog #171](https://intellij-rust.github.io/2022/05/30/changelog-171.html)
+* [This week in Databend #44: A Modern Cloud Data Warehouse for Everyone](https://weekly.databend.rs/2022-06-01-databend-weekly/)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
ty!

---
### `COPY INTO` Databend with `COMPRESSION` Option

After [PR 5655](https://github.com/datafuselabs/databend/pull/5655), Databend started to support decompression reads in `COPY INTO` and streaming leading.

**Loading Compressed Files from Amazon S3**

Try to load data from a gzip compressed csv and insert into `mytable`.

```sql
COPY INTO mytable
  FROM s3://mybucket/data.csv.gz
  credentials=(aws_key_id='<AWS_ACCESS_KEY_ID>' aws_secret_key='<AWS_SECRET_ACCESS_KEY>')
  FILE_FORMAT = (type = "CSV" field_delimiter = ',' record_delimiter = '\n' 
  skip_header = 1 compression = GZIP) size_limit=10;
```

**`COMPRESSION` Option**

The `COMPRESSION` option is a string that represents the compression algorithm.

```
| Values        | Notes                                                           |
| ------------- | --------------------------------------------------------------- |
| `AUTO`        | Auto detect compression via file extensions                     |
| `GZIP`        |                                                                 |
| `BZ2`         |                                                                 |
| `BROTLI`      | Must be specified if loading/unloading Brotli-compressed files. |
| `ZSTD`        | Zstandard v0.8 (and higher) is supported.                       |
| `DEFLATE`     | Deflate-compressed files (with zlib header, RFC1950).           |
| `RAW_DEFLATE` | Deflate-compressed files (without any header, RFC1951).         |
| `NONE`        | Indicates that the files have not been compressed.              |
```

**Learn more:**

- [Doc | COPY INTO \<table\>](https://databend.rs/doc/reference/sql/dml/dml-copy-into-table)
- [PR 5655 | Add decompress support for COPY INTO and streaming loading](https://github.com/datafuselabs/databend/pull/5655)
