### PR TITLE
Add blogpost about Zellij WebAssembly Rust plugins

### DIFF
--- a/draft/2023-06-21-this-week-in-rust.md
+++ b/draft/2023-06-21-this-week-in-rust.md
@@ -44,6 +44,7 @@ and just ask the editors to select the category.
 * [rust-libp2p v0.52.0: a modular p2p networking stack](https://github.com/libp2p/rust-libp2p/releases/tag/libp2p-v0.52.0)
 * [`autometrics` 0.5 - Automatically connecting Prometheus metrics to traces with exemplars](https://fiberplane.com/blog/autometrics-rs-0-5-automatically-connecting-prometheus-metrics-to-traces)
 * [Introducing ducktor: Duck typed constructors for Rust structs with wasm-bindgen JsValue](https://mhamza.dev/blog/ducktor/)
+* [Build Zellij WebAssembly (Rust) plugins for your Terminal](https://zellij.dev/news/new-plugin-system/)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
Hey there,

We just overhauled our plugin system and are excited to invite Rust developers to develop terminal plugins with us. Would love to be included in the newsletter.

Thanks!