### PR TITLE
Add Rust and default parameters

### DIFF
--- a/draft/2023-01-11-this-week-in-rust.md
+++ b/draft/2023-01-11-this-week-in-rust.md
@@ -57,6 +57,7 @@ and just ask the editors to select the category.
 * [Rust vs C++ Formatting](https://brevzin.github.io/c++/2023/01/02/rust-cpp-format/)
 * [My impressions of Rust after a year of working with it](https://reltech.substack.com/p/my-impressions-of-rust-after-a-year)
 * [audio] [Fermyon with Matt Butcher](https://rustacean-station.org/episode/matt-butcher/)
+* [Rust and Default Parameters](https://www.thecodedmessage.com/posts/default-params/)
 
 ### Rust Walkthroughs
 * [Testing SIMD instructions on ARM with Rust on Android](https://gendignoux.com/blog/2023/01/05/rust-arm-simd-android.html)


### PR DESCRIPTION
This post discusses why default parameters are not included in Rust, and what you can do instead.