### PR TITLE
Add Observations/Thoughts link that should have been in 541

### DIFF
--- a/draft/2024-04-10-this-week-in-rust.md
+++ b/draft/2024-04-10-this-week-in-rust.md
@@ -36,6 +36,7 @@ and just ask the editors to select the category.
 ### Project/Tooling Updates
 
 ### Observations/Thoughts
+* [Leaky Abstractions and a Rusty Pin](https://medium.com/itnext/leaky-abstractions-and-a-rusty-pin-fbf3b84eea1f)
 
 ### Rust Walkthroughs
 


### PR DESCRIPTION
The link from PR #5355 was dropped in a merge rebase. This PR adds it back in for TWIR 542. 