### PR TITLE
Add Tokyo Rust Game Hack 2022 edition: Bombercrab

### DIFF
--- a/draft/2022-07-27-this-week-in-rust.md
+++ b/draft/2022-07-27-this-week-in-rust.md
@@ -120,6 +120,8 @@ Rusty Events between 2022-07-27 - 2022-08-24 🦀
     * [**Monthly Meetup**](https://www.meetup.com/boulder-elixir-rust/events/zvxcsrydclbnb/)
 * 2022-08-11 | Nürnberg, DE | [Rust Nuremberg](https://www.meetup.com/rust-noris/)
     * [**Rust Nürnberg online**](https://www.meetup.com/rust-noris/events/hlvbvsydclbpb/)
+* 2022-08-12 | Virtual + Tokyo, JP | [tonari](https://gallery.tonari.no/en/tonari-lab)
+    * [**Tokyo Rust Game Hack 2022 edition: The Bombercrab Challenge**](https://www.reddit.com/r/rust/comments/w7bktx/2022_tokyo_and_elsewhere_rust_game_hack_event_aug/)
 * 2022-08-13 | Virtual | [Rust Gamedev](https://gamedev.rs/)
     * [**Rust Gamedev Monthly Meetup**](https://www.google.com/url?q=https://discord.gg/yNtPTb2&sa=D&source=calendar&usd=2&usg=AOvVaw2Eop9Blil9YUWeTq472NIi)
 * 2022-08-16 | Washington, DC, US | [Rust DC](https://www.meetup.com/RustDC/)
@@ -128,6 +130,11 @@ Rusty Events between 2022-07-27 - 2022-08-24 🦀
     * [**Rust Study/Hack/Hang-out**](https://www.meetup.com/Vancouver-Rust/events/nwcmpsydclbwb/)
 * 2022-08-18 | Charlottesville, VA, US | [Charlottesville Rust Meetup](https://www.meetup.com/charlottesville-rust-meetup/)
     * [**Hierarchical Task Network compiler written in Rust**](https://www.meetup.com/charlottesville-rust-meetup/events/287203159/)
+
+### Asia
+
+* 2022-08-12 | Tokyo, JP + Virtual | [tonari](https://gallery.tonari.no/en/tonari-lab)
+    * [**Tokyo Rust Game Hack 2022 edition: The Bombercrab Challenge**](https://bombercrab-rust-game-hack.peatix.com/view)
 
 ### Europe
 


### PR DESCRIPTION
Is it okay to add an entry to both Virtual and Asia sections for a hybrid event? Each section entry links to slightly different, dedicated page.

CC @PabloMansanet.