### PR TITLE
Link the Meilisearch v1.0 release

### DIFF
--- a/draft/2023-02-15-this-week-in-rust.md
+++ b/draft/2023-02-15-this-week-in-rust.md
@@ -34,6 +34,7 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
+* [Meilisearch releases v1.0, the first completely stable version of its open-source search engine](https://github.com/meilisearch/meilisearch/releases/tag/v1.0.0/)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
Hey 👋, I want to link to the latest release of Meilisearch, v1.0, the first stable release of the open-source engine.