### PR TITLE
Add `Bare-metal Rust on ESP32: A brief overview`

### DIFF
--- a/draft/2022-07-13-this-week-in-rust.md
+++ b/draft/2022-07-13-this-week-in-rust.md
@@ -36,9 +36,9 @@ and just ask the editors to select the category.
 ### Project/Tooling Updates
 
 ### Observations/Thoughts
+* [Bare-metal Rust on ESP32: A brief overview](https://beta7.io/posts/bare-metal-rust-on-esp32/)
 
 ### Rust Walkthroughs
-* [Bare-metal Rust on ESP32: A brief overview](https://beta7.io/posts/bare-metal-rust-on-esp32/)
 
 ### Research
 

--- a/draft/2022-07-13-this-week-in-rust.md
+++ b/draft/2022-07-13-this-week-in-rust.md
@@ -38,6 +38,7 @@ and just ask the editors to select the category.
 ### Observations/Thoughts
 
 ### Rust Walkthroughs
+* [Bare-metal Rust on ESP32: A brief overview](https://beta7.io/posts/bare-metal-rust-on-esp32/)
 
 ### Research
 


### PR DESCRIPTION
Include [BARE-METAL RUST ON ESP32: A BRIEF OVERVIEW](https://beta7.io/posts/bare-metal-rust-on-esp32/)  on the Rust Walkthroughs section