### PR TITLE
tooling update: what-the-time v1.0.0

### DIFF
--- a/draft/2024-07-03-this-week-in-rust.md
+++ b/draft/2024-07-03-this-week-in-rust.md
@@ -37,6 +37,9 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [what-the-time 1.0.0](https://github.com/sdball/what-the-time/releases/tag/v1.0.0): calculate
+  time diffs between JSON log lines
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
what-the-time `wtt` is a new Rust tool I've made that replaces a few Ruby scripts with one command.