### PR TITLE
Added a fix for the M1 Docker problem

### DIFF
--- a/publishing/Dockerfile
+++ b/publishing/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM --platform=linux/amd64 ubuntu:20.04
 
 # Must run from base TWIR directory... makefile takes care of this.
 WORKDIR /usr/twir


### PR DESCRIPTION
When running the docker command, I was getting an error.  

```
 => exporting to image                                                                                                                                          1.3s
 => => exporting layers                                                                                                                                         1.3s
 => => writing image sha256:3ade69a97314da8f265731eded27f515c06eb8213a1c6cfd2ba9ec53b6695c28                                                                    0.0s
 => => naming to docker.io/library/twir                                                                                                                         0.0s

Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them
/Users/bennyvasquez/Documents/github/this-week-in-rust/publishing
rm -rf output/
docker run -it \
		-v /Users/bennyvasquez/Documents/github/this-week-in-rust/publishing/output:/usr/twir/output \
		twir:latest 
[00:12:37] CRITICAL Exception: Search plugin reported qemu-x86_64: Could not open '/lib64/ld-linux-x86-64.so.2': No such file or directory            __init__.py:550
                                                                                                                                                                     
make: *** [generate-website] Error 1
```

I got the idea for this fix [from this stockoverflow thread](https://stackoverflow.com/questions/71040681/qemu-x86-64-could-not-open-lib64-ld-linux-x86-64-so-2-no-such-file-or-direc), and it fixed it for me. HOWEVER, I don't know anything about docker, so I didn't want to make the change without a review. 

I was also getting this error even after it would build successfully

```
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
```

