### PR TITLE
Add `headtail` project to the updates section

### DIFF
--- a/draft/2022-09-21-this-week-in-rust.md
+++ b/draft/2022-09-21-this-week-in-rust.md
@@ -35,6 +35,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+[`headtail`](https://github.com/CleanCut/headtail/), a new utility written in Rust to head and tail a file or pipe simultaneously.
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
Since combining `head` and `tail` to get the top and bottom of a file/pipe is surprisingly difficult, a group of GitHub engineers decided to create [`headtail`](https://github.com/CleanCut/headtail) as a new open source project for fun (and because we wanted it to exist so we could use it)!