### PR TITLE
Add link to 'Surprises with Rust's as' to Walkthroughs

### DIFF
--- a/draft/2024-07-17-this-week-in-rust.md
+++ b/draft/2024-07-17-this-week-in-rust.md
@@ -41,6 +41,8 @@ and just ask the editors to select the category.
 
 ### Rust Walkthroughs
 
+* [Surprises with Rust's `as` (and Python division)](https://annahope.me/blog/rust-as/)
+
 ### Research
 
 ### Miscellaneous


### PR DESCRIPTION
Added my recent blog post about potentially surprising behavior when using `as` to cast types, and why I try to avoid it and prefer `TryFrom` instead. Also includes background information, notably an exploration of Python's division operations, to show why Rust's strict type system might prevent surprising behavior or bugs.

I *think* this fits into Walkthroughs, but might also fit in "Observations/Thoughts" instead. Please let me know if I should move it!