### PR TITLE
Add missing links from draft problems

### DIFF
--- a/draft/2023-06-21-this-week-in-rust.md
+++ b/draft/2023-06-21-this-week-in-rust.md
@@ -39,6 +39,8 @@ and just ask the editors to select the category.
 * [rust-analyzer changelog #186](https://rust-analyzer.github.io/thisweek/2023/06/19/changelog-186.html)
 * [Tantivy 0.20: Schemaless](https://quickwit.io/blog/tantivy-0.20)
 * [lz4_flex 0.11: Gainzzzzz Unleashed!](https://flexineering.com/posts/lz4-011/)
+* [redb (Rust Embedded DataBase) 1.0 release](https://www.redb.org/post/2023/06/16/1-0-stable-release/)
+* [rust-libp2p v0.52.0: a modular p2p networking stack](https://github.com/libp2p/rust-libp2p/releases/tag/libp2p-v0.52.0)
 
 ### Observations/Thoughts
 * [How we built the Grafbase local development experience in Rust](https://grafbase.com/blog/how-we-built-the-grafbase-cli-in-rust)
@@ -50,9 +52,12 @@ and just ask the editors to select the category.
 
 ### Rust Walkthroughs
 
+* [API with Axum, SurrealDB, GraphQL - Template](https://radim.xyz/project/axum-template/)
+
 ### Research
 
 ### Miscellaneous
+* [Build a CLI Tool for Data Masking, Encryption, and Decryption With Rust](https://medium.com/better-programming/build-a-cli-tool-for-data-masking-encryption-and-decryption-with-rust-ad36bea27559)
 * [Santiago Pastorino: Maintainer Retention](https://yaah.dev/santiago-maintainer-retention)
 * [DE] [Programmiersprachen: Die Beliebtheit von Rust bleibt ungebrochen](https://www.heise.de/news/Programmiersprachen-Die-Beliebtheit-von-Rust-bleibt-ungebrochen-9187369.html)
 


### PR DESCRIPTION
Adding missing links that were submitted outside the normal process due to me forgetting to push the draft for this week live.