### PR TITLE
add Devoxx PL 2024

### DIFF
--- a/draft/2024-02-14-this-week-in-rust.md
+++ b/draft/2024-02-14-this-week-in-rust.md
@@ -71,10 +71,14 @@ If you are a Rust project owner and are looking for contributors, please submit 
 
 Are you a new or experienced speaker looking for a place to share something cool? This section highlights events that are being planned and are accepting submissions to join their event as a speaker. 
 
+
 <!-- CFPs go here, use this format: * [**event name**](link to CFP)| Date CFP closes in YYYY-MM-DD | city,state,country | Date of event in YYYY-MM-DD -->
 <!-- or if none - *No Calls for papers or presentations were submitted this week.* -->
 
+* [**Devoxx PL 2024**](https://devoxxpl24.cfp.dev/) | CFP closes 2024-03-01 | Krakow, Poland | Date of event 2024-06-19 - 2024-06-21
+
 If you are an event organizer hoping to expand the reach of your event, please submit a link to the submission website through a [PR to TWiR](https://github.com/rust-lang/this-week-in-rust).
+
 
 ## Updates from the Rust Project
 


### PR DESCRIPTION
Added CFP for [Devoxx PL ](https://devoxx.pl/). I'm a member of a program comitee and although Devoxx PL is not a Rust conference - we are focused on Java and programming in general - but I'm interested in pulling more Rust content.