### PR TITLE
Add Kani blog about Bolero integration

### DIFF
--- a/draft/2022-11-02-this-week-in-rust.md
+++ b/draft/2022-11-02-this-week-in-rust.md
@@ -34,6 +34,7 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
+ * [From Fuzzing to Proof: Using Kani with the Bolero Property-Testing Framework](https://model-checking.github.io/kani-verifier-blog/2022/10/27/using-kani-with-the-bolero-property-testing-framework.html)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
Adds the Kani blog post on Bolero integration.

(I think "Project/Tooling" updates is the best place to add it, but please let me know if this is not the case. Thanks!)