### PR TITLE
Add link to the blog post about Rust macros

### DIFF
--- a/draft/2022-12-07-this-week-in-rust.md
+++ b/draft/2022-12-07-this-week-in-rust.md
@@ -37,6 +37,8 @@ and just ask the editors to select the category.
 
 ### Observations/Thoughts
 
+* [What Every Rust Developer Should Know About Macro Support in IDEs](https://blog.jetbrains.com/rust/2022/12/05/what-every-rust-developer-should-know-about-macro-support-in-ides/)
+
 ### Rust Walkthroughs
 
 ### Research


### PR DESCRIPTION
Hi! Although this [blogpost](https://blog.jetbrains.com/rust/2022/12/05/what-every-rust-developer-should-know-about-macro-support-in-ides/) is coupled with the recent [release of the IntelliJ Rust plugin](https://intellij-rust.github.io/2022/12/05/changelog-184.html), I believe its topic is more general than that, and it's more appropriate for the "Observations/Thoughts" section, not the "Project/Tooling Updates".