### PR TITLE
Add link to Rust generics blog

### DIFF
--- a/draft/2022-08-10-this-week-in-rust.md
+++ b/draft/2022-08-10-this-week-in-rust.md
@@ -38,6 +38,7 @@ and just ask the editors to select the category.
 ### Observations/Thoughts
 
 ### Rust Walkthroughs
+- [Understanding Rust generics and how to use them](https://blog.logrocket.com/understanding-rust-generics-how-use/)
 
 ### Research
 


### PR DESCRIPTION
This adds link of blog about introduction to rust generics. The blog is open to all, not behind any paywall or compulsory sign-up.
Thanks!