### PR TITLE
Add Rustacean Station episode on cargo-semver-checks

### DIFF
--- a/draft/2024-04-03-this-week-in-rust.md
+++ b/draft/2024-04-03-this-week-in-rust.md
@@ -36,6 +36,7 @@ and just ask the editors to select the category.
 ### Project/Tooling Updates
 
 ### Observations/Thoughts
+- [audio] [cargo-semver-checks with Predrag Gruevski — Rustacean Station](https://rustacean-station.org/episode/predrag-gruevski/)
 
 ### Rust Walkthroughs
 

--- a/draft/2024-04-03-this-week-in-rust.md
+++ b/draft/2024-04-03-this-week-in-rust.md
@@ -36,7 +36,7 @@ and just ask the editors to select the category.
 ### Project/Tooling Updates
 
 ### Observations/Thoughts
-- [audio] [cargo-semver-checks with Predrag Gruevski — Rustacean Station](https://rustacean-station.org/episode/predrag-gruevski/)
+* [podcast] [cargo-semver-checks with Predrag Gruevski — Rustacean Station](https://rustacean-station.org/episode/predrag-gruevski/)
 
 ### Rust Walkthroughs
 


### PR DESCRIPTION
I wasn't sure what the accepted format for podcast episodes is, like whether the podcast name goes in the entry or only the episode name.

I gave it a shot based on what I felt I might like to see as a reader, but I of course wouldn't mind if any TWiR editors have different preferences and make a change.

Thanks for maintaining TWiR! ♥