### PR TITLE
Add blog on why we rewrote Ockam in Rust

### DIFF
--- a/draft/2023-06-21-this-week-in-rust.md
+++ b/draft/2023-06-21-this-week-in-rust.md
@@ -37,6 +37,8 @@ and just ask the editors to select the category.
 
 ### Observations/Thoughts
 
+* [Rewriting Ockam in Rust](https://www.ockam.io/blog/rewriting_in_rust)
+
 ### Rust Walkthroughs
 
 ### Research


### PR DESCRIPTION
In [this article](https://www.ockam.io/blog/rewriting_in_rust) I shared Ockam's journey from C to Rust and the things that drove our choice. Hope you would consider including it in this week's newsletter.