### PR TITLE
TWiR 546 - Add Meilisearch 1.8

### DIFF
--- a/draft/2024-05-08-this-week-in-rust.md
+++ b/draft/2024-05-08-this-week-in-rust.md
@@ -35,6 +35,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [Meilisearch releases v1.8](https://blog.meilisearch.com/meilisearch-1-8/) - ([Rust SDK](https://github.com/meilisearch/meilisearch-rust))
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
Hey there,

Meilisearch just shipped v1.8: I included a link to the release notes + Rust SDK.

Cheers,