### PR TITLE
Zenoh 0.7.0 Release -- Rust Pub/Sub/Query Protocol

### DIFF
--- a/draft/2023-01-25-this-week-in-rust.md
+++ b/draft/2023-01-25-this-week-in-rust.md
@@ -34,6 +34,8 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
+* [**Zenoh 0.7.0**, a pure Rust Pub/Sub/Query protocol for cloud-to-thing continuum, was released and it is packed with new features.](https://zenoh.io/blog/2023-01-10-zenoh-charmander/)
+
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
As commented on the rejected pull request, Zenoh is a 100% rust protocol (See https://crates.io/crates/zenoh and http://github.com/eclipse-zenoh/zenoh). We have had the releases covered in the past (see content/2022-10-19-this-week-in-rust.md), not sure why the pull request for the last instalment was rejected, thus re-iterating.