### PR TITLE
Add HexoSynth Devlog 13

### DIFF
--- a/draft/2022-10-19-this-week-in-rust.md
+++ b/draft/2022-10-19-this-week-in-rust.md
@@ -35,6 +35,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [HexoSynth 2022 - Devlog #13: Files, ADSR and VA Filters](https://m8geil.de/posts/hexosynth-13/)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
Even though I was told last time, that my Devlogs `would likely NOT qualify for inclusion in future issues.`
( See also https://github.com/rust-lang/this-week-in-rust/pull/3650 and https://github.com/rust-lang/this-week-in-rust/issues/3639 ),
maybe it might still be okay? Because I have seen many other similar posts in that section in the recent "Project/Tooling Updates".