### PR TITLE
feat: Add cargo-run-bin blog post

### DIFF
--- a/draft/2023-11-29-this-week-in-rust.md
+++ b/draft/2023-11-29-this-week-in-rust.md
@@ -35,7 +35,7 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
-- [cargo-run-bin: Why does everyone install crates globally?](https://dustinblackman.com/posts/why-does-everyone-install-crates-globally/)
+* [cargo-run-bin: Why does everyone install crates globally?](https://dustinblackman.com/posts/why-does-everyone-install-crates-globally/)
 
 ### Observations/Thoughts
 

--- a/draft/2023-11-29-this-week-in-rust.md
+++ b/draft/2023-11-29-this-week-in-rust.md
@@ -35,6 +35,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+- [cargo-run-bin: Why does everyone install crates globally?](https://dustinblackman.com/posts/why-does-everyone-install-crates-globally/)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
## Overview

Adds a project blog post introducing [cargo-run-bin](https://github.com/dustinblackman/cargo-run-bin). Build, cache, and run CLI tools scoped in Cargo.toml rather than installing globally.