### PR TITLE
Adjust Rust Foundation link.

### DIFF
--- a/content/2022-10-26-this-week-in-rust.md
+++ b/content/2022-10-26-this-week-in-rust.md
@@ -27,7 +27,7 @@ and just ask the editors to select the category.
 
 -->
 ### Foundation
-* [Rust Foundation](https://foundation.rust-lang.org/news/implementing-the-network-time-protocol-ntp-in-rust/)
+* [Implementing the Network Time Protocol (NTP) in Rust](https://foundation.rust-lang.org/news/implementing-the-network-time-protocol-ntp-in-rust/)
 
 ### Project/Tooling Updates
 * [rust-analyzer changelog #152](https://rust-analyzer.github.io/thisweek/2022/10/24/changelog-152.html)


### PR DESCRIPTION
The link text didn't really explain what the link was about. This adjusts it to the title of the blog post.