### PR TITLE
Added guidance around formatting for the CFP section

### DIFF
--- a/draft/DRAFT_TEMPLATE
+++ b/draft/DRAFT_TEMPLATE
@@ -58,6 +58,9 @@ Every week we highlight some tasks from the Rust community for you to pick and g
 
 Some of these tasks may also have mentors available, visit the task page for more information.
 
+<!-- CFPs go here, use this format: * [project name - title of issue](link to issue) -->
+<!-- * [ - ]() -->
+
 If you are a Rust project owner and are looking for contributors, please submit tasks [here][guidelines].
 
 [guidelines]: https://users.rust-lang.org/t/twir-call-for-participation/4821


### PR DESCRIPTION
I noticed this week while doing the CFP update that the other sections had 'thing goes here' tags. When I took over this section I'd used past issues to identify a pattern for how the section was structured. In this PR I've added guidance to the template for future editions. 