### PR TITLE
bump python Markdown package to version 3.3.7

### DIFF
--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,2 +1,2 @@
 beautifulsoup4==4.10.0
-Markdown==3.3.6
+Markdown==3.3.7


### PR DESCRIPTION
The version used to build the site was bumped in #3338, but the version used in CI was not.