### PR TITLE
Add news of Rust being the awarded the SIGPLAN Programming Languages Software Award 2024

### DIFF
--- a/draft/2024-07-31-this-week-in-rust.md
+++ b/draft/2024-07-31-this-week-in-rust.md
@@ -45,6 +45,8 @@ and just ask the editors to select the category.
 
 ### Miscellaneous
 
+* [Rust wins the SIGPLAN Programming Language Software Award 2024](https://sigplan.org/Awards/Software/#2024_The_Rust_Programming_Language)
+
 ## Crate of the Week
 
 <!-- COTW goes here -->


### PR DESCRIPTION
The Rust language and all current and future contributors were awarded the SIGPLAN Programming Languages Software Award this year. Even though this shows how highly the academic world values Rust, it seems to not have been disseminated much (apart from this tweet by the foundation: https://x.com/rust_foundation/status/1814459715633414183). Even though this was not last week, I think it should be interesting enough to many Rustaceans that it should still be published in TWiR.

Since there is no official press release by the foundation etc. I put the link under miscellaneous, as it doesn't seem to fit any other category either. Please change if there is a better place for it.