### PR TITLE
Add "Checking semver in the presence of doc(hidden) items" blog post.

### DIFF
--- a/draft/2023-11-22-this-week-in-rust.md
+++ b/draft/2023-11-22-this-week-in-rust.md
@@ -36,6 +36,7 @@ and just ask the editors to select the category.
 ### Project/Tooling Updates
 
 ### Observations/Thoughts
+- [Checking semver in the presence of doc(hidden) items](https://predr.ag/blog/checking-semver-for-doc-hidden-items/)
 
 ### Rust Walkthroughs
 


### PR DESCRIPTION
This post explains how the headline feature (correct `doc(hidden)` handling) of the newly-released cargo-semver-checks v0.25 works under the hood.

Thanks for running TWiR! ♥