### PR TITLE
Revert "add enzyme"

### DIFF
--- a/draft/cft_rfc_fcp_draft_template.md
+++ b/draft/cft_rfc_fcp_draft_template.md
@@ -14,10 +14,6 @@ which are reaching a decision. Express your opinions now.
 
 * [Add RFC on governance, establishing the Leadership Council](https://github.com/rust-lang/rfcs/pull/3392)
 
-
-#### [Approved Major Change Proposals (MCP)](https://forge.rust-lang.org/compiler/mcp.html)
-
-*  [major change accepted] [Integrate Enzyme into nightly rustc](https://github.com/rust-lang/compiler-team/issues/611#issuecomment-1506929616)
 #### [Tracking Issues & PRs](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Afinal-comment-period+sort%3Aupdated-desc)
 * [disposition: merge] [Use fulfillment to check Drop impl compatibility](https://github.com/rust-lang/rust/pull/110577)
 * [disposition: merge] [Only check outlives goals on impl compared to trait](https://github.com/rust-lang/rust/pull/109356)


### PR DESCRIPTION
Reverts rust-lang/this-week-in-rust#4317.

We are not yet ready to update the template, as related Issue #4112 is currently closed. 

The changes applicable to TWiR #493 were made with commit [17afd69](https://github.com/rust-lang/this-week-in-rust/commit/17afd6984350230804ff09643fafbd99b7d30dd4) to the `master` branch.