### PR TITLE
Add "Toward fearless cargo update" to 2022-08-31 edition.

### DIFF
--- a/draft/2022-08-31-this-week-in-rust.md
+++ b/draft/2022-08-31-this-week-in-rust.md
@@ -36,6 +36,7 @@ and just ask the editors to select the category.
 ### Project/Tooling Updates
 
 ### Observations/Thoughts
+- [Toward fearless `cargo update`](https://predr.ag/blog/toward-fearless-cargo-update/)
 
 ### Rust Walkthroughs
 


### PR DESCRIPTION
This is a blog post about `cargo-semver-checks` describing the problem this linter aims to solve.