### PR TITLE
Add subscription message to newsletter body

### DIFF
--- a/draft/2024-06-19-this-week-in-rust.md
+++ b/draft/2024-06-19-this-week-in-rust.md
@@ -12,6 +12,8 @@ Want to get involved? [We love contributions](https://github.com/rust-lang/rust/
 *This Week in Rust* is openly developed [on GitHub](https://github.com/rust-lang/this-week-in-rust) and archives can be viewed at [this-week-in-rust.org](https://this-week-in-rust.org/).
 If you find any errors in this week's issue, [please submit a PR](https://github.com/rust-lang/this-week-in-rust/pulls).
 
+Want TWIR in your inbox? [Subscribe here](http://eepurl.com/dgPJ_D).
+
 ## Updates from Rust Community
 
 <!--

--- a/draft/2024-06-19-this-week-in-rust.md
+++ b/draft/2024-06-19-this-week-in-rust.md
@@ -12,7 +12,7 @@ Want to get involved? [We love contributions](https://github.com/rust-lang/rust/
 *This Week in Rust* is openly developed [on GitHub](https://github.com/rust-lang/this-week-in-rust) and archives can be viewed at [this-week-in-rust.org](https://this-week-in-rust.org/).
 If you find any errors in this week's issue, [please submit a PR](https://github.com/rust-lang/this-week-in-rust/pulls).
 
-Want TWIR in your inbox? [Subscribe here](http://eepurl.com/dgPJ_D).
+Want TWIR in your inbox? [Subscribe here](https://this-week-in-rust.us11.list-manage.com/subscribe?u=fd84c1c757e02889a9b08d289&id=0ed8b72485).
 
 ## Updates from Rust Community
 

--- a/draft/DRAFT_TEMPLATE
+++ b/draft/DRAFT_TEMPLATE
@@ -12,6 +12,8 @@ Want to get involved? [We love contributions](https://github.com/rust-lang/rust/
 *This Week in Rust* is openly developed [on GitHub](https://github.com/rust-lang/this-week-in-rust) and archives can be viewed at [this-week-in-rust.org](https://this-week-in-rust.org/).
 If you find any errors in this week's issue, [please submit a PR](https://github.com/rust-lang/this-week-in-rust/pulls).
 
+Want TWIR in your inbox? [Subscribe here](http://eepurl.com/dgPJ_D).
+
 ## Updates from Rust Community
 
 <!--

--- a/draft/DRAFT_TEMPLATE
+++ b/draft/DRAFT_TEMPLATE
@@ -12,7 +12,7 @@ Want to get involved? [We love contributions](https://github.com/rust-lang/rust/
 *This Week in Rust* is openly developed [on GitHub](https://github.com/rust-lang/this-week-in-rust) and archives can be viewed at [this-week-in-rust.org](https://this-week-in-rust.org/).
 If you find any errors in this week's issue, [please submit a PR](https://github.com/rust-lang/this-week-in-rust/pulls).
 
-Want TWIR in your inbox? [Subscribe here](http://eepurl.com/dgPJ_D).
+Want TWIR in your inbox? [Subscribe here](https://this-week-in-rust.us11.list-manage.com/subscribe?u=fd84c1c757e02889a9b08d289&id=0ed8b72485).
 
 ## Updates from Rust Community
 


### PR DESCRIPTION
I realized that we didn't have the subscription message in the body of our email. This PR adds it to the draft template + the current #552 of TWIR. 
