### PR TITLE
adding a blog post article: Practical guide to Error Handling in Rust

### DIFF
--- a/draft/2024-02-28-this-week-in-rust.md
+++ b/draft/2024-02-28-this-week-in-rust.md
@@ -39,6 +39,8 @@ and just ask the editors to select the category.
 
 ### Rust Walkthroughs
 
+* [Practical guide to Error Handling in Rust](https://dev-state.com/posts/error_handling/)
+
 ### Research
 
 ### Miscellaneous


### PR DESCRIPTION
I'm adding my recent blog post about Error handling in Rust: https://dev-state.com/posts/error_handling/.
If you find it useful, I would be honored to have it listed in your next newsletter issue.
