### PR TITLE
Add Space Acres open issues to the 2024-03-06-this-week-in-rust

### DIFF
--- a/draft/2024-03-06-this-week-in-rust.md
+++ b/draft/2024-03-06-this-week-in-rust.md
@@ -1,0 +1,187 @@
+Title: This Week in Rust 537
+Number: 537
+Date: 2024-03-06
+Category: This Week in Rust
+
+Hello and welcome to another issue of *This Week in Rust*!
+[Rust](https://www.rust-lang.org/) is a programming language empowering everyone to build reliable and efficient software.
+This is a weekly summary of its progress and community.
+Want something mentioned? Tag us at [@ThisWeekInRust](https://twitter.com/ThisWeekInRust) on Twitter or [@ThisWeekinRust](https://mastodon.social/@thisweekinrust) on mastodon.social, or [send us a pull request](https://github.com/rust-lang/this-week-in-rust).
+Want to get involved? [We love contributions](https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md).
+
+*This Week in Rust* is openly developed [on GitHub](https://github.com/rust-lang/this-week-in-rust) and archives can be viewed at [this-week-in-rust.org](https://this-week-in-rust.org/).
+If you find any errors in this week's issue, [please submit a PR](https://github.com/rust-lang/this-week-in-rust/pulls).
+
+## Updates from Rust Community
+
+<!--
+
+Dear community contributors:
+Please read README.md for guidance on submissions.
+Each submitted link should be of the form:
+
+* [Title of the Linked Page](https://example.com/my_article)
+
+If you don't know which category to use, feel free to submit a PR anyway
+and just ask the editors to select the category.
+
+-->
+
+### Official
+
+### Foundation
+
+### Newsletters
+
+### Project/Tooling Updates
+
+### Observations/Thoughts
+
+### Rust Walkthroughs
+
+### Research
+
+### Miscellaneous
+
+## Crate of the Week
+
+<!-- COTW goes here -->
+
+[Please submit your suggestions and votes for next week][submit_crate]!
+
+[submit_crate]: https://users.rust-lang.org/t/crate-of-the-week/2704
+
+## [Call for Testing](https://github.com/rust-lang/rfcs/issues?q=label%3Acall-for-testing)
+An important step for RFC implementation is for people to experiment with the
+implementation and give feedback, especially before stabilization.  The following
+RFCs would benefit from user testing before moving forward:
+
+<!-- Calls for Testing go here, use this format:
+    * [<RFC Topic>](<RFC URL>)
+        * [Tracking Issue](<Tracking Issue URL>)
+        * [Testing steps](<Testing Steps URL>)
+-->
+<!-- or if there are no new or updated RFCs this week, use: * *No New or Updated RFCs were created this week.* -->
+<!-- Remember to remove the `call-for-testing` label from the RFC so that the maintainer can signal for testers again, if desired. -->
+
+If you are a feature implementer and would like your RFC to appear on the above list, add the new `call-for-testing`
+label to your RFC along with a comment providing testing instructions and/or guidance on which aspect(s) of the feature
+need testing.
+
+## Call for Participation; projects and speakers
+
+### CFP - Projects
+
+Always wanted to contribute to open-source projects but did not know where to start?
+Every week we highlight some tasks from the Rust community for you to pick and get started!
+
+Some of these tasks may also have mentors available, visit the task page for more information.
+
+<!-- CFPs go here, use this format: * [project name - title of issue](link to issue) -->
+<!-- * [ - ]() -->
+
+* [ Space Acres by Subspace - [8 different issues with USDC rewards for contributors] ranging from UX improvements to tray support and MacOS packaging](https://github.com/orgs/subspace/projects/26/views/1?filterQuery=usdc)
+
+
+If you are a Rust project owner and are looking for contributors, please submit tasks [here][guidelines].
+
+[guidelines]: https://users.rust-lang.org/t/twir-call-for-participation/4821
+
+### CFP - Speakers
+
+Are you a new or experienced speaker looking for a place to share something cool? This section highlights events that are being planned and are accepting submissions to join their event as a speaker.
+
+<!-- CFPs go here, use this format: * [**event name**](link to CFP)| Date CFP closes in YYYY-MM-DD | city,state,country | Date of event in YYYY-MM-DD -->
+<!-- or if none - *No Calls for papers or presentations were submitted this week.* -->
+
+If you are an event organizer hoping to expand the reach of your event, please submit a link to the submission website through a [PR to TWiR](https://github.com/rust-lang/this-week-in-rust).
+
+## Updates from the Rust Project
+
+<!-- Rust updates go here -->
+
+### Rust Compiler Performance Triage
+
+<!-- Perf results go here -->
+
+### [Approved RFCs](https://github.com/rust-lang/rfcs/commits/master)
+
+Changes to Rust follow the Rust [RFC (request for comments) process](https://github.com/rust-lang/rfcs#rust-rfcs). These
+are the RFCs that were approved for implementation this week:
+
+<!-- Approved RFCs go here, use this format: * [Topic](URL) -->
+<!-- or if none were approved this week, use: * *No RFCs were approved this week.* -->
+<!-- * []() -->
+
+<!--
+### [Approved Major Change Proposals (MCP)](https://forge.rust-lang.org/compiler/mcp.html)
+<!~~ MCPs occur infrequently, so this section is commented out by default. ~~>
+<!~~ MCPs which have been approved or rejected this week go here, use this format: * [major change accepted|rejected] [Topic](URL) ~~>
+-->
+
+### Final Comment Period
+
+Every week, [the team](https://www.rust-lang.org/team.html) announces the 'final comment period' for RFCs and key PRs
+which are reaching a decision. Express your opinions now.
+
+#### [RFCs](https://github.com/rust-lang/rfcs/labels/final-comment-period)
+
+<!-- RFCs which have entered FCP go here, use this format: * [disposition: merge|close] [Topic](URL) -->
+<!-- or if none entered FCP this week, use: * *No RFCs entered Final Comment Period this week.* -->
+<!-- * [disposition: ] []() -->
+
+#### [Tracking Issues & PRs](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Afinal-comment-period+sort%3Aupdated-desc)
+
+<!-- Tracking Issues which have entered FCP go here, use this format: * [disposition: merge|close] [Topic](URL) -->
+<!-- or if none entered FCP this week, use: * *No Tracking Issues or PRs entered Final Comment Period this week.* -->
+<!-- * [disposition: ] []() -->
+
+### [Language Reference](https://github.com/rust-lang/reference/issues?q=is%3Aopen+label%3Afinal-comment-period+sort%3Aupdated-desc)
+<!-- Remove this section if empty>
+
+### [Unsafe Code Guidelines](https://github.com/rust-lang/unsafe-code-guidelines/issues?q=is%3Aopen+label%3Afinal-comment-period+sort%3Aupdated-desc)
+<!-- Remove this section if empty>
+
+### [New and Updated RFCs](https://github.com/rust-lang/rfcs/pulls)
+
+<!-- New or updated RFCs go here, use this format: * [new|updated] [Topic](URL) -->
+<!-- or if there are no new or updated RFCs this week, use: * *No New or Updated RFCs were created this week.* -->
+<!-- * [new|updated] []() -->
+
+## Upcoming Events
+
+Rusty Events between $twir_issue_date - $twir_events_end_date 🦀
+
+$twir_events_list
+
+If you are running a Rust event please add it to the [calendar] to get
+it mentioned here. Please remember to add a link to the event too.
+Email the [Rust Community Team][community] for access.
+
+[calendar]: https://www.google.com/calendar/embed?src=apd9vmbc22egenmtu5l6c5jbfc%40group.calendar.google.com
+[community]: mailto:community-team@rust-lang.org
+
+## Jobs
+<!--
+
+Rust Jobs:
+
+TWiR has stopped featuring individual job postings. You can read more about this change here:
+
+https://github.com/rust-lang/this-week-in-rust/issues/3412
+
+-->
+
+Please see the latest [Who's Hiring thread on r/rust](INSERT_LINK_HERE)
+
+# Quote of the Week
+
+<!-- QOTW goes here -->
+
+[Please submit quotes and vote for next week!](https://users.rust-lang.org/t/twir-quote-of-the-week/328)
+
+*This Week in Rust is edited by: [nellshamrell](https://github.com/nellshamrell), [llogiq](https://github.com/llogiq), [cdmistman](https://github.com/cdmistman), [ericseppanen](https://github.com/ericseppanen), [extrawurst](https://github.com/extrawurst), [andrewpollack](https://github.com/andrewpollack), [U007D](https://github.com/U007D), [kolharsam](https://github.com/kolharsam), [joelmarcey](https://github.com/joelmarcey), [mariannegoldin](https://github.com/mariannegoldin), [bennyvasquez](https://github.com/bennyvasquez).*
+
+*Email list hosting is sponsored by [The Rust Foundation](https://foundation.rust-lang.org/)*
+
+<small>[Discuss on r/rust](REDDIT_LINK_HERE)</small>


### PR DESCRIPTION
The only relevant line in the proposed changes is 83. 

Please include our issues (we currently have 8 issues, but be adding a few more). We also offer a USDC prize for the merged contributions! Thanks!