### PR TITLE
Re-exporting enums with `pub type` is breaking, not major

### DIFF
--- a/draft/2023-03-08-this-week-in-rust.md
+++ b/draft/2023-03-08-this-week-in-rust.md
@@ -36,6 +36,7 @@ and just ask the editors to select the category.
 ### Project/Tooling Updates
 
 ### Observations/Thoughts
+* [Re-exporting an enum with a type alias is breaking, but not major](https://predr.ag/blog/re-exporting-enum-with-type-alias-breaking-change-not-major/)
 
 ### Rust Walkthroughs
 


### PR DESCRIPTION
A blog post documenting an unexpected difference between `pub use` and `pub type`. It causes a breaking change that under Rust's rules is not semver-major.