### PR TITLE
TWIR 447 events: Correct Rust Iran location to virtual

### DIFF
--- a/draft/2022-06-15-this-week-in-rust.md
+++ b/draft/2022-06-15-this-week-in-rust.md
@@ -100,7 +100,7 @@ Rusty Events between 2022-06-15 - 2022-07-13 🦀
     * [**Remote Book Club: Rust for Rustaceans Chapter Discussion**](https://www.meetup.com/RustPhilly/events/qkbktsydcjbtb/)
 * 2022-06-15 | Vancouver, BC, CA | [Vancouver Rust](https://www.meetup.com/Vancouver-Rust/)
     * [**Nushell**](https://www.meetup.com/Vancouver-Rust/events/nwcmpsydcjbtb/)
-* 2022-06-17 | Tehran, IR | [Rust Iran Meetup](https://rust-meetup.ir/)
+* 2022-06-17 | Virtual | [Rust Iran Meetup](https://rust-meetup.ir/)
     * [**Rust Iran Meetup #7 - Actix-Web Framework**](https://rust-meetup.ir/2022/06/17/seventh-meetup.html)
 * 2022-06-20 | Köln, DE | [Rust Cologne](https://www.meetup.com/rustcologne/)
     * [**Reboot**](https://www.meetup.com/rustcologne/events/286557151/)


### PR DESCRIPTION
In double checking, the events page for the [Rust Iran Meetup](https://rust-meetup.ir/) did not specify an associated city for the meetup; defaulting location to "Virtual".