### PR TITLE
TWiR 554 - Add Meilisearch 1.9 + Rust SDK

### DIFF
--- a/draft/2024-07-03-this-week-in-rust.md
+++ b/draft/2024-07-03-this-week-in-rust.md
@@ -37,7 +37,7 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
-* [Meilisearch releases v1.9](https://blog.meilisearch.com/meilisearch-1-9/) - ([Rust SDK](https://github.com/meilisearch/meilisearch-rust))
+* [Meilisearch releases v1.9](https://blog.meilisearch.com/meilisearch-1-9/)
 
 ### Observations/Thoughts
 

--- a/draft/2024-07-03-this-week-in-rust.md
+++ b/draft/2024-07-03-this-week-in-rust.md
@@ -37,6 +37,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [Meilisearch releases v1.9](https://blog.meilisearch.com/meilisearch-1-9/) - ([Rust SDK](https://github.com/meilisearch/meilisearch-rust))
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
Hey TWiR maintainers 👋 

This PR adds a link to [Meilisearch 1.9 release notes](https://blog.meilisearch.com/meilisearch-1-9/) and its [Rust SDK](https://github.com/meilisearch/meilisearch-rust).

Cheers,