### PR TITLE
TWiR 562 - Add Meilisearch 1.10

### DIFF
--- a/draft/2024-08-28-this-week-in-rust.md
+++ b/draft/2024-08-28-this-week-in-rust.md
@@ -37,6 +37,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [Meilisearch 1.10 - Federated search, language settings, and improved AI search](https://blog.meilisearch.com/meilisearch-1-10/)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
Hey TWiR maintainers,

This PR adds a link to [Meilisearch 1.10 release notes](https://blog.meilisearch.com/meilisearch-1-10/) in the next issue (562).

Cheers,