### PR TITLE
Add AeroRust's "Space Conference - Plovdiv"

### DIFF
--- a/draft/2023-05-17-this-week-in-rust.md
+++ b/draft/2023-05-17-this-week-in-rust.md
@@ -205,9 +205,9 @@ Rusty Events between 2023-05-17 - 2023-06-14 🦀
 * 2023-05-30 | Barcelona, ES | [BcnRust](https://www.meetup.com/bcnrust/)
     * [**10th BcnRust Meetup**](https://www.meetup.com/bcnrust/events/293363107)
 * 2023-06-03 | Plovidv, BG | [AeroRust](https://aerorust.org)
-    * [**Space Conference - Plovdiv**](https://space-conference-plovdiv.eventbrite.com) (3rd of June)
-    * [**Nanosatellite embedded workshop**](https://forms.gle/rnFx5wCbrYA9qN7m6) (4th of June)
-
+    * [**Space Conference - Plovdiv**](https://space-conference-plovdiv.eventbrite.com)
+* 2023-06-04 | Plovidv, BG | [AeroRust](https://aerorust.org)
+    * [**Space Conference : Nanosatellite embedded workshop**](https://forms.gle/rnFx5wCbrYA9qN7m6)
 ### North America
 
 * 2023-05-11 | Lehi, UT, US | [Utah Rust](https://www.meetup.com/utah-rust/)

--- a/draft/2023-05-17-this-week-in-rust.md
+++ b/draft/2023-05-17-this-week-in-rust.md
@@ -204,6 +204,9 @@ Rusty Events between 2023-05-17 - 2023-06-14 🦀
     * [**Rust Paris meetup #59**](https://www.meetup.com/rust-paris/events/293191172)
 * 2023-05-30 | Barcelona, ES | [BcnRust](https://www.meetup.com/bcnrust/)
     * [**10th BcnRust Meetup**](https://www.meetup.com/bcnrust/events/293363107)
+* 2023-06-03 | Plovidv, BG | [AeroRust](https://aerorust.org)
+    * [**Space Conference - Plovdiv**](https://space-conference-plovdiv.eventbrite.com) (3rd of June)
+    * [**Nanosatellite embedded workshop**](https://forms.gle/rnFx5wCbrYA9qN7m6) (4th of June)
 
 ### North America
 


### PR DESCRIPTION
The conference will take place in Plovdiv, Bulgaria on 3rd and 4th of June. The first day will be the conference with exhibition while the second - Nanosatellite embedded workshop with Rust.

Thank you for considering our event for the newsletter!