### PR TITLE
Add Zenoh 0.10.0 release

### DIFF
--- a/draft/2023-10-04-this-week-in-rust.md
+++ b/draft/2023-10-04-this-week-in-rust.md
@@ -34,6 +34,7 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
+* [Zenoh 0.10.0,  a pure Rust Pub/Sub/Query protocol for cloud-to-thing continuum, was released and it is packed with new features.](https://zenoh.io/blog/2023-10-03-zenoh-dragonite/)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
Zenoh is a pure Rust Pub/Sub/Query/Reply protocol. The latest Zenoh 0.10.0 release has just been published. 
Changelog is accompanied by a dedicated blog post on the project's website: https://zenoh.io/blog/2023-10-03-zenoh-dragonite/

Previous PRs in *this week in rust* regarding Zenoh:
- https://github.com/rust-lang/this-week-in-rust/pull/3734
- https://github.com/rust-lang/this-week-in-rust/pull/3976