### PR TITLE
add link to mutant-kraken release in project updates

### DIFF
--- a/draft/2024-07-03-this-week-in-rust.md
+++ b/draft/2024-07-03-this-week-in-rust.md
@@ -37,6 +37,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [Mutant-Kraken: A Mutation Testing Tool For Kotlin Built in Rust Released!](https://github.com/JosueMolinaMorales/mutant-kraken)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
Hi there, i just released mutant-kraken a mutation testing tool for kotlin built in rust!

The tool isnt for Rust but since it was built in Rust i was wondering if it would quality for the next release of this week in rust!

If it doesnt, no worries. Figured i would try.

Thanks reviewers!