### PR TITLE
Temporarily remove search functionality

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -56,8 +56,13 @@ PLUGIN_PATHS = ["plugins"]
 if USE_EMAIL_THEME:
     PLUGINS = ['webassets']
 else:
+    PLUGINS = ['webassets', 'neighbors']
+    """
+    Search functionality disabled while troubleshooting performance issues
+    for non-desktop readers. See https://github.com/rust-lang/this-week-in-rust/issues/4271
     PLUGINS = ['webassets', 'neighbors', 'search']
     SEARCH_HTML_SELECTOR = "article"
+    """
 
 MARKDOWN = {
     'extension_configs': {

--- a/themes/rusted/templates/base.html
+++ b/themes/rusted/templates/base.html
@@ -32,8 +32,9 @@
     <link href="{{ FEED_DOMAIN }}/{{ FEED_ALL_ATOM }}" type="application/atom+xml" rel="alternate" title="{{ SITENAME|striptags }} - Full Atom Feed" />
 
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css" />
+    <!-- Search temporarily disabled. See https://github.com/rust-lang/this-week-in-rust/issues/4271
     <link rel="stylesheet" href="https://files.stork-search.net/basic.css" />
-    <link rel="stylesheet" media="screen and (prefers-color-scheme: dark)" href="{{ SITEURL }}/{{ THEME_STATIC_DIR }}/css/stork-dark.css">
+    <link rel="stylesheet" media="screen and (prefers-color-scheme: dark)" href="{{ SITEURL }}/{{ THEME_STATIC_DIR }}/css/stork-dark.css"> -->
     {% assets filters="libsass,cssmin", output="css/web-min.css", "css/main.scss" %}
 
     <link rel="stylesheet" href="/{{ ASSET_URL }}" />

--- a/themes/rusted/templates/index.html
+++ b/themes/rusted/templates/index.html
@@ -27,6 +27,7 @@
       </li>
     </ul>
   </div>
+  <!-- Search temporarily disabled. See https://github.com/rust-lang/this-week-in-rust/issues/4271
   <div class ="col-md-12">
     <ul class="list-unstyled search">
       <li class="nav-header disabled"><h2>Search</h2></li>
@@ -43,6 +44,6 @@
         </script>
       </div>
     </ul>
-  </div>
+  </div> -->
 </div>
 {% endblock content %}


### PR DESCRIPTION
Context: #4270 #4271

Search functionality loading is blocking the front page from loading for readers on mobile/tablet devices. This PR temporarily disables search functionality until longer term fix can be implemented.