### PR TITLE
Add this week in Databend 54

### DIFF
--- a/draft/2022-08-10-this-week-in-rust.md
+++ b/draft/2022-08-10-this-week-in-rust.md
@@ -50,6 +50,7 @@ and just ask the editors to select the category.
 * [Fornjot (code-first CAD in Rust) - Weekly Release - 2022-W32](https://www.fornjot.app/blog/weekly-release/2022-w32/)
 * [Fang, async background processing for Rust](https://pxp9.github.io/rust/async-processing/)
 * [HexoSynth 2022 - Devlog #8 - A Visual DSP Programming Language](https://m8geil.de/posts/hexosynth-8/)
+* [This week in Databend #54: A Modern Cloud Data Warehouse for Everyone](https://weekly.databend.rs/2022-08-10-databend-weekly/)
 
 ### Observations/Thoughts
 * [Using unwrap() in Rust is Okay](https://blog.burntsushi.net/unwrap/)


### PR DESCRIPTION
ty!

---

Let's take a look at what's new at Databend each week.

**Release proposal: Nightly v0.9**

Databend plans to release v0.8 in the coming week, with new parser and planner support. 

The call for proposals for the release of v0.9 is now open. See [Release proposal: Nightly v0.9 #7052](https://github.com/datafuselabs/databend/issues/7052)

**Benchmarking Databend using TPC-H**

Databend has recently enabled the new Planner by default, which means that we have fully enabled support for JOIN queries and correlated subqueries.

Now you can easily run the TPC-H test suite with Databend and perform benchmark tests. See [Benchmarking Databend using TPC-H](https://databend.rs/blog/2022/08/08/benchmark-tpc-h)

**Deprecate clickhouse's tcp protocol support**

As the Clickhouse TCP protocol is almost a black box and requires a lot of effort to ensure compatibility, Databend has removed compatibility with the Clickhouse TCP protocol. See [Deprecate clickhouse's tcp protocol support #7012](https://github.com/datafuselabs/databend/pull/7012)

Databend will focus on Clickhouse HTTP protocol compatibility to ensure compatibility with the existing ecosystem.
