### PR TITLE
Add my crate `breadcrumbs` to project/tooling updates.

### DIFF
--- a/draft/2023-11-15-this-week-in-rust.md
+++ b/draft/2023-11-15-this-week-in-rust.md
@@ -35,6 +35,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+- [`breadcrumbs 0.1.4`](https://crates.io/crates/breadcrumbs) released - now the smallest logging library on crates.io, supporting `#[no_std]` and concurrency.
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
Hi!

I would like to add my new (and first) crate [`breadcrumbs`](https://crates.io/crates/breadcrumbs) to the `Project/Tooling Updates` if that is ok?

Thank you for making This Week in Rust!