### PR TITLE
Add link to cargo-dist deps blog post

### DIFF
--- a/draft/2023-10-25-this-week-in-rust.md
+++ b/draft/2023-10-25-this-week-in-rust.md
@@ -34,6 +34,7 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
+* [System dependencies are hard (so we made them easier)](https://blog.axo.dev/2023/10/dependencies)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
This adds a link to a [blog post](https://blog.axo.dev/2023/10/dependencies) I wrote on cargo-dist's new system dependencies and dynamic linkage integration features, with a writeup on the implementation.