### PR TITLE
Add Enzyme info

### DIFF
--- a/draft/cft_rfc_fcp_draft_template.md
+++ b/draft/cft_rfc_fcp_draft_template.md
@@ -5,6 +5,12 @@ are the RFCs that were approved for implementation this week:
 
 * *No RFCs were approved this week.*
 
+#### Approved MCPs
+
+*    The MCP (Major Change Proposal) [Integreate Enzyme into nightly rustc](https://github.com/rust-lang/compiler-team/issues/611#issuecomment-1506929616) got accepted. The [current prototype](https://github.com/EnzymeAD/rust) will be upgraded and integrated into some future nightly releases. Those releases will have experimental support to vectorize and differentiate (in the calculus sense) Rust code.
+
+
+
 ### Final Comment Period
 
 Every week, [the team](https://www.rust-lang.org/team.html) announces the 'final comment period' for RFCs and key PRs


### PR DESCRIPTION
I understand that you usually don't announce MCP, since they are quite a few more than RFCs.
However, I think that this one is a bit bigger than usual and will be followed by an RFC in a year or so.
For the meantime I want to get people interested, in order to have as many test users as possible once I finished the integration into rustc. Could we therefore please announce it here?

I do not really care about the specific design, if you prefer we can remove the MCP section and add it in another place, just let me know!