### PR TITLE
reduce double-link to single link

### DIFF
--- a/draft/2024-05-08-this-week-in-rust.md
+++ b/draft/2024-05-08-this-week-in-rust.md
@@ -35,7 +35,7 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
-* [Meilisearch releases v1.8](https://blog.meilisearch.com/meilisearch-1-8/) - ([Rust SDK](https://github.com/meilisearch/meilisearch-rust))
+* [Meilisearch releases v1.8](https://blog.meilisearch.com/meilisearch-1-8/)
 * [r3bl_terminal_async v0.5.2 released](https://github.com/r3bl-org/r3bl-open-core/blob/main/CHANGELOG.md#v052-2020-05-06)
 
 ### Observations/Thoughts

--- a/draft/2024-05-08-this-week-in-rust.md
+++ b/draft/2024-05-08-this-week-in-rust.md
@@ -44,8 +44,6 @@ and just ask the editors to select the category.
 * [This Month in Rust GameDev #50 - April 2024](https://gamedev.rs/news/050/)
 
 ### Project/Tooling Updates
-
-* [Zed Decoded: Linux when? - Zed Blog](https://zed.dev/blog/zed-decoded-linux-when)
 * [image v0.25: performance improvements, production-ready WebP](https://www.reddit.com/r/rust/comments/1cj94va/image_v025_performance_improvements/)
 * [Changelog #232](https://rust-analyzer.github.io/thisweek/2024/05/06/changelog-232.html)
 * [rustc_codegen_gcc: Progress Report #32](https://blog.antoyo.xyz/rustc_codegen_gcc-progress-report-32)


### PR DESCRIPTION
We try to follow a one-link per line rule in the community sections. Remove the second link.