### PR TITLE
add header links

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -48,3 +48,15 @@ scattered about.
 }
 
 PLUGINS = ['webassets']
+
+MARKDOWN = {
+    'extension_configs': {
+        'markdown.extensions.codehilite': {'css_class': 'highlight'},
+        'markdown.extensions.extra': {},
+        'markdown.extensions.meta': {},
+        'markdown.extensions.toc': {
+            'anchorlink': True,
+        },
+    },
+    'output_format': 'html5',
+}

--- a/themes/newsletter/templates/base.html
+++ b/themes/newsletter/templates/base.html
@@ -122,6 +122,10 @@
        font-size: 16px;
      }
 
+     a.toclink, a.toclink:visited {
+       color: #444444;
+     }
+
      a, a:visited {
        color: #2a7ae2;
        text-decoration: none;
@@ -188,6 +192,10 @@
      @media (prefers-color-scheme: dark) {
        body {
          background: #111 !important;
+         color: white !important;
+       }
+
+       a.toclink, a.toclink:visited {
          color: white !important;
        }
 

--- a/themes/rusted/static/css/_base.scss
+++ b/themes/rusted/static/css/_base.scss
@@ -83,6 +83,13 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 
+/**
+ * Anchor links
+ */
+a.toclink, a.toclink:visited {
+    color: $text-color;
+}
+
 
 /**
  * Links


### PR DESCRIPTION
Fixes https://github.com/rust-lang/this-week-in-rust/issues/3669 if merged

Hi again! Same author of the dark mode draft PR; basically just searched up how to add anchors in pelican and used the [first link](https://github.com/getpelican/pelican/issues/1357#issuecomment-362075129) with [some](https://docs.getpelican.com/en/latest/settings.html?highlight=MARKDOWN#basic-settings) [documentation](https://python-markdown.github.io/extensions/toc/#usage) to get the following result:

![image](https://user-images.githubusercontent.com/57812141/206021928-ecb29942-7dd4-4d66-8de7-5e7c4d795ee4.png)

Again, no experience with UI and my design choices are subjective, but I chose to have a permalink with this specific css to prevent it from being to obtrusive and taking the same colors as other links, while also making it easy to find.

**Let me know if there's anything I can/should change!**