### PR TITLE
Add January 2024 Rust Jobs Report

### DIFF
--- a/draft/2024-02-14-this-week-in-rust.md
+++ b/draft/2024-02-14-this-week-in-rust.md
@@ -42,6 +42,7 @@ and just ask the editors to select the category.
 ### Research
 
 ### Miscellaneous
+* [January 2024 Rust Jobs Report](https://filtra.io/rust-jan-24)
 
 ## Crate of the Week
 


### PR DESCRIPTION
Just adding a link to the January 2024 Rust Jobs Report. I'm not sure if Miscellaneous is the right section, so please move it as needed!