### PR TITLE
Add "Can Rust prevent logic errors?" article to 2023-11-01

### DIFF
--- a/draft/2023-11-01-this-week-in-rust.md
+++ b/draft/2023-11-01-this-week-in-rust.md
@@ -37,6 +37,8 @@ and just ask the editors to select the category.
 
 ### Observations/Thoughts
 
+* [Can Rust prevent logic errors?](https://itsallaboutthebit.com/logic-errors-in-rust/)
+
 ### Rust Walkthroughs
 
 ### Research


### PR DESCRIPTION
This adds an article ["Can Rust prevent logic errors?"](https://itsallaboutthebit.com/logic-errors-in-rust/) to the Observations list.