### PR TITLE
Video of talk: The status of parallel rustc by Nicholas Nethercote

### DIFF
--- a/draft/2023-06-07-this-week-in-rust.md
+++ b/draft/2023-06-07-this-week-in-rust.md
@@ -34,6 +34,7 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
+* [video] [The status of parallel rustc - Nicholas Nethercote](https://www.youtube.com/watch?v=q2vJ8Faundw)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
Video of Nick's talk at our RustNL 2023 conf, about status of parallel rustc.

PS The full conference video was already in TWiR a couple of weeks back, but this talk was not very visible that way, and I'm guessing that there is a lot of interest in this topic. We just published the individual videos on youtube last week.

