### PR TITLE
Added link to draft 473

### DIFF
--- a/draft/2022-12-14-this-week-in-rust.md
+++ b/draft/2022-12-14-this-week-in-rust.md
@@ -38,7 +38,7 @@ and just ask the editors to select the category.
 ### Observations/Thoughts
 
 ### Rust Walkthroughs
-* [Sending Emails from the Edge with Rust]([https://github.com/rust-lang/rust/pull/103293](https://mainmatter.com/blog/2022/12/09/sending-emails-from-the-edge-with-rust/))
+* [Sending Emails from the Edge with Rust](https://mainmatter.com/blog/2022/12/09/sending-emails-from-the-edge-with-rust/)
 
 ### Research
 

--- a/draft/2022-12-14-this-week-in-rust.md
+++ b/draft/2022-12-14-this-week-in-rust.md
@@ -38,6 +38,7 @@ and just ask the editors to select the category.
 ### Observations/Thoughts
 
 ### Rust Walkthroughs
+* [Sending Emails from the Edge with Rust]([https://github.com/rust-lang/rust/pull/103293](https://mainmatter.com/blog/2022/12/09/sending-emails-from-the-edge-with-rust/))
 
 ### Research
 


### PR DESCRIPTION
Added the link to a new blog post "Sending Emails from the Edge with Rust" in the Rust Walkthroughs session.