### PR TITLE
Fix formatting in 2023-05-24-this-week-in-rust.md

### DIFF
--- a/draft/2023-05-24-this-week-in-rust.md
+++ b/draft/2023-05-24-this-week-in-rust.md
@@ -188,8 +188,8 @@ If you are a Rust project owner and are looking for contributors, please submit 
 
 ### Rust Compiler Performance Triage
 
-There were a few regressions, but most were expected, and one in particular (PR
-#111807) is expected yield gains in object code performance at the expense of a
+There were a few regressions, but most were expected, and one in particular
+(PR #111807) is expected yield gains in object code performance at the expense of a
 slight compile-time hit. There are a couple PR's that need future followup,
 namely PRs #111364 and #111524.
 


### PR DESCRIPTION
Due to an unfortunate line break location, a # character was placed in the first column, causing the line to be spuriously formatted as a headline.