### PR TITLE
Add blog link for Rust parser using Pest

### DIFF
--- a/draft/2023-02-08-this-week-in-rust.md
+++ b/draft/2023-02-08-this-week-in-rust.md
@@ -38,6 +38,7 @@ and just ask the editors to select the category.
 ### Observations/Thoughts
 
 ### Rust Walkthroughs
+- [Building a Rust parser using Pest and PEG](https://blog.logrocket.com/building-rust-parser-pest-peg/)
 
 ### Research
 


### PR DESCRIPTION
This adds link for the blog 'Building a Rust parser using Pest and PEG' . It is open to everyone, and not behind the paywall.

Thanks :)