### PR TITLE
Events rustnl gosim

### DIFF
--- a/draft/2024-04-10-this-week-in-rust.md
+++ b/draft/2024-04-10-this-week-in-rust.md
@@ -221,6 +221,9 @@ Rusty Events between 2024-04-10 - 2024-05-08 🦀
     * [**Fullstack Rust - Workshop #2**](https://www.meetup.com/rust-basel/events/299933581/)
 * 2024-05-06 | Delft, NL | [GOSIM](https://www.gosim.org/)
     * [**GOSIM Europe 2024**](https://europe2024.gosim.org/)
+* 2024-05-07 & 2024-05-08 | Delft, NL | [RustNL](https://rustnl.org/)
+    * [**RustNL 2024**](https://2024.rustnl.org/)
+
 
 ### North America
 

--- a/draft/2024-04-10-this-week-in-rust.md
+++ b/draft/2024-04-10-this-week-in-rust.md
@@ -219,6 +219,8 @@ Rusty Events between 2024-04-10 - 2024-05-08 🦀
     * [**Rust and Tell**](https://www.meetup.com/rust-berlin/events/299288960/)
 * 2024-04-27 | Basel, CH | [Rust Basel](https://www.meetup.com/rust-basel/)
     * [**Fullstack Rust - Workshop #2**](https://www.meetup.com/rust-basel/events/299933581/)
+* 2024-05-06 | Delft, NL | [GOSIM](https://www.gosim.org/)
+    * [**GOSIM Europe 2024**](https://europe2024.gosim.org/)
 
 ### North America
 


### PR DESCRIPTION
This adds the RustNL 2024 and the co-located GOSIM 2024 events in Delft, NL from May 6 to May 8.

Info on GOSIM: the GOSIM event is an open-source conference; not a purely Rust event, but the majority of the talks are. 

Talks include:

- Dioxus - UI framework
- Dora-rs - robotic applications
- Moxin - pure Rust explorer for open source LLMs
- Wrapping Cargo for Shipping
- Servo
- Leptos-rs
- Palpus - Open-Sourced Rust Matrix Server

And a bunch more. Speakers see https://europe2024.gosim.org/speakers#app&web (3 tabs for the 3 tracks)