### PR TITLE
Added Trippy 0.9.0 release

### DIFF
--- a/draft/2023-12-06-this-week-in-rust.md
+++ b/draft/2023-12-06-this-week-in-rust.md
@@ -35,6 +35,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [Trippy (Network diagnostic tool) - 0.9.0 release](https://github.com/fujiapple852/trippy/releases/tag/0.9.0)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
Following on from the `0.8.0` release announcement in May (#4368), added a link to the [release note](https://github.com/fujiapple852/trippy/releases/tag/0.9.0) for Trippy `0.9.0`.  Thanks!