### PR TITLE
Add WebAssembly on the server blog post

### DIFF
--- a/draft/2024-07-24-this-week-in-rust.md
+++ b/draft/2024-07-24-this-week-in-rust.md
@@ -38,10 +38,9 @@ and just ask the editors to select the category.
 ### Project/Tooling Updates
 
 ### Observations/Thoughts
+* [WebAssembly on the server: Compiling Rust to WASM and executing it from Go](https://blog.arcjet.com/webassembly-on-the-server-compiling-rust-to-wasm-and-executing-it-from-go/)
 
 ### Rust Walkthroughs
-
-* [WebAssembly on the server: Compiling Rust to WASM and executing it from Go](https://blog.arcjet.com/webassembly-on-the-server-compiling-rust-to-wasm-and-executing-it-from-go/)
 
 ### Research
 

--- a/draft/2024-07-24-this-week-in-rust.md
+++ b/draft/2024-07-24-this-week-in-rust.md
@@ -41,6 +41,8 @@ and just ask the editors to select the category.
 
 ### Rust Walkthroughs
 
+* [WebAssembly on the server: Compiling Rust to WASM and executing it from Go](https://blog.arcjet.com/webassembly-on-the-server-compiling-rust-to-wasm-and-executing-it-from-go/)
+
 ### Research
 
 ### Miscellaneous


### PR DESCRIPTION
Added a link to https://blog.arcjet.com/webassembly-on-the-server-compiling-rust-to-wasm-and-executing-it-from-go/