### PR TITLE
add rumqttd in project updates

### DIFF
--- a/draft/2023-05-31-this-week-in-rust.md
+++ b/draft/2023-05-31-this-week-in-rust.md
@@ -34,6 +34,7 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
+* [rumqttd now supports MQTTv5 features like topic alias and message expiry](https://bytebeam.io/blog/one-step-closer-to-mqttv5-broker/)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
rumqttd, MQTT broker in Rust now supports MQTTv5 features like Topic Alias and Message Expiry. Thought this would be a cool to post project update in TWIR!

Please let me know if any changes are required, thanks.