### PR TITLE
TWiR-466: Point whos hiring link to the correct one

### DIFF
--- a/content/2022-10-26-this-week-in-rust.md
+++ b/content/2022-10-26-this-week-in-rust.md
@@ -347,7 +347,7 @@ https://github.com/rust-lang/this-week-in-rust/issues/3412
 
 ## Jobs
 
-Please see the latest [Who's Hiring thread on r/rust](https://www.reddit.com/r/rust/comments/yc3z4r/hey_rustaceans_got_a_question_ask_here_432022/)
+Please see the latest [Who's Hiring thread on r/rust](https://www.reddit.com/r/rust/comments/xldzbl/official_rrust_whos_hiring_thread_for_jobseekers/)
 
 # Quote of the Week
 


### PR DESCRIPTION
The link for hiring thread points to the question mega thread. This PR updates it to the hiring thread instead.