### PR TITLE
Update a link after change of username

### DIFF
--- a/draft/2023-03-08-this-week-in-rust.md
+++ b/draft/2023-03-08-this-week-in-rust.md
@@ -47,7 +47,7 @@ and just ask the editors to select the category.
 * [Creating and publishing a Python package written in Rust](https://antoniosbarotsis.github.io/posts/python_package_written_in_rust/)
 * [video] [Matching Braces With a Stack, Beginner Tutorial](https://www.youtube.com/watch?v=i_ghB5AusDs)
 
-* [Embedded Rust on ESP32C3 Board, a Hands-on Quickstart Guide](https://gitlab.com/cyril.marpaud/rust_esp_quickstart/)
+* [Embedded Rust on ESP32C3 Board, a Hands-on Quickstart Guide](https://gitlab.com/cyril-marpaud/rust_esp_quickstart/)
 
 ### Research
 


### PR DESCRIPTION
I changed my username from cyril.marpaud to cyril-marpaud... So the link to the article changed in the process... Sorry for the hassle !