### PR TITLE
Add Link to Web-Based in Rust Workshop

### DIFF
--- a/draft/2023-05-10-this-week-in-rust.md
+++ b/draft/2023-05-10-this-week-in-rust.md
@@ -44,6 +44,7 @@ and just ask the editors to select the category.
 ### Research
 
 ### Miscellaneous
+* 2023-07-11 | Virtual | [Web-based Services in Rust, 3-day Workshop with Stefan Baumgartner - organized by Mainmatter](https://rust-web-services-workshop.mainmatter.com/)
 
 ## Crate of the Week
 


### PR DESCRIPTION
I am not sure if you promote (non-free) workshops, I haven't read anything about it in the ReadME. I have also added the link under "Miscellaneous" because I couldn't find a better category.