### PR TITLE
Update link visited color light mode

### DIFF
--- a/themes/rusted/static/css/main.scss
+++ b/themes/rusted/static/css/main.scss
@@ -29,7 +29,7 @@ $grey-colour-dark:      darken($grey-colour, 25%);
 $text-color-lt:          #444;
 $background-color-lt:    #fdfdfd;
 $brand-color-lt:         #2a7ae2;
-$brand-color-visited-lt: #1756a9;
+$brand-color-visited-lt: #551A8B;
 $pre-color-lt:           #333;
 $code-bg-color-lt:       #eef;
 $thead-color-lt:         #eeeeee;


### PR DESCRIPTION
Closes: #2688 

Changes coloring of clicked links from a darker blue, to a dark purple. Several websites use this color distinction (e.g. [here](https://health.gov/healthliteracyonline/display/section-3-7/)), and I believe it will make it easier to tell which links have been visited already in light mode

The example below shows the same page containing several clicked links, with the image on the right showing the newer color choice.

<img width="1563" alt="Screen Shot 2023-01-05 at 6 34 20 PM" src="https://user-images.githubusercontent.com/24868505/210918753-fe52e215-f68b-477b-b2b7-c9dabc95bc5f.png">

