### PR TITLE
Add RustFest CfP again

### DIFF
--- a/draft/2024-03-13-this-week-in-rust.md
+++ b/draft/2024-03-13-this-week-in-rust.md
@@ -89,6 +89,7 @@ If you are a Rust project owner and are looking for contributors, please submit 
 Are you a new or experienced speaker looking for a place to share something cool? This section highlights events that are being planned and are accepting submissions to join their event as a speaker.
 
 <!-- CFPs go here, use this format: * [**event name**](link to CFP)| Date CFP closes in YYYY-MM-DD | city,state,country | Date of event in YYYY-MM-DD -->
+* [RustFest Zürich 2024](https://rustfest.ch/cfp/) CFP open - closes 2024-03-31 | Zürich, Switzerland | Event date: 2024-06-19 - 2024-06-24
 <!-- or if none - *No Calls for papers or presentations were submitted this week.* -->
 
 If you are an event organizer hoping to expand the reach of your event, please submit a link to the submission website through a [PR to TWiR](https://github.com/rust-lang/this-week-in-rust).


### PR DESCRIPTION
Hi all

Do we have to add the CfP  to every TWiR until the CfP is closed?
Or could we have it included for the next few?

Cheers,
Stefan
