### PR TITLE
Adding a link to an article

### DIFF
--- a/draft/2023-02-22-this-week-in-rust.md
+++ b/draft/2023-02-22-this-week-in-rust.md
@@ -37,6 +37,8 @@ and just ask the editors to select the category.
 
 ### Observations/Thoughts
 
+* [Rust development for the Raspberry PI on Apple Silicon](https://manuel.bernhardt.io/posts/2022-11-04-rust-development-for-the-raspberry-pi-on-apple-silicon/)
+
 ### Rust Walkthroughs
 
 ### Research


### PR DESCRIPTION
Following the encouraging words at the Rust Nation UK keynote, I'm submitting a link to this article I wrote a while back (and now updated with new findings)