### PR TITLE
Add Announcing async-openai-wasm

### DIFF
--- a/draft/2024-04-17-this-week-in-rust.md
+++ b/draft/2024-04-17-this-week-in-rust.md
@@ -34,6 +34,7 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
+* `[ZH][EN]` [Announcing async-openai-wasm, and thoughts on wasmization and streams](https://ideas.reify.ing/en/blog/announcing-async-openai-wasm/): Async Rust library for interacting with OpenAI's APIs on WASM and how I did it.
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
Hi this-week-in-rust,

I recently released a crate `async-openai-wasm` and wrote a blog that announces it and how I make it work on WASM. I'd like it to be included in this week's release. The blog has both CN and EN versions.