### PR TITLE
Add this week in Databend 48

### DIFF
--- a/draft/2022-06-29-this-week-in-rust.md
+++ b/draft/2022-06-29-this-week-in-rust.md
@@ -38,6 +38,7 @@ and just ask the editors to select the category.
 * [Cross v0.2.2 Released](https://www.reddit.com/r/rust/comments/vk2xfc/cross_v022_released/)
 * [Release-plz: release Rust packages from CI](https://www.marcoieni.com/2022/06/release-plz-release-rust-packages-from-ci/)
 * [Fornjot (code-first CAD in Rust) - Weekly Dev Log - 2022-W25](https://www.fornjot.app/blog/weekly-dev-log/2022-w25/)
+* [This week in Databend #48: A Modern Cloud Data Warehouse for Everyone](https://weekly.databend.rs/2022-06-29-databend-weekly/)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
ty!

---

### `DELETE` in Databend

The `DELETE` statement can delete one or more rows from a table.

**Syntax**

Databend now supports such syntax:

```sql
DELETE FROM table_name
[WHERE search_ condition]
```

**Example**

Suppose that the `bookstore` table currently contains the following data:

|   bookId        |     bookName      |
| --------- | --------- |
| 101       | After the death of Don Juan   |
| 102       | Grown ups    |
| 103       | The long answer |
| 104       | Wartime friends |
| 105       | Deconstructed |

Now let's delete the book with id = 103:

```sql
DELETE from bookstore where bookId = 103;
```

After deletion, the data in the `bookstore` table is shown as follows:

|   bookId        |     bookName      |
| --------- | --------- |
| 101       | After the death of Don Juan   |
| 102       | Grown ups    |
| 104       | Wartime friends |
| 105       | Deconstructed |

**Learn more:**

- [DOC | DELETE](https://databend.rs/doc/reference/sql/dml/dml-delete-from)
- [PR | statement `delete from... `](https://github.com/datafuselabs/databend/pull/5691)