### PR TITLE
Add EtherCrab announcement post

### DIFF
--- a/draft/2023-10-18-this-week-in-rust.md
+++ b/draft/2023-10-18-this-week-in-rust.md
@@ -34,6 +34,7 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
+* [Announcing EtherCrab, a Rust implementation of the EtherCAT industrial automation protocol](https://wapl.es/announcing-ethercrab-the-rust-ethercat-controller/)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
This post announces [EtherCrab](https://crates.io/crates/ethercrab). Pretty sure I'm editing the right file!