### PR TITLE
Fix dupe link in TWIR 542 to make pipeline green

### DIFF
--- a/draft/2024-04-10-this-week-in-rust.md
+++ b/draft/2024-04-10-this-week-in-rust.md
@@ -92,9 +92,6 @@ and just ask the editors to select the category.
 * [Rust Meetup and user groups (updated)](https://rust.code-maven.com/user-groups)
 * [Embedding the Servo Web Engine in Qt](https://www.kdab.com/embedding-servo-in-qt/)
 * [A memory model for Rust code in the kernel](https://lwn.net/SubscriberLink/967049/0ffb9b9ed8940013/)
-
-* [Embedding the Servo Web Engine in Qt](https://www.kdab.com/embedding-servo-in-qt/)
-
 * [Ratatui Received Funding: What's Next?](https://blog.orhun.dev/open-source-funding-with-ratatui/)
 
 ## Crate of the Week


### PR DESCRIPTION
Remove dupe link for https://www.kdab.com/embedding-servo-in-qt/