### PR TITLE
Add Rust Nation UK 2023 blog post from Jetstack

### DIFF
--- a/draft/2023-02-22-this-week-in-rust.md
+++ b/draft/2023-02-22-this-week-in-rust.md
@@ -37,13 +37,13 @@ and just ask the editors to select the category.
 
 ### Observations/Thoughts
 
-- [Rust Nation UK 2023](https://www.jetstack.io/blog/rust-nation-uk-2023/)
-
 ### Rust Walkthroughs
 
 ### Research
 
 ### Miscellaneous
+
+- [Rust Nation UK 2023](https://www.jetstack.io/blog/rust-nation-uk-2023/)
 
 ## Crate of the Week
 

--- a/draft/2023-02-22-this-week-in-rust.md
+++ b/draft/2023-02-22-this-week-in-rust.md
@@ -37,6 +37,8 @@ and just ask the editors to select the category.
 
 ### Observations/Thoughts
 
+- [Rust Nation UK 2023](https://www.jetstack.io/blog/rust-nation-uk-2023/)
+
 ### Rust Walkthroughs
 
 ### Research


### PR DESCRIPTION
This adds my blog post on my company's blog about my time at Rust Nation UK 2023.

I'm not sure if this is the fully correct category (I know another blogger https://github.com/rust-lang/this-week-in-rust/pull/4072 used the misc. category), so I'm happy to change it if wanted.