### PR TITLE
tools: improve filename regex in inspect_links

### DIFF
--- a/tools/inspect_links.py
+++ b/tools/inspect_links.py
@@ -41,7 +41,7 @@ class Warnings:
 warnings = Warnings()
 
 # A regex that matches filenames to inspect.
-RE_FILENAME = re.compile(r'\d\d\d\d-\d\d-\d\d-this-week-in-rust.md')
+RE_FILENAME = re.compile(r'\d\d\d\d-\d\d-\d\d-this-week-in-rust.md$')
 
 # A block-list of tracking parameters
 TRACKING_PARAMETERS = set([


### PR DESCRIPTION
When merging, I sometimes leave `*.orig` files behind, and inspect_links starts yelling about a lot of duplicate links. A little tweak to the regex fixes that.