### PR TITLE
Add `Cargo Lambda 1.0.0` release to project/tooling updates

### DIFF
--- a/draft/2023-11-15-this-week-in-rust.md
+++ b/draft/2023-11-15-this-week-in-rust.md
@@ -35,7 +35,7 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
-- [Cargo Lambda 1.0.0](https://cargo-lambda.into) released - includes support for Amazon Linux 2023 on AWS Lambda, SSO, and more release optimizations.
+- [Cargo Lambda 1.0.0](https://cargo-lambda.info/) released - includes support for Amazon Linux 2023 on AWS Lambda, SSO, and more release optimizations.
 
 ### Observations/Thoughts
 

--- a/draft/2023-11-15-this-week-in-rust.md
+++ b/draft/2023-11-15-this-week-in-rust.md
@@ -35,7 +35,7 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
-- [Cargo Lambda 1.0.0](https://cargo-lambda.info/) released - includes support for Amazon Linux 2023 on AWS Lambda, SSO, and more release optimizations.
+* [Cargo Lambda 1.0.0](https://cargo-lambda.info/) released - includes support for Amazon Linux 2023 on AWS Lambda, SSO, and more release optimizations.
 
 ### Observations/Thoughts
 

--- a/draft/2023-11-15-this-week-in-rust.md
+++ b/draft/2023-11-15-this-week-in-rust.md
@@ -35,6 +35,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+- [Cargo Lambda 1.0.0](https://cargo-lambda.into) released - includes support for Amazon Linux 2023 on AWS Lambda, SSO, and more release optimizations.
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
Hi,

I just released the first major version of [Cargo Lambda](https://www.cargo-lambda.info/), and I'd like to add this highlight to the newsletter.

Let me know if the entry makes sense.