### PR TITLE
Add `What part of Rust compilation is the bottleneck` blog post

### DIFF
--- a/draft/2024-03-20-this-week-in-rust.md
+++ b/draft/2024-03-20-this-week-in-rust.md
@@ -37,6 +37,8 @@ and just ask the editors to select the category.
 
 ### Observations/Thoughts
 
+* [What part of Rust compilation is the bottleneck?](https://kobzol.github.io/rust/rustc/2024/03/15/rustc-what-takes-so-long.html)
+
 ### Rust Walkthroughs
 
 ### Research


### PR DESCRIPTION
Self-nomination for my [blog post](https://kobzol.github.io/rust/rustc/2024/03/15/rustc-what-takes-so-long.html).