### PR TITLE
Add Ringboard project

### DIFF
--- a/draft/2024-08-14-this-week-in-rust.md
+++ b/draft/2024-08-14-this-week-in-rust.md
@@ -36,6 +36,7 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
+* [Ringboard: a new clipboard manager for Linux](https://alexsaveau.dev/blog/projects/performance/clipboard/ringboard/ringboard)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
Not sure if this kind of project counts for inclusion? I feel like usually the projects spot is for frameworks/libraries which Ringboard is not. But it's written in Rust and pretty cool! I'm biased obviously. :)