### PR TITLE
Add new Meilisearch release link

### DIFF
--- a/draft/2023-09-27-this-week-in-rust.md
+++ b/draft/2023-09-27-this-week-in-rust.md
@@ -34,6 +34,7 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
+*[Meilisearch 1.4 - new features, including custom text separators, and user-definded dictionary](https://blog.meilisearch.com/v1-4-release/)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
Hello!

This PR adds a link to a release blog post highlighting new [Meilisearch](https://github.com/meilisearch/meilisearch) features.

The blog post itself contains a link to the exhaustive [changelog](https://github.com/meilisearch/meilisearch/releases/tag/v1.4.0).

Thanks for considering it!