### PR TITLE
Add Kani blog post on stubbing

### DIFF
--- a/draft/2023-03-01-this-week-in-rust.md
+++ b/draft/2023-03-01-this-week-in-rust.md
@@ -34,6 +34,7 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
+ * [Kani Internship Projects 2022: Function Stubbing](https://model-checking.github.io/kani-verifier-blog/2023/02/28/kani-internship-projects-2022-stubbing.html)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
Adds the Kani blog post [Kani Internship Projects 2022: Function Stubbing](https://model-checking.github.io/kani-verifier-blog/2023/02/28/kani-internship-projects-2022-stubbing.html).