### PR TITLE
Add kinded to the tooling and the blog post

### DIFF
--- a/draft/2023-08-09-this-week-in-rust.md
+++ b/draft/2023-08-09-this-week-in-rust.md
@@ -34,10 +34,12 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
+* [kinded](https://github.com/greyblake/kinded/) - generate enum variants without data
 
 ### Observations/Thoughts
 
 ### Rust Walkthroughs
+* [Handling Rust enum variants with kinded crate](https://www.greyblake.com/blog/handling-rust-enum-variants-with-kinded-crate/)
 
 ### Research
 


### PR DESCRIPTION
This PR adds 2 links:
* Tooling section: Announcement about [kinded](https://github.com/greyblake/kinded) crate
* Rust Walkthroughs section: blog post about kinded: https://www.greyblake.com/blog/handling-rust-enum-variants-with-kinded-crate/