### PR TITLE
Add Czech Rust community index

### DIFF
--- a/draft/2024-03-06-this-week-in-rust.md
+++ b/draft/2024-03-06-this-week-in-rust.md
@@ -43,6 +43,8 @@ and just ask the editors to select the category.
 
 ### Miscellaneous
 
+* [Czech Rust community index](https://rustlang.cz/)
+
 ## Crate of the Week
 
 <!-- COTW goes here -->


### PR DESCRIPTION
I created an index page for Rust community events happening in my country (the Czech Republic).

I'm not sure if such a link is a good fit for TWiR (or if it should perhaps be added to a different section of the newsletter?). Let me know.