### PR TITLE
Talks on RISC-V + compiler backends-from Rust meetup in Delft NL, Oct 26

### DIFF
--- a/draft/2023-11-08-this-week-in-rust.md
+++ b/draft/2023-11-08-this-week-in-rust.md
@@ -46,6 +46,8 @@ and just ask the editors to select the category.
 
 ### Miscellaneous
 * [Migrating SecureDrop’s PGP backend from GnuPG to Sequoia](https://securedrop.org/news/migrating-securedrops-pgp-backend-from-gnupg-to-sequoia/)
+* [video] [10x faster - taking charge of the compiler backend](https://www.youtube.com/watch?v=FCVfofYsWHU)
+* [video] [RISC-V Vector Extension in Rust](https://www.youtube.com/watch?v=jb5-P_r3jmw)
 
 ## Crate of the Week
 


### PR DESCRIPTION
Two talks from the https://github.com/rustnl meetup in Delft, NL:

- RISC-V Vector Extension in Rust
- Experiences from building a language and compiler in Rust, and translating those experiences an approach for future improvements to the Rust compiler back-end

