### PR TITLE
Updated the docs, though I'm not sure it's used much anymore.

### DIFF
--- a/docs/assembling_twir.md
+++ b/docs/assembling_twir.md
@@ -6,9 +6,7 @@ This documents the general process for assembling each of the sections.
 
 ## Updates from the Rust Community
 
-[@nellshamrell](https://github.com/nellshamrell) currently covers this section, but would welcome help from additional editors!
-
-(Thank you to [@cdmistman](https://github.com/cdmistman) for covering this section so long! We look forward to when you can return!)
+The full editoral staff works together to cover this section, but the primary contributors are [@extrawurst](https://github.com/extrawurst), [@ericseppanen](https://github.com/ericseppanen), and [@cdmistman](https://github.com/cdmistman). 
 
 Many of the links featured in this section come from pull requests to this GitHub repo and tweets to the [@ThisWeekInRust](https://twitter.com/ThisWeekInRust).
 
@@ -34,17 +32,17 @@ The quotes are nominated and voted on in [this forums thread](https://users.rust
 
 ## Call for Participation Links
 
-[@nellshamrell](https://github.com/nellshamrell) covers this section.
+[@bennyvasquez](https://github.com/bennyvasquez) covers this section.
 
 These are submitted in [this forums thread](https://users.rust-lang.org/t/twir-call-for-participation/4821).
 
-## Updates from Rust Core
+## Updates from Rust Project
 
 [@llogiq](https://github.com/llogiq) covers this section and has scripts that collect these links.
 
 ## RFCs and FCP Issues/Pull Requests
 
-[@nellshamrell](https://github.com/nellshamrell) currently covers this section, but would welcome help from additional editors!
+[@U007D](https://github.com/U007D) currently covers this section!
 
 These are collected using GitHub queries:
 * [Recently approved RFCs](https://github.com/rust-lang/rfcs/commits/master)
@@ -54,12 +52,12 @@ These are collected using GitHub queries:
 
 ## Events
 
-[@nellshamrell](https://github.com/nellshamrell) currently covers this section, but would welcome help from additional editors!
+[@andrewpollack](https://github.com/andrewpollack) currently covers this section, but would welcome help from additional editors!
 
-These are collected from the [Rust Community Calendar](https://calendar.google.com/calendar/u/0/embed?src=apd9vmbc22egenmtu5l6c5jbfc@group.calendar.google.com). We generally only feature events that are upcoming in the next 14 days.
+These are collected from the [Rust Community Calendar](https://calendar.google.com/calendar/u/0/embed?src=apd9vmbc22egenmtu5l6c5jbfc@group.calendar.google.com). We generally only feature events that are upcoming in the next 4 weeks.
 
 Most events include a meetup link, it's important to follow the link and check the date on the meetup page. If the date on the meetup page is different from the date on the calendar, the date on the meetup page should take precedence.
 
 ## Jobs
 
-This section is currently filled by requests on Twitter and incoming pull requests into this repo.
+This section has been updated to refer to the most recent ['Who's Hiring'](https://www.reddit.com/r/rust/search/?q=who%27s%20hiring&restrict_sr=1&sr_nsfw=&include_over_18=1&sort=new) thread on the [Rust subreddit](https://www.reddit.com/r/rust/). 

--- a/docs/assembling_twir.md
+++ b/docs/assembling_twir.md
@@ -52,7 +52,7 @@ These are collected using GitHub queries:
 
 ## Events
 
-[@andrewpollack](https://github.com/andrewpollack) currently covers this section, but would welcome help from additional editors!
+[@andrewpollack](https://github.com/andrewpollack) and [@mariannegoldin](https://github.com/mariannegoldin) currently cover this section.
 
 These are collected from the [Rust Community Calendar](https://calendar.google.com/calendar/u/0/embed?src=apd9vmbc22egenmtu5l6c5jbfc@group.calendar.google.com). We generally only feature events that are upcoming in the next 4 weeks.
 


### PR DESCRIPTION
docs/assembling_twir.md was pretty out of date. Updated it mostly with educated guesses. 