### PR TITLE
Add Kani blog post on function contracts

### DIFF
--- a/draft/2024-01-31-this-week-in-rust.md
+++ b/draft/2024-01-31-this-week-in-rust.md
@@ -34,6 +34,7 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
+ * [Function Contracts for Kani](https://model-checking.github.io/kani-verifier-blog/2024/01/29/function-contracts.html)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
Adds the [Function Contracts for Kani](https://model-checking.github.io/kani-verifier-blog/2024/01/29/function-contracts.html) post from the Kani blog to the "Project/Tooling Updates" section.

Happy to move it anywhere else you consider more appropriate. Thanks!

