### PR TITLE
Smaller Docker image

### DIFF
--- a/publishing/Dockerfile
+++ b/publishing/Dockerfile
@@ -1,15 +1,14 @@
-FROM ubuntu:20.04
+FROM --platform=linux/amd64 python:3.8.16-slim
 
 # Must run from base TWIR directory... makefile takes care of this.
 WORKDIR /usr/twir
 
-RUN apt-get update
-RUN apt-get install -qq -y curl python3.8 python3-pip language-pack-en
+RUN apt update
+RUN apt install -y curl
 
 # pelican+friends
 ENV LANG='en_US.UTF-8'
 ENV LC_ALL='en_US.UTF-8'
-RUN ln -s /usr/bin/python3.8 /usr/bin/python
 COPY requirements.txt .
 RUN pip3 install -r requirements.txt
 RUN curl https://files.stork-search.net/releases/v1.5.0/stork-ubuntu-20-04 -o stork \
@@ -17,7 +16,6 @@ RUN curl https://files.stork-search.net/releases/v1.5.0/stork-ubuntu-20-04 -o st
     && mv ./stork /usr/bin/stork
 
 # sass/juice
-RUN apt-get install -y curl
 RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
 RUN apt-get install -y nodejs
 RUN npm install -g sass


### PR DESCRIPTION
Switched to using a base Python image instead of the Ubuntu one (therefore no need to install Python). The new Dockerfile produces a final Docker image of about 2/3 of the size (~387MB instead of ~700mb on my machine).

I tried running all commands in the Makefile and all seems fine (though I am not terribly familiar with the workflow of TwiR).