### PR TITLE
fix python urllib syntax

### DIFF
--- a/tools/inspect_links.py
+++ b/tools/inspect_links.py
@@ -13,7 +13,7 @@ import markdown
 import os
 import re
 import sys
-import urllib
+import urllib.parse
 
 LOG = logging.getLogger(__name__)
 LOG.setLevel(logging.INFO)


### PR DESCRIPTION
On Ubuntu 22.04 with Python 3.10.6, the script crashes with
```txt
AttributeError: module 'urllib' has no attribute 'parse'
```
Apparently the import was wrong all along, but some quirk of the older distro allowed it to work previously.