### PR TITLE
Update CFP guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,9 +127,9 @@ The project section will include good issues for someone looking to get into Rus
 * Include a link to your contribution guidelines in the task, and call out any specific requirements for contributors (e.g., copyright waiver).
 * The issue will be omitted if it has been completed and/or closed since it was submitted to the forums.
 
-### CFP - Speakers
+### CFP - Events
 
-The speakers section will include CFPs links for events that either heavily feature Rust content, or have a specific Rust track. It's not appropriate for general tech conferences, unless there is a large enough coding or Rust section to appeal to the TWiR audience. 
+The CFP events section will include CFP links for events that either heavily feature Rust content, or have a specific Rust track. It's not appropriate for general tech conferences, unless there is a large enough coding or Rust section to appeal to the TWiR audience. 
 
 Generally speaking (excepting the rolling 30 day window), if it would be listed in the Events section of TWiR, it will be right for this section as well. 
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,26 @@ Most blog posts about Rust belong in **Rust Walkthroughs** if they show how some
 
 If a set of related links is published (e.g. from a large Rust conference), the editors may choose to invent a new category just for that issue.
 
+## Call for Participation guidelines
+
+The Call for Participation section covers both projects looking for contributors and events recruiting speakers. 
+
+### CFP - Projects 
+
+The project section will include good issues for someone looking to get into Rust, or for someone who wants to find a new project to contribute to. Guidelines:
+
+* Ensure that your project has at least one [Open Source Initiative](https://opensource.org/)-approved license.
+* Ensure that the issue tracker for your project is publicly accessible.
+* Create a new issue in your issue tracker and clearly describe the task, and include the difficulty level (easy/medium/hard/tedious), either as a tag/label or somewhere in the title/description.
+* Include a link to your contribution guidelines in the task, and call out any specific requirements for contributors (e.g., copyright waiver).
+* The issue will be omitted if it has been completed and/or closed since it was submitted to the forums.
+
+### CFP - Speakers
+
+The speakers section will include CFPs links for events that either heavily feature Rust content, or have a specific Rust track. It's not appropriate for general tech conferences, unless there is a large enough coding or Rust section to appeal to the TWiR audience. 
+
+Generally speaking (excepting the rolling 30 day window), if it would be listed in the Events section of TWiR, it will be right for this section as well. 
+
 # Publishing 
 
 The editors have a detailed guide for publishing that is stored elsewhere, but this content is retained here as well.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Content for [this-week-in-rust.org](http://this-week-in-rust.org). Made availabl
 All code Copyright 2014 Ember Arlynx, made available under [the MIT
 license](http://mit-license.org/).
 
-## TWiR Editors
+# TWiR Editors
 
 * [nellshamrell](https://github.com/nellshamrell)
 * [llogiq](https://github.com/llogiq)
@@ -20,7 +20,7 @@ license](http://mit-license.org/).
 * [mariannegoldin](https://github.com/mariannegoldin)
 * [bennyvasquez](https://github.com/bennyvasquez)
 
-### Language Reviewers
+## Language Reviewers
 
 * [yuk1ty](https://github.com/yuk1ty) - Japanese
 * [rpruizc](https://github.com/rpruizc) - Spanish
@@ -36,7 +36,7 @@ draft.
 
 Alternately, tweet us [@thisweekinrust](https://twitter.com/thisweekinrust).
 
-### What do we look for when considering whether to include something in This Week in Rust?
+## What do we look for when considering whether to include something in This Week in Rust?
 
 This Week in Rust is intended to highlight the incredible work of the Rust Community. 
 
@@ -63,7 +63,7 @@ What we are generally NOT looking for includes:
 * Anything behind a paywall (this includes Medium's paid article / members-only mechanism)
 * Anything that requires information to be shared/captured (like an email address) in order to access
 
-**Projects/Tooling Updates**
+## Projects/Tooling Updates
 
 There are further guidelines for the Projects/Tooling Updates Section
 
@@ -113,15 +113,24 @@ Most blog posts about Rust belong in **Rust Walkthroughs** if they show how some
 
 If a set of related links is published (e.g. from a large Rust conference), the editors may choose to invent a new category just for that issue.
 
+# Publishing 
+
+The editors have a detailed guide for publishing that is stored elsewhere, but this content is retained here as well.
+
 ## How I get PR lists:
 
 ```
 git log --author=bors --since='MM/DD/YYYY 12:00PM' --until='MM/DD/YYYY 12:00PM' --pretty=oneline > ~/entropy/twir.txt
-# edit in vim to get rid of everything but PR number, copy into clipboard
-for pr in $(xsel -ob); do firefox https://github.com/mozilla/rust/pull/$pr; sleep 0.07; done
-# wait a long time...
-# write TWIR
 ```
+
+edit in vim to get rid of everything but PR number, copy into clipboard
+
+```
+for pr in $(xsel -ob); do firefox https://github.com/mozilla/rust/pull/$pr; sleep 0.07; done
+```
+
+wait a long time...
+write TWIR
 
 Alternatively use GitHub search:
 
@@ -154,7 +163,7 @@ you intend to build the website or email newsletter.
   make build && make generate-website && make host-content
   ```
 * View the website locally at default http://localhost:8000, or specific posts
-  at http://localhost:8000/blog/{YEAR}/{MONTH}/{DAY}/{ISSUE}/.
+  at http://localhost:8000/blog/{YEAR}/{MONTH}/{DAY}/{ISSUE}/
 
 Note: If looking to test the website's search functionality locally, you will need to adjust the [`TESTING_LOCALLY`](https://github.com/rust-lang/this-week-in-rust/blob/dc127f17fcabbf0f058eb3d5a3febba434ddca83/pelicanconf.py#L7)
 variable to `True`.
@@ -172,4 +181,4 @@ variable to `True`.
   make build && make generate-email && make host-content
   ```
 * View the email newsletter formatting of specific posts at
-  http://localhost:8000/blog/{YEAR}/{MONTH}/{DAY}/{ISSUE}/.
+  http://localhost:8000/blog/{YEAR}/{MONTH}/{DAY}/{ISSUE}/

--- a/draft/2024-05-29-this-week-in-rust.md
+++ b/draft/2024-05-29-this-week-in-rust.md
@@ -85,7 +85,7 @@ If you are a Rust project owner and are looking for contributors, please submit 
 
 [guidelines]:https://github.com/rust-lang/this-week-in-rust?tab=readme-ov-file#call-for-participation-guidelines
 
-### CFP - Speakers
+### CFP - Events
 
 Are you a new or experienced speaker looking for a place to share something cool? This section highlights events that are being planned and are accepting submissions to join their event as a speaker.
 

--- a/draft/2024-05-29-this-week-in-rust.md
+++ b/draft/2024-05-29-this-week-in-rust.md
@@ -6,7 +6,8 @@ Category: This Week in Rust
 Hello and welcome to another issue of *This Week in Rust*!
 [Rust](https://www.rust-lang.org/) is a programming language empowering everyone to build reliable and efficient software.
 This is a weekly summary of its progress and community.
-Want something mentioned? Tag us at [@ThisWeekInRust](https://twitter.com/ThisWeekInRust) on Twitter or [@ThisWeekinRust](https://mastodon.social/@thisweekinrust) on mastodon.social, or [send us a pull request](https://github.com/rust-lang/this-week-in-rust).
+Want something mentioned? Tag us at [@ThisWeekInRust](https://x.com/ThisWeekInRust) on X(formerly Twitter) or [@ThisWeekinRust](https://mastodon.social/@thisweekinrust) on mastodon.social, or [send us a pull request](https://github.com/rust-lang/this-week-in-rust).
+
 Want to get involved? [We love contributions](https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md).
 
 *This Week in Rust* is openly developed [on GitHub](https://github.com/rust-lang/this-week-in-rust) and archives can be viewed at [this-week-in-rust.org](https://this-week-in-rust.org/).
@@ -80,9 +81,9 @@ Some of these tasks may also have mentors available, visit the task page for mor
 <!-- CFPs go here, use this format: * [project name - title of issue](link to issue) -->
 <!-- * [ - ]() -->
 
-If you are a Rust project owner and are looking for contributors, please submit tasks [here][guidelines].
+If you are a Rust project owner and are looking for contributors, please submit tasks [here][guidelines] or through a [PR to TWiR](https://github.com/rust-lang/this-week-in-rust) or by reaching out on [X (Formerly twitter)](https://x.com/ThisWeekInRust) or [Mastodon](https://mastodon.social/@thisweekinrust)!
 
-[guidelines]: https://users.rust-lang.org/t/twir-call-for-participation/4821
+[guidelines]:https://github.com/rust-lang/this-week-in-rust?tab=readme-ov-file#call-for-participation-guidelines
 
 ### CFP - Speakers
 
@@ -91,7 +92,7 @@ Are you a new or experienced speaker looking for a place to share something cool
 <!-- CFPs go here, use this format: * [**event name**](link to CFP)| Date CFP closes in YYYY-MM-DD | city,state,country | Date of event in YYYY-MM-DD -->
 <!-- or if none - *No Calls for papers or presentations were submitted this week.* -->
 
-If you are an event organizer hoping to expand the reach of your event, please submit a link to the submission website through a [PR to TWiR](https://github.com/rust-lang/this-week-in-rust).
+If you are an event organizer hoping to expand the reach of your event, please submit a link to the website through a [PR to TWiR](https://github.com/rust-lang/this-week-in-rust) or by reaching out on [X (Formerly twitter)](https://x.com/ThisWeekInRust) or [Mastodon](https://mastodon.social/@thisweekinrust)!
 
 ## Updates from the Rust Project
 

--- a/draft/DRAFT_TEMPLATE
+++ b/draft/DRAFT_TEMPLATE
@@ -85,7 +85,7 @@ If you are a Rust project owner and are looking for contributors, please submit 
 
 [guidelines]:https://github.com/rust-lang/this-week-in-rust?tab=readme-ov-file#call-for-participation-guidelines
 
-### CFP - Speakers
+### CFP - Events
 
 Are you a new or experienced speaker looking for a place to share something cool? This section highlights events that are being planned and are accepting submissions to join their event as a speaker.
 

--- a/draft/DRAFT_TEMPLATE
+++ b/draft/DRAFT_TEMPLATE
@@ -6,7 +6,7 @@ Category: This Week in Rust
 Hello and welcome to another issue of *This Week in Rust*!
 [Rust](https://www.rust-lang.org/) is a programming language empowering everyone to build reliable and efficient software.
 This is a weekly summary of its progress and community.
-Want something mentioned? Tag us at [@ThisWeekInRust](https://twitter.com/ThisWeekInRust) on Twitter or [@ThisWeekinRust](https://mastodon.social/@thisweekinrust) on mastodon.social, or [send us a pull request](https://github.com/rust-lang/this-week-in-rust).
+Want something mentioned? Tag us at [@ThisWeekInRust](https://x.com/ThisWeekInRust) on X(formerly Twitter) or [@ThisWeekinRust](https://mastodon.social/@thisweekinrust) on mastodon.social, or [send us a pull request](https://github.com/rust-lang/this-week-in-rust).
 Want to get involved? [We love contributions](https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md).
 
 *This Week in Rust* is openly developed [on GitHub](https://github.com/rust-lang/this-week-in-rust) and archives can be viewed at [this-week-in-rust.org](https://this-week-in-rust.org/).
@@ -77,21 +77,22 @@ Every week we highlight some tasks from the Rust community for you to pick and g
 
 Some of these tasks may also have mentors available, visit the task page for more information.
 
-<!-- CFPs go here, use this format: * [project name - title of issue](link to issue) -->
+<!-- CFPs go here, use this format: * [project name - title of issue](URL to issue) -->
 <!-- * [ - ]() -->
+<!-- or if none - *No Calls for participation were submitted this week.* -->
 
-If you are a Rust project owner and are looking for contributors, please submit tasks [here][guidelines].
+If you are a Rust project owner and are looking for contributors, please submit tasks [here][guidelines] or through a [PR to TWiR](https://github.com/rust-lang/this-week-in-rust) or by reaching out on [X (Formerly twitter)](https://x.com/ThisWeekInRust) or [Mastodon](https://mastodon.social/@thisweekinrust)!
 
-[guidelines]: https://users.rust-lang.org/t/twir-call-for-participation/4821
+[guidelines]:https://github.com/rust-lang/this-week-in-rust?tab=readme-ov-file#call-for-participation-guidelines
 
 ### CFP - Speakers
 
 Are you a new or experienced speaker looking for a place to share something cool? This section highlights events that are being planned and are accepting submissions to join their event as a speaker.
 
-<!-- CFPs go here, use this format: * [**event name**](link to CFP)| Date CFP closes in YYYY-MM-DD | city,state,country | Date of event in YYYY-MM-DD -->
+<!-- CFPs go here, use this format: * [**event name**](URL to CFP)| Date CFP closes in YYYY-MM-DD | city,state,country | Date of event in YYYY-MM-DD -->
 <!-- or if none - *No Calls for papers or presentations were submitted this week.* -->
 
-If you are an event organizer hoping to expand the reach of your event, please submit a link to the submission website through a [PR to TWiR](https://github.com/rust-lang/this-week-in-rust).
+If you are an event organizer hoping to expand the reach of your event, please submit a link to the website through a [PR to TWiR](https://github.com/rust-lang/this-week-in-rust) or by reaching out on [X (Formerly twitter)](https://x.com/ThisWeekInRust) or [Mastodon](https://mastodon.social/@thisweekinrust)!
 
 ## Updates from the Rust Project
 


### PR DESCRIPTION
This PR implements the changes discussed in #5434. 

In the README.md
* Added the guidelines for both projects and events
* Adjusted the formatting for consistency (all headings are now formatted the same way, and the levels (ie: number of #) are consistent)

In the draft template, and this week's draft.
* Added a link to the new CFP guidelines
* Updated the text of the template to include guidelines

While I was there, I also updated the social links in the header for the twitter/X updates.