### PR TITLE
Add `static mut` survey to 527

### DIFF
--- a/draft/2023-12-27-this-week-in-rust.md
+++ b/draft/2023-12-27-this-week-in-rust.md
@@ -42,7 +42,7 @@ and just ask the editors to select the category.
 ### Research
 
 ### Miscellaneous
-* [An anonymous survey about mutable statics](https://www.surveyhero.com/c/static-mut)
+* [an anonymous survey about mutable statics](https://www.surveyhero.com/c/static-mut)
 
 ## Crate of the Week
 

--- a/draft/2023-12-27-this-week-in-rust.md
+++ b/draft/2023-12-27-this-week-in-rust.md
@@ -42,6 +42,7 @@ and just ask the editors to select the category.
 ### Research
 
 ### Miscellaneous
+* [An anonymous survey about mutable statics](https://www.surveyhero.com/c/static-mut)
 
 ## Crate of the Week
 

--- a/draft/2023-12-27-this-week-in-rust.md
+++ b/draft/2023-12-27-this-week-in-rust.md
@@ -42,7 +42,7 @@ and just ask the editors to select the category.
 ### Research
 
 ### Miscellaneous
-* [an anonymous survey about mutable statics](https://www.surveyhero.com/c/static-mut)
+* [An anonymous survey about mutable statics](https://www.surveyhero.com/c/static-mut)
 
 ## Crate of the Week
 


### PR DESCRIPTION
I created a survey to go with my proposal on IRLO [Pre-RFC: Deprecate then remove `static mut`](https://internals.rust-lang.org/t/pre-rfc-deprecate-then-remove-static-mut/20072), and I'd like to add it to TWiR to get it some more exposure. The survey is entirely anonymous as guaranteed by SurveyHero: "we will hide email address, IP address, link parameters, meta data and any other piece of information that might allow you to identify a participant".