### PR TITLE
Added blog post "Coherence in Rust (feat. rustc sources)"

### DIFF
--- a/draft/2023-05-10-this-week-in-rust.md
+++ b/draft/2023-05-10-this-week-in-rust.md
@@ -47,6 +47,7 @@ and just ask the editors to select the category.
 ### Rust Walkthroughs
 
 * [Build a non-binary tree that is thread safe using Rust](https://developerlife.com/2022/02/24/rust-non-binary-tree/)
+* [Coherence in Rust (feat. rustc sources)](https://ohadravid.github.io/posts/2023-05-coherence-and-errors/)
 
 ### Research
 


### PR DESCRIPTION
A [blog post](https://ohadravid.github.io/posts/2023-05-coherence-and-errors/) about the error

```
error[E0210]: type parameter `T` must be covered by another type when it appears before the first local type
```

with code for causing this error, rational for coherence rules and code in `rustc` for checking the rules and generating the error (long!)