### PR TITLE
Added link to Timeplus Proton project announcing its Rust client.

### DIFF
--- a/draft/2024-02-21-this-week-in-rust.md
+++ b/draft/2024-02-21-this-week-in-rust.md
@@ -35,8 +35,7 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
-[Rust Client for Timeplus Proton SQL Streaming](https://www.timeplus.com/post/rust-client-for-proton?utm_source=rustnewsletter&utm_medium=referral&utm_campaign=rustclient)
-
+[Rust Client for Timeplus Proton SQL Streaming](https://www.timeplus.com/post/rust-client-for-proton)
 
 ### Observations/Thoughts
 

--- a/draft/2024-02-21-this-week-in-rust.md
+++ b/draft/2024-02-21-this-week-in-rust.md
@@ -35,6 +35,9 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+[Rust Client for Timeplus Proton SQL Streaming](https://www.timeplus.com/post/rust-client-for-proton?utm_source=rustnewsletter&utm_medium=referral&utm_campaign=rustclient)
+
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION

In the project section, I added a link to Timeplus Proton project announcing its Rust client.

I hope that is the right category. If not, please let me know and I change it.

Thank you
 