### PR TITLE
Rust for Linux LWN articles

### DIFF
--- a/draft/2023-12-20-this-week-in-rust.md
+++ b/draft/2023-12-20-this-week-in-rust.md
@@ -34,6 +34,10 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
+* [Committing to Rust for kernel code](https://lwn.net/Articles/952029/)
+* [A Rust implementation of Android's Binder](https://lwn.net/Articles/953116/)
+* [Preventing atomic-context violations in Rust code with klint](https://lwn.net/Articles/951550/)
+* [Rust for Linux — in space](https://lwn.net/Articles/954974/)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
The first 3 are recent articles from the Rust MC at LPC and the Kernel Maintainers Summit, all freely available now.

The last one is not a full article, but it still seems worth it.

Fixes https://github.com/rust-lang/this-week-in-rust/issues/4956.