### PR TITLE
add Paradigm Shift

### DIFF
--- a/draft/2023-03-29-this-week-in-rust.md
+++ b/draft/2023-03-29-this-week-in-rust.md
@@ -60,6 +60,7 @@ and just ask the editors to select the category.
 * [The AsyncIterator interface](https://without.boats/blog/async-iterator/)
 * [A Proposal for Safe Window Handles](https://notgull.github.io/safe-windows/)
 * [Rust Is a Scalable Language](https://matklad.github.io/2023/03/28/rust-is-a-scalable-language.html)
+* [Paradigm Shift](https://www.thecodedmessage.com/posts/paradigm-shift/)
 
 ### Rust Walkthroughs
 * [Building a Fibonacci Heap](https://www.kurtlawrence.info/blog/building-a-fibonacci-heap)


### PR DESCRIPTION
Adding a post I co-wrote with a friend, which contextualizes Rust in a general shift towards functional paradigm approach and programming language features.