### PR TITLE
Added blog post Making Python 100x faster with less than 100 lines of Rust

### DIFF
--- a/draft/2023-03-29-this-week-in-rust.md
+++ b/draft/2023-03-29-this-week-in-rust.md
@@ -69,6 +69,7 @@ and just ask the editors to select the category.
 * [Linear Types One-Pager](https://blog.yoshuawuyts.com/linear-types-one-pager/)
 * [Writing a Linux executable from scratch with x86_64-unknown-none and Rust](https://vulns.xyz/2023/03/linux-executable-from-scratch-with-x86_64-unknown-none-rust/)
 * [Efficient, Extensible, Expressive: Typed Tagless Final Interpreters in Rust](https://getcode.substack.com/p/efficient-extensible-expressive-typed)
+* [Making Python 100x faster with less than 100 lines of Rust](https://ohadravid.github.io/posts/2023-03-rusty-python/)
 * [video] [Env Config Option](https://youtu.be/r6niPhmgxRY)
 
 ### Research


### PR DESCRIPTION
A tutorial about using Rust + `{pyo3,numpy,ndarray}` crates to speed up a Python library [link](https://ohadravid.github.io/posts/2023-03-rusty-python/)