### PR TITLE
Add blog post version of "SemVer in Rust: Tooling, Breakage, and Edge Cases" talk

### DIFF
--- a/draft/2024-03-20-this-week-in-rust.md
+++ b/draft/2024-03-20-this-week-in-rust.md
@@ -37,6 +37,8 @@ and just ask the editors to select the category.
 
 ### Observations/Thoughts
 
+- [SemVer in Rust: Breakage, Tooling, and Edge Cases — FOSDEM 2024 annotated talk](https://predr.ag/blog/semver-in-rust-tooling-breakage-and-edge-cases/)
+
 ### Rust Walkthroughs
 
 ### Research


### PR DESCRIPTION
Some folks prefer written content instead of video, so over the weekend I wrote up my FOSDEM 2024 talk as a blog post. This allowed me to include some additional content that wasn't part of the talk — for example, some recent information from the weeks after I gave the talk.

The YouTube link with the talk video was in last week's TWiR, so to disambiguate this link whose title is similar, I appended "annotated talk" which is the term for this coined by [Simon Willison](https://twitter.com/simonw). If you feel there's a better way to disambiguate, I'd be happy to edit this or have you edit it as you see fit.

Thanks for maintaining This Week in Rust!