### PR TITLE
2022-10-12: Add update announcement for error-stack

### DIFF
--- a/draft/2022-10-12-this-week-in-rust.md
+++ b/draft/2022-10-12-this-week-in-rust.md
@@ -35,6 +35,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [Announcing error-stack v0.2](https://hash.dev/blog/error-stack-update-0-2)
+
 ### Observations/Thoughts
 * [RAII: Compile-Time Memory Management in C++ and Rust](https://www.thecodedmessage.com/posts/raii/)
 


### PR DESCRIPTION
Includes the update announcement for `error-stack` 🙂 