### PR TITLE
Add `yaml-rust2`: a successor to the unmaintained `yaml-rust`

### DIFF
--- a/draft/2024-03-20-this-week-in-rust.md
+++ b/draft/2024-03-20-this-week-in-rust.md
@@ -34,7 +34,7 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
-* [`yaml-rust2`: A successor to the unmaintained `yaml-rust`](https://github.com/Ethiraric/yaml-rust2/blob/master/documents/2024-03-15-FirstRelease.md)
+* [`yaml-rust2`: A successor to `yaml-rust`](https://github.com/Ethiraric/yaml-rust2/blob/master/documents/2024-03-15-FirstRelease.md)
 
 ### Observations/Thoughts
 

--- a/draft/2024-03-20-this-week-in-rust.md
+++ b/draft/2024-03-20-this-week-in-rust.md
@@ -34,6 +34,7 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
+* [`yaml-rust2`: A successor to the unmaintained `yaml-rust`](https://github.com/Ethiraric/yaml-rust2/blob/master/documents/2024-03-15-FirstRelease.md)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
Here is the link : https://github.com/Ethiraric/yaml-rust2/blob/master/documents/2024-03-15-FirstRelease.md

Do feel free to offer suggestion on the contents, if you think that could be improved.