### PR TITLE
Remove AA's case study from TWIR#533

### DIFF
--- a/content/2024-02-07-this-week-in-rust.md
+++ b/content/2024-02-07-this-week-in-rust.md
@@ -65,7 +65,6 @@ and just ask the editors to select the category.
 
 ### Miscellaneous
 * [RustFest 2024 Announcement](https://rustfest.ch/posts/2024-02-01/announcement/)
-* [Preprocessing trillions of tokens with Rust (case study)](https://mainmatter.com/cases/aleph-alpha/)
 * [All EuroRust 2023 talks ordered by the view count](https://techtalksweekly.substack.com/p/all-eurorust-2023-talks-ordered-by)
 
 ## Crate of the Week


### PR DESCRIPTION
Hey!
AA asked us to review some of the wording in the case study, therefore we've (temporarily) taken it down and the link now redirects to Mainmatter's Rust homepage.
Since it'd be inappropriate to have a link to Mainmatter's homepage on Twir, I've opened this PR to take it out entirely. If there's a better course of action, let me know!

Sorry again for the inconvenience.