### PR TITLE
fix next/previous buttons

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -19,8 +19,6 @@ else:
     THEME = 'themes/rusted'
 
 THEME_STATIC_DIR = THEME + '/static'
-PLUGIN_PATHS = ["plugins"]
-PLUGINS = ['assets', 'neighbors']
 
 TIMEZONE = 'America/New_York'
 
@@ -52,11 +50,13 @@ scattered about.
 """
 }
 
-# Don't add search functionality for email.
+PLUGIN_PATHS = ["plugins"]
+
+# Don't add next/previous buttons search functionality for email.
 if USE_EMAIL_THEME:
     PLUGINS = ['webassets']
 else:
-    PLUGINS = ['webassets', 'search']
+    PLUGINS = ['webassets', 'neighbors', 'search']
     SEARCH_HTML_SELECTOR = "article"
 
 MARKDOWN = {

--- a/themes/rusted/static/css/_layout.scss
+++ b/themes/rusted/static/css/_layout.scss
@@ -166,7 +166,7 @@ body > footer {
         display: inline-flex;
         align-items: center;
         line-height: 1.25;
-        color: $grey-colour-dark;
+        color: $text-color;
         &:hover {
             text-decoration: none;
             .neighbor-title {


### PR DESCRIPTION
Fixes #3175.

Said issue references https://github.com/rust-lang/this-week-in-rust/commit/2749a86022447516e1bb225112e5ca3eff2558ce which adds `PLUGINS=['webassets']` when it's already been defined with `neighbors` 20 lines up!

Doesn't affect the email/newsletter, but I don't think the email/newsletter ever had this functionality.

![image](https://user-images.githubusercontent.com/57812141/220776214-450ebff3-970e-4512-ba68-7961b1fc8030.png)
