### PR TITLE
Add link to Rust developers survey

### DIFF
--- a/draft/2022-11-30-this-week-in-rust.md
+++ b/draft/2022-11-30-this-week-in-rust.md
@@ -41,6 +41,8 @@ and just ask the editors to select the category.
 
 ### Research
 
+* [Rust developers survey: coexisting Rust and C/C++ ecosystems](https://surveys.jetbrains.com/s3/rust-developers-survey)
+
 ### Miscellaneous
 
 ## Crate of the Week


### PR DESCRIPTION
Hi! 

I consider this survey as being of general interest to the Rust community. Its goal is to learn how exactly Rust and C/C++ ecosystems coexist. The results are might be shared back with the community.