### PR TITLE
Add Rust FFI in Go blog post

### DIFF
--- a/draft/2024-02-14-this-week-in-rust.md
+++ b/draft/2024-02-14-this-week-in-rust.md
@@ -39,6 +39,8 @@ and just ask the editors to select the category.
 
 ### Rust Walkthroughs
 
+* [Calling Rust FFI libraries from Go](https://blog.arcjet.com/calling-rust-ffi-libraries-from-go/)
+
 ### Research
 
 ### Miscellaneous


### PR DESCRIPTION
Adds https://blog.arcjet.com/calling-rust-ffi-libraries-from-go/