### PR TITLE
Add Kani feat. Firecracker blog post

### DIFF
--- a/draft/2023-09-06-this-week-in-rust.md
+++ b/draft/2023-09-06-this-week-in-rust.md
@@ -38,6 +38,7 @@ and just ask the editors to select the category.
 ### Observations/Thoughts
 
 ### Rust Walkthroughs
+* [Using Kani to Validate Security Boundaries in AWS Firecracker](https://model-checking.github.io/kani-verifier-blog/2023/08/31/using-kani-to-validate-security-boundaries-in-aws-firecracker.html)
 
 ### Research
 


### PR DESCRIPTION
Adds the [Using Kani to Validate Security Boundaries in AWS Firecracker](https://model-checking.github.io/kani-verifier-blog/2023/08/31/using-kani-to-validate-security-boundaries-in-aws-firecracker.html) blog post to the "Rust Walkthroughs" section.