### PR TITLE
Fix approved RFCs rendering

### DIFF
--- a/content/2024-07-17-this-week-in-rust.md
+++ b/content/2024-07-17-this-week-in-rust.md
@@ -236,6 +236,7 @@ Revision range: [a2d58197..5572759b](https://perf.rust-lang.org/?start=a2d58197a
 
 Changes to Rust follow the Rust [RFC (request for comments) process](https://github.com/rust-lang/rfcs#rust-rfcs). These
 are the RFCs that were approved for implementation this week:
+
 * [Match ergonomics 2024](https://github.com/rust-lang/rfcs/pull/3627)
 * [Return type notation (RTN)](https://github.com/rust-lang/rfcs/pull/3654)
 * [#[derive(SmartPointer)]](https://github.com/rust-lang/rfcs/pull/3621)


### PR DESCRIPTION
It seems like the markdown renderer used here doesn't allow starting a list next to a paragraph without a blank line. This prevents it from being rendered as a list.

I'm guessing there is a template or a script somewhere that generates this, since previous issues seem to have the same problem. You may want to update that.