### PR TITLE
Draft: Add a Dark Mode

### DIFF
--- a/themes/rusted/static/css/_base.scss
+++ b/themes/rusted/static/css/_base.scss
@@ -126,9 +126,9 @@ blockquote {
 pre,
 code {
     font-size: 15px;
-    border: 1px solid $grey-colour-light;
+    border: 1px solid $code-border-color;
     border-radius: 3px;
-    background-color: #eef;
+    background-color: $code-bg-color;
 }
 
 code {
@@ -138,6 +138,7 @@ code {
 pre {
     padding: 8px 12px;
     overflow-x: scroll;
+    color: $pre-color;
 
     > code {
         border: 0;

--- a/themes/rusted/static/css/_base.scss
+++ b/themes/rusted/static/css/_base.scss
@@ -92,7 +92,7 @@ a {
     text-decoration: none;
 
     &:visited {
-        color: darken($brand-color, 15%);
+        color: $brand-color-visited;
     }
 
     &:hover {

--- a/themes/rusted/static/css/_homepage.scss
+++ b/themes/rusted/static/css/_homepage.scss
@@ -8,5 +8,6 @@
 }
 
 .subtext {
-    
+    margin-left: 50px;
+    margin-right: 50px;
 }

--- a/themes/rusted/static/css/_layout.scss
+++ b/themes/rusted/static/css/_layout.scss
@@ -17,9 +17,9 @@
     letter-spacing: -1px;
     margin-bottom: 0;
 
-    &,
+    color: $text-color;
     &:visited {
-        color: $grey-colour-dark;
+        color: $text-color;
     }
 }
 

--- a/themes/rusted/static/css/main.scss
+++ b/themes/rusted/static/css/main.scss
@@ -11,31 +11,41 @@ $base-line-height: 1.5;
 $spacing-unit:     30px;
 
 // Our variables
-$text-color: var(--text-color);
-$background-color: var(--background-color);
-$brand-color: var(--brand-color);
-$brand-color-visited: var(--brand-color-visited);
-$grey-colour: #828282;
-$grey-colour-light: lighten($grey-colour, 40%);
-$grey-colour-dark: darken($grey-colour, 25%);
+$text-color:            var(--text-color);
+$background-color:      var(--background-color);
+$brand-color:           var(--brand-color);
+$brand-color-visited:   var(--brand-color-visited);
+$pre-color:             var(--pre-color);
+$code-bg-color:         var(--code-bg-color);
+$code-border-color:     var(--code-border-color);
+$grey-colour:           #828282;
+$grey-colour-light:     lighten($grey-colour, 40%);
+$grey-colour-dark:      darken($grey-colour, 25%);
 
 // Light theme colors
 $text-color-lt:          #444;
 $background-color-lt:    #fdfdfd;
 $brand-color-lt:         #2a7ae2;
 $brand-color-visited-lt: #1756a9;
+$pre-color-lt:           #333;
+$code-bg-color-lt:       #eef;
 
 // Dark theme colors
 $text-color-dt:          #f0f0f0;
 $background-color-dt:    #353535;
 $brand-color-dt:         #d2991d;
 $brand-color-visited-dt: #9a7015;
+$pre-color-dt:           #aeaeae;
+$code-bg-color-dt:       #2a2a2a;
 
 :root {
-    --text-color:       #{$text-color-lt};
-    --background-color: #{$background-color-lt};
-    --brand-color:      #{$brand-color-lt};
+    --text-color:           #{$text-color-lt};
+    --background-color:     #{$background-color-lt};
+    --brand-color:          #{$brand-color-lt};
     --brand-color-visited:  #{$brand-color-visited-lt};
+    --pre-color:            #{$pre-color-lt};
+    --code-bg-color:        #{$code-bg-color-lt};
+    --code-border-color:    #{$grey-colour-light};
 }
 
 @media(prefers-color-scheme: dark) {
@@ -44,6 +54,9 @@ $brand-color-visited-dt: #9a7015;
         --background-color:     #{$background-color-dt};
         --brand-color:          #{$brand-color-dt};
         --brand-color-visited:  #{$brand-color-visited-dt};
+        --pre-color:            #{$pre-color-dt};
+        --code-bg-color:        #{$code-bg-color-dt};
+        --code-border-color:    #{$code-bg-color-dt};
     }
 }
 

--- a/themes/rusted/static/css/main.scss
+++ b/themes/rusted/static/css/main.scss
@@ -3,7 +3,6 @@
 // Bootstrap variables
 $screen-xs-max: 768px !default;
 
-// Our variables
 $base-font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
 $base-font-size:   16px;
 $small-font-size:  $base-font-size * 0.875;
@@ -11,13 +10,42 @@ $base-line-height: 1.5;
 
 $spacing-unit:     30px;
 
-$text-color:       #444;
-$background-color: #fdfdfd;
-$brand-color:      #2a7ae2;
-
-$grey-colour:       #828282;
+// Our variables
+$text-color: var(--text-color);
+$background-color: var(--background-color);
+$brand-color: var(--brand-color);
+$brand-color-visited: var(--brand-color-visited);
+$grey-colour: #828282;
 $grey-colour-light: lighten($grey-colour, 40%);
-$grey-colour-dark:  darken($grey-colour, 25%);
+$grey-colour-dark: darken($grey-colour, 25%);
+
+// Light theme colors
+$text-color-lt:          #444;
+$background-color-lt:    #fdfdfd;
+$brand-color-lt:         #2a7ae2;
+$brand-color-visited-lt: #1756a9;
+
+// Dark theme colors
+$text-color-dt:          #f0f0f0;
+$background-color-dt:    #353535;
+$brand-color-dt:         #d2991d;
+$brand-color-visited-dt: #9a7015;
+
+:root {
+    --text-color:       #{$text-color-lt};
+    --background-color: #{$background-color-lt};
+    --brand-color:      #{$brand-color-lt};
+    --brand-color-visited:  #{$brand-color-visited-lt};
+}
+
+@media(prefers-color-scheme: dark) {
+    :root {
+        --text-color:           #{$text-color-dt};
+        --background-color:     #{$background-color-dt};
+        --brand-color:          #{$brand-color-dt};
+        --brand-color-visited:  #{$brand-color-visited-dt};
+    }
+}
 
 $on-palm:          600px;
 $on-laptop:        800px;

--- a/themes/rusted/templates/index.html
+++ b/themes/rusted/templates/index.html
@@ -4,7 +4,7 @@
 <div class="row">
   <div class="col-md-12 text-center">
     <h1 class="pitch">Handpicked Rust updates, <br /> delivered to your inbox.</h1>
-    <p class="subtext">Stay up to date with events, learning resources, and recent developments in Rust community.</p>
+    <p class="subtext">Stay up to date with events, learning resources, and recent developments in the Rust community.</p>
   </div>
 </div>
 {% include "_subscribe-form.html" %}


### PR DESCRIPTION
Fixes #2274 (if merged)

Hello! Saw this on TWiR and thought I'd give it a go; I have no experience with frontend work so I'm completely OK with scrapping this PR too.

This sets dark mode for users who have dark color schemes preferred. I tried replicating a similar color scheme to docs.rs' Dark theme because I thought it'd look nice. I'm also down to change the color scheme, but I kind of agree about not liking straight white-on-black, which is discussed in a previous attempt to bring a dark mode (https://github.com/rust-lang/this-week-in-rust/pull/1089#issuecomment-565978373).

Preview:
![image](https://user-images.githubusercontent.com/57812141/205834691-ccfdd8d2-0250-4730-aca8-374cdbd8eb62.png)
![image](https://user-images.githubusercontent.com/57812141/205834850-26f386f9-5dba-4c7b-b31a-edfef2af4fa7.png)

I understand that this doesn't give users the option to change between themes. If that prevents a merge, I'll try and spend additional time to implement some tri-state widget as mentioned by @flying-sheep.

---

I also added a tiny commit that's unrelated to dark mode that fixes a typo (developments in Rust community -> developments in THE Rust Community). In addition, I added margins to make it look nicer and aligned with the other components like the input and header text. Without the margins:

![image](https://user-images.githubusercontent.com/57812141/205835708-6e524c3d-09ee-46f9-a536-12f186f5588f.png)
![image](https://user-images.githubusercontent.com/57812141/205836592-ff3e580b-b5a4-4b43-9c52-b7480f0e6f8b.png)

With margins and fixed typo:

![image](https://user-images.githubusercontent.com/57812141/205836281-d9322a5a-bbfc-416c-ac97-54543c8765e6.png)
![image](https://user-images.githubusercontent.com/57812141/205836533-5ee50203-40a9-4b51-903e-a1631e891a20.png)

Adding margins is kind of a subjective choice, and  my choice in color scheme is also just my preference, so please let me know what you all think!