### PR TITLE
Self-nominate "Transition from Go to Rust" to 2023-08-02

### DIFF
--- a/draft/2023-08-02-this-week-in-rust.md
+++ b/draft/2023-08-02-this-week-in-rust.md
@@ -37,6 +37,8 @@ and just ask the editors to select the category.
 
 ### Observations/Thoughts
 
+[Rusk - The transition of our Node software from Golang to Rust](https://dusk.network/news/piecrust-and-our-transition-to-rust/)
+
 ### Rust Walkthroughs
 
 ### Research


### PR DESCRIPTION
Hey! 

I've added a new article to the 'Observations/Thoughts' section on the transition of Dusk's Node software, [Rusk](https://github.com/dusk-network/rusk), from Golang to Rust. I think it's particularly relevant as it provides a concrete example of a project choosing to move a large component of its existing Golang code base over to Rust.