### PR TITLE
Revert "Remove AA's case study from TWIR#533"

### DIFF
--- a/content/2024-02-07-this-week-in-rust.md
+++ b/content/2024-02-07-this-week-in-rust.md
@@ -65,6 +65,7 @@ and just ask the editors to select the category.
 
 ### Miscellaneous
 * [RustFest 2024 Announcement](https://rustfest.ch/posts/2024-02-01/announcement/)
+* [Preprocessing trillions of tokens with Rust (case study)](https://mainmatter.com/cases/aleph-alpha/)
 * [All EuroRust 2023 talks ordered by the view count](https://techtalksweekly.substack.com/p/all-eurorust-2023-talks-ordered-by)
 
 ## Crate of the Week


### PR DESCRIPTION
Reverts rust-lang/this-week-in-rust#5163

The case study is now back online: https://mainmatter.com/cases/aleph-alpha/

Sorry again for the back-and-forth!