### PR TITLE
Add link to blog post on Kani's usage on s2n-quic

### DIFF
--- a/draft/2023-05-31-this-week-in-rust.md
+++ b/draft/2023-05-31-this-week-in-rust.md
@@ -42,6 +42,7 @@ and just ask the editors to select the category.
 ### Research
 
 ### Miscellaneous
+* [How s2n-quic uses Kani to inspire confidence](https://model-checking.github.io/kani-verifier-blog/2023/05/30/how-s2n-quic-uses-kani-to-inspire-confidence.html)
 
 ## Crate of the Week
 


### PR DESCRIPTION
Adds the  [How s2n-quic uses Kani to inspire confidence](https://model-checking.github.io/kani-verifier-blog/2023/05/30/how-s2n-quic-uses-kani-to-inspire-confidence.html) blog post to the Miscellaneous section.