### PR TITLE
2022-10-12: Add When to vendor (or not) your dependencies in Rust

### DIFF
--- a/draft/2022-10-12-this-week-in-rust.md
+++ b/draft/2022-10-12-this-week-in-rust.md
@@ -36,6 +36,7 @@ and just ask the editors to select the category.
 ### Project/Tooling Updates
 
 ### Observations/Thoughts
+* [When to vendor (or not) your dependencies in Rust](https://kerkour.com/rust-vendor-dependencies)
 * [RAII: Compile-Time Memory Management in C++ and Rust](https://www.thecodedmessage.com/posts/raii/)
 
 ### Rust Walkthroughs


### PR DESCRIPTION
Hi,

Following [last week's feedback](https://github.com/rust-lang/this-week-in-rust/pull/3708), I've added more details about vendoring Rust dependencies and its specificities (such as very very large `vendor` folders).

✌️ 