### PR TITLE
Add this week in Databend 59

### DIFF
--- a/draft/2022-09-14-this-week-in-rust.md
+++ b/draft/2022-09-14-this-week-in-rust.md
@@ -43,6 +43,7 @@ and just ask the editors to select the category.
 * [Slint weekly updates (The GUI framework)](https://slint-ui.com/thisweek/2022-09-12.html)
 * [Fang 0.9 - new version of the background processing framework for rust](https://fang.badykov.com/blog/fang-09-release/)
 * [Fornjot (code-first CAD in Rust) - Weekly Release - 2022-W37](https://www.fornjot.app/blog/weekly-release/2022-w37/)
+* [This week in Databend #59: A Modern Cloud Data Warehouse for Everyone](https://weekly.databend.rs/2022-09-14-databend-weekly/)
 
 ### Observations/Thoughts
 * [You Can't Do That: Abstracting over Ownership in Rust with Higher-Rank Type Bounds. Or Can You?](https://lucumr.pocoo.org/2022/9/11/abstracting-over-ownership/)


### PR DESCRIPTION
ty!

---


Let's take a look at what's new at Datafuse Labs & Databend each week.

**RFC: Idempotent Copy**

When streaming copy stage files into a table, there is a chance that some files have already been copied, So it needs some ways to avoid duplicate copying files, make it an `idempotent` operation.

- Save copy into table stage files meta information in meta service
- Avoiding duplicates when copy stage files into a table

Learn more: <https://databend.rs/doc/contributing/rfcs/idempotent-copy>

**Databend Perf with Ontime JOIN**

With several recent patches, Databend can fully support Ontime JOIN queries, so you can now also see them in the Databend Perf dashboard.

- Q5 JOIN

    ```sql
    SELECT Carrier, c, c2, c*100/c2 as c3 FROM( SELECT IATA_CODE_Reporting_Airline AS Carrier, count(*) AS c FROM ontime WHERE DepDelay>10 AND Year=2007 GROUP BY Carrier) q JOIN ( SELECT IATA_CODE_Reporting_Airline AS Carrier, count(*) AS c2 FROM ontime WHERE Year=2007 GROUP BY Carrier ) qq USING (Carrier) ORDER BY c3 DESC;
    ```

- Q6 JOIN


    ```sql
    SELECT Carrier, c, c2, c*100/c2 as c3 FROM( SELECT IATA_CODE_Reporting_Airline AS Carrier, count(*) AS c FROM ontime WHERE DepDelay>10 AND Year>=2000 AND Year<=2008 GROUP BY Carrier) q JOIN ( SELECT IATA_CODE_Reporting_Airline AS Carrier, count(*) AS c2 FROM ontime WHERE Year>=2000 AND Year<=2008 GROUP BY Carrier ) qq USING (Carrier) ORDER BY c3 DESC;
    ```

- Q7 JOIN

    ```sql
    SELECT Year, c1/c2 FROM( select Year, count(*)*100 as c1 from ontime WHERE DepDelay>10 GROUP BY Year) q JOIN ( select Year, count(*) as c2 from ontime GROUP BY Year ) qq USING (Year) ORDER BY Year;
    ```

View dashboard: <https://perf.databend.rs/>