### PR TITLE
Add Kani post on Tokio Bytes

### DIFF
--- a/draft/2022-08-17-this-week-in-rust.md
+++ b/draft/2022-08-17-this-week-in-rust.md
@@ -41,6 +41,7 @@ and just ask the editors to select the category.
 * [Exploring Traits with Erased `serde`](https://www.thecodedmessage.com/posts/erased-serde/)
 * [Rust and Neovim - A Thorough Guide and Walkthrough](https://rsdlt.github.io/posts/rust-nvim-ide-guide-walkthrough-development-debug/)
 * [Hooking Go from Rust - Hitchhiker’s Guide to the Go-laxy](https://metalbear.co/blog/hooking-go-from-rust-hitchhikers-guide-to-the-go-laxy/)
+* [Using the Kani Rust Verifier on Tokio Bytes](https://model-checking.github.io/kani-verifier-blog/2022/08/17/using-the-kani-rust-verifier-on-tokio-bytes.html)
 * [video] [Rust image viewer from scratch](https://www.youtube.com/watch?v=1yofBPRx864)
 
 ### Research


### PR DESCRIPTION
Add the [Using the Kani Rust Verifier on Tokio Bytes](https://model-checking.github.io/kani-verifier-blog/2022/08/17/using-the-kani-rust-verifier-on-tokio-bytes.html) post to the Rust Walkthroughs section