### PR TITLE
Add Mastodon profile in base footer

### DIFF
--- a/themes/rusted/templates/base.html
+++ b/themes/rusted/templates/base.html
@@ -72,6 +72,7 @@
           <div class="col-sm-4 col-xs-12">
             <ul class="list-unstyled">
               <li><a href="https://twitter.com/ThisWeekInRust">twitter</a></li>
+              <li><a href="https://mastodon.social/@thisweekinrust">mastodon</a></li>
             </ul>
           </div>
           <div class="col-sm-4 col-xs-12 text-right custom-xs-text-left">


### PR DESCRIPTION
Like [someone else suggested on Reddit](https://www.reddit.com/r/rust/comments/15zpq03/this_week_in_rust_509/jxijn44/), add the Mastodon profile that is mentioned in newer issue bodies to the page footer aswell.