### PR TITLE
Add Kani VS Code extension blog post

### DIFF
--- a/draft/2023-07-05-this-week-in-rust.md
+++ b/draft/2023-07-05-this-week-in-rust.md
@@ -43,6 +43,8 @@ and just ask the editors to select the category.
 
 ### Miscellaneous
 
+* [Verify Rust code in VS Code with the Kani VS Code extension](https://model-checking.github.io/kani-verifier-blog/2023/06/30/introducing-the-kani-vscode-extension.html)
+
 ## Crate of the Week
 
 <!-- COTW goes here -->


### PR DESCRIPTION
Adds the [Verify Rust code in VS Code with the Kani VS Code extension](https://model-checking.github.io/kani-verifier-blog/2023/06/30/introducing-the-kani-vscode-extension.html) blog post to the "Rust Walkthroughs" section.