### PR TITLE
Add Meilisearch 1.6 release

### DIFF
--- a/draft/2024-01-17-this-week-in-rust.md
+++ b/draft/2024-01-17-this-week-in-rust.md
@@ -34,6 +34,7 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
+[Meilisearch 1.6 - AI search & 2x faster indexing](https://blog.meilisearch.com/meilisearch-1-6/)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
Hello!
 
This PR adds a link to a release blog post highlighting new [Meilisearch](https://github.com/meilisearch/meilisearch) features.

The blog post itself contains a link to the exhaustive [changelog](https://github.com/meilisearch/meilisearch/releases/tag/v1.6.0)
 
Thanks for considering it!
