### PR TITLE
Add cargo-semver-checks release to project updates

### DIFF
--- a/draft/2022-07-20-this-week-in-rust.md
+++ b/draft/2022-07-20-this-week-in-rust.md
@@ -40,6 +40,7 @@ and just ask the editors to select the category.
 * [What's new in SeaORM 0.9.0](https://www.sea-ql.org/SeaORM/blog/2022-07-17-whats-new-in-0.9.0/)
 
 * [Slint UI crate weekly updates](https://slint-ui.com/thisweek/2022-07-18.html)
+* [`cargo-semver-checks`: Fast, CI-friendly semver linter available as a GitHub Action](https://twitter.com/PredragGruevski/status/1550130476244926464)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
I'm in the middle of migrating from Medium to my own site, and in the meantime I've been using Twitter to announce updates for the projects I'm working on. Hope this is okay -- the README didn't say one way or the other whether linking to Twitter rather than a dedicated page or blog was within the guidelines.

Thanks for the awesome newsletter!