### PR TITLE
Add TLC5940, ESP32 RMT embedded tutorial

### DIFF
--- a/draft/2024-06-26-this-week-in-rust.md
+++ b/draft/2024-06-26-this-week-in-rust.md
@@ -41,6 +41,8 @@ and just ask the editors to select the category.
 
 ### Rust Walkthroughs
 
+- [Running a TLC5940 with an ESP32 using the RMT peripheral](https://wapl.es/esp32-tlc5940-rmt/)
+
 ### Research
 
 ### Miscellaneous


### PR DESCRIPTION
Adds link to [Running a TLC5940 with an ESP32 using the RMT peripheral](https://wapl.es/esp32-tlc5940-rmt/)