### PR TITLE
Add post: what's new in git-cliff 1.2.0?

### DIFF
--- a/draft/2023-05-03-this-week-in-rust.md
+++ b/draft/2023-05-03-this-week-in-rust.md
@@ -35,6 +35,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+- [git-cliff 1.2.0 released (Highly Customizable Changelog Generator)](https://git-cliff.org/blog/git-cliff-1.2.0)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
Hey! 🐻

I just released the new version of [`git-cliff`](https://github.com/orhun/git-cliff) which is a changelog generator written in Rust.

This PR simply adds the blog post about the new version to this week's draft.

Thank you!
