### PR TITLE
Add "Writing ergonomic async assertions in Rust" blog post

### DIFF
--- a/draft/DRAFT_TEMPLATE
+++ b/draft/DRAFT_TEMPLATE
@@ -37,6 +37,8 @@ and just ask the editors to select the category.
 
 ### Observations/Thoughts
 
+[Writing ergonomic async assertions in Rust](https://www.niklaslong.ch/deadline/)
+
 ### Rust Walkthroughs
 
 ### Research


### PR DESCRIPTION
I've included it under "Observations/Thoughts" for now, hopefully that's appropriate. 

Alternatively, if you'd prefer it to be under tooling updates, the crate name could feature more prominently in the link title, something like: "Deadline: writing ergonomic async assertions in Rust". 