### PR TITLE
add part 3 of series on understanding async/await in Rust

### DIFF
--- a/draft/2023-08-02-this-week-in-rust.md
+++ b/draft/2023-08-02-this-week-in-rust.md
@@ -38,6 +38,8 @@ and just ask the editors to select the category.
 ### Observations/Thoughts
 
 ### Rust Walkthroughs
+* [How I finally understood async/await in Rust (part 3: why shouldn’t I hold a mutex guard across an await point?)](https://hegdenu.net/posts/understanding-async-await-3/)
+
 
 ### Research
 


### PR DESCRIPTION
This part looks at what happens when you hold a mutex guard across an await point.

This Week in Rust is great. I never miss an issue!