### PR TITLE
Add rust+wasm+svelte blog post

### DIFF
--- a/draft/2022-06-29-this-week-in-rust.md
+++ b/draft/2022-06-29-this-week-in-rust.md
@@ -38,6 +38,7 @@ and just ask the editors to select the category.
 ### Observations/Thoughts
 
 ### Rust Walkthroughs
+- [Integrating a Svelte app with Rust using WebAssembly](https://blog.logrocket.com/integrating-svelte-app-rust-webassembly/)
 
 ### Research
 


### PR DESCRIPTION
Hey, I have added a link to the blog post in rust walkthroughs. It is not behind any paywalls or mandatory sign-ins, and follows the code of conduct in general.

Thanks :)