### PR TITLE
add CFP projects entries for the rama (proxy) project

### DIFF
--- a/draft/2024-03-20-this-week-in-rust.md
+++ b/draft/2024-03-20-this-week-in-rust.md
@@ -79,6 +79,11 @@ Some of these tasks may also have mentors available, visit the task page for mor
 
 <!-- CFPs go here, use this format: * [project name - title of issue](link to issue) -->
 <!-- * [ - ]() -->
+* [Rama — add Form support (IntroResponse + FromRequest)](https://github.com/plabayo/rama/issues/68)
+* [Rama — rename \*Filter matchers to \*Matcher](https://github.com/plabayo/rama/issues/91)
+* [Rama — Provide support for boxed custom matchers in layer enums](https://github.com/plabayo/rama/issues/92)
+* [Rama — use workspace dependencies for common workspace dep versionning](https://github.com/plabayo/rama/issues/89)
+* [Rama — add open-telemetry middleware and extended prometheus support](https://github.com/plabayo/rama/issues/23)
 
 If you are a Rust project owner and are looking for contributors, please submit tasks [here][guidelines].
 


### PR DESCRIPTION
Now that [Rama](https://github.com/plabayo/rama)'s design is more or less settled, I am working hard towards a first useable release (v0.2). As part of this effort I am also making lower prior issues available for other people to pick up. I am available as a mentor, guide and reviewer.

Available over [email](mailto:glen@plabayo.tech), [Discord](https://discord.gg/29EetaSYCD) and GitHub.