### PR TITLE
Simplify publishing workflows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@ cache
 .DS_Store
 
 # Publishing creations...
-publishing/output
+publishing/email
+publishing/output*
 publishing/juice

--- a/publishing/Dockerfile
+++ b/publishing/Dockerfile
@@ -3,8 +3,7 @@ FROM --platform=linux/amd64 python:3.8.16-slim
 # Must run from base TWIR directory... makefile takes care of this.
 WORKDIR /usr/twir
 
-RUN apt-get update
-RUN apt-get install -y curl build-essential
+RUN apt-get update && apt-get install -y curl build-essential
 
 # pelican+friends
 ENV LANG='en_US.UTF-8'
@@ -16,10 +15,9 @@ RUN curl https://files.stork-search.net/releases/v1.5.0/stork-ubuntu-20-04 -o st
     && mv ./stork /usr/bin/stork
 
 # sass/juice
-RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - 
 RUN apt-get install -y nodejs
-RUN npm install -g sass
-RUN npm install -g juice
+RUN npm install -g sass juice
 
 # pelican setup
 COPY content content

--- a/publishing/Makefile
+++ b/publishing/Makefile
@@ -1,81 +1,77 @@
 #!/bin/sh
 
 # TODO: Make sure running from latest "main" branch commit
-# TODO: Remove `BLOG_DOWNLOAD` variable requirement. Adjust "email" logic to:
-# 			- Run generate container
-#			- Curl website
-#  			- Run HTML-friendly container
 
 # Typical flows:
-# 
-# 1. The first workflow will generate the desired website, landing
-#    the end contents in the local "output/" directory. This is the 
+#
+# 1. `make website`
+# 	 The first workflow will generate the desired website, landing
+#    the end contents in the local "output-website/" directory. This is the 
 #    equivalent of running `pelican --delete-output-directory content`
 #    from a properly instantantiated environment.
 #
-#    $ make build && make generate-website && make host-content
-#   
+#    $ generate-website host-website
+#
 #    Then, visit the printed URL from a browser to verify.
-# 
-# 2. This workflow will generate the desired email template, landing
-#    the end contents in the local "output/" directory. This is the 
+#
+#    Output: `output-website/`
+#
+# 2. `make copy-website-contents`
+#    This workflow will sync the `output-website/` directory from above, and sync
+#    it with the directory passed to it. Used for syncing state with
+#    this-week-in-rust.github.io repo.
+#
+# 3. `make email`
+#    This workflow will generate the desired email template, landing
+#    the end contents in the local "email/" directory. This is the 
 #    equivalent of running `USE_EMAIL_THEME=1 pelican --delete-output-directory content`
-#    from a properly instantantiated environment.   
+#    from a properly instantantiated environment, and running
+#    `juice --web-resources-images false /juice/in.html /juice/out.html` on the latest content post.
 # 
-#    $ make build && make generate-email && make host-content
+#    $ build clean generate-email optimize-email
 #
-# 	Then, visit the printed URL from a browser to verify.
-#   Once verified, one can adjust the "BLOG_DOWNLOAD" variable below, and 
-#   we can create an email-friendly HTML version of the latest Blog page. 
-#   **While the above container is still running**, open another terminal.
-#   This is the equivalent of running 
-#   `curl ${BLOG_DOWNLOAD} > juice/in.html && juice --web-resources-images false /juice/in.html /juice/out.html`
-#   
-#    $ make optimize-email
+#	 Output: `email/<NUMBER>-<YEAR>-<MONTH>-<DAY>-email.html`
 #
-#   This results in the desired email-friendly HTML version: "juice/out.html".
 
-# TODO: The BLOG_DOWNLOAD is only needed because one dockerfile will have to communicate
-#       with another, and I don't want to deal with building out the networking logic... yet...
-# CHANGE ME!  vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
-BLOG_DOWNLOAD=http://localhost:8000/blog/2024/09/04/this-week-in-rust-563/
-
-website-workflow: build clean generate-website host-content
-
-email-workflow-1: build clean generate-email host-content
-email-workflow-2: optimize-email
+website: generate-website host-website
+copy-website-contents:
+	@./copy_website_content_to_repo.sh
+email: generate-email optimize-email
 
 build:
 	cd .. && docker build -t twir -f publishing/Dockerfile . && cd -
 
-clean:
-	rm -rf output/
+clean-website:
+	@rm -rf output/ && rm -rf output-website/ && rm -rf juice/
+clean-email:
+	@rm -rf output/ && rm -rf output-email-format/ && rm -rf email/ && rm -rf juice/
 
-generate-website: clean
-	docker run -it \
-		-v $(shell pwd)/output:/usr/twir/output \
+generate-website: build clean-website
+	@echo "Generating website..."
+	@docker run -it \
+		-v $(shell pwd)/output-website:/usr/twir/output \
 		twir:latest 
+	@echo "Finished generating website."
 
-generate-email: clean
-	docker run -it \
-		-e USE_EMAIL_THEME=1 \
-		-v $(shell pwd)/output:/usr/twir/output \
-		twir:latest
-
-host-content:
-	docker run -it \
+host-website:
+	@echo "Hosting website..."
+	@docker run -it \
 		-p 8000:8000 \
-	 	-v $(shell pwd)/output:/usr/twir/output:ro \
+	 	-v $(shell pwd)/output-website:/usr/twir/output:ro \
 		-it \
 		twir:latest \
 		bash run_server.sh
+	@echo "Finished hosting website."
+	@echo ""
+	@echo "To sync contents with your local 'this-week-in-rust.github.io' repo, run \033[1;33m'make copy-website-contents'\033[0m"
+
+generate-email: build clean-email
+	@echo "Generating email..."
+	@docker run -it \
+		-e USE_EMAIL_THEME=1 \
+		-v $(shell pwd)/output-email-format:/usr/twir/output \
+		twir:latest
 
 optimize-email:
-	@echo -n "Is this '${BLOG_DOWNLOAD}' your desired blog? [y/N] " && read ans && [ $${ans:-N} = y ]
-	rm -rf juice
-	mkdir juice
-	curl ${BLOG_DOWNLOAD} > juice/in.html
-	docker run \
-		-v $(shell pwd)/juice:/usr/twir/juice \
-		twir:latest \
-		bash create_html_friendly_page.sh
+	@echo "Generating optimized email..."
+	@OUTPUT_PREFIX=output-email-format ./create_optimized_email.sh

--- a/publishing/copy_website_content_to_repo.sh
+++ b/publishing/copy_website_content_to_repo.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+read -p "Enter the directory to copy website contents to (likely ending in 'this-week-in-rust.github.io'): " directory
+
+# Check if the provided input is a valid directory
+if [ ! -d "$directory" ]; then
+  echo "Error: $directory is not a valid directory."
+  exit 1
+fi
+
+# Check if the file "CNAME" exists in the directory
+if [ -f "$directory/CNAME" ]; then
+  rsync -razvP --delete --exclude /CNAME --exclude /.git output-website/ $directory
+  echo "Finished syncing with directory '$directory'"
+else
+  echo "ERROR: This does not seem to be the 'this-week-in-rust.github.io' repo..."
+  echo "Please copy contents manually using 'rsync -razvP --delete --exclude /CNAME --exclude /.git output-website/ /path/to/this-week-in-rust.github.io/'"
+fi

--- a/publishing/create_html_friendly_page.sh
+++ b/publishing/create_html_friendly_page.sh
@@ -1,4 +1,3 @@
 #!/bin/sh
 
-juice --web-resources-images false juice/in.html juice/out.html
-rm juice/in.html
+juice --web-resources-images false ${LOCAL_EMAIL_PREFIX}-in.html ${LOCAL_EMAIL_PREFIX}-email.html

--- a/publishing/create_optimized_email.sh
+++ b/publishing/create_optimized_email.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+source utils.sh
+
+LOCAL_EMAIL_PREFIX="email/${LATEST_ISSUE_NUMBER}-${LATEST_YEAR}-${LATEST_MONTH}-${LATEST_DAY}"
+echo "Creating email for ${LATEST_ISSUE_NUMBER}-${LATEST_YEAR}-${LATEST_MONTH}-${LATEST_DAY}"
+
+# Prepare email directory
+mkdir -p email
+rm -f ${LOCAL_EMAIL_PREFIX}-in.html
+cp ${LATEST_ISSUE_FULL_PATH} ${LOCAL_EMAIL_PREFIX}-in.html
+
+docker run \
+    -v $(pwd)/email:/usr/twir/email \
+    -e LOCAL_EMAIL_PREFIX=${LOCAL_EMAIL_PREFIX} \
+    twir:latest \
+    bash create_html_friendly_page.sh 
+
+rm ${LOCAL_EMAIL_PREFIX}-in.html
+
+printf "\n\n${CYAN_FONT}*****${PURPLE_FONT}*****${CYAN_FONT}*****${PURPLE_FONT}*****${NC}"
+printf "\n${CYAN_FONT}*****${PURPLE_FONT}*****${CYAN_FONT}*****${PURPLE_FONT}*****${NC}"
+printf "\n${CYAN_FONT}*****${PURPLE_FONT}*****${CYAN_FONT}*****${PURPLE_FONT}*****${NC}"
+printf "\n📧 HEY TWiR PUBLISHER..."
+printf "\nLatest email template found at:  ${YELLOW_FONT}'$(pwd)/${LOCAL_EMAIL_PREFIX}-email.html'${NC}"
+printf "\n${CYAN_FONT}*****${PURPLE_FONT}*****${CYAN_FONT}*****${PURPLE_FONT}*****${NC}"
+printf "\n${CYAN_FONT}*****${PURPLE_FONT}*****${CYAN_FONT}*****${PURPLE_FONT}*****${NC}"
+printf "\n${CYAN_FONT}*****${PURPLE_FONT}*****${CYAN_FONT}*****${PURPLE_FONT}*****${NC}\n\n"

--- a/publishing/form_latest_url.sh
+++ b/publishing/form_latest_url.sh
@@ -1,9 +1,0 @@
-LATEST_YEAR=$(ls output/blog/ | sort | tail -2 | head -1)
-LATEST_MONTH=$(ls output/blog/${LATEST_YEAR} | sort | tail -1)
-LATEST_DAY=$(ls output/blog/${LATEST_YEAR}/${LATEST_MONTH} | sort | tail -1)
-LATEST_ISSUE=$(ls output/blog/${LATEST_YEAR}/${LATEST_MONTH}/${LATEST_DAY}/)
-LATEST_BLOG_URL="http://localhost:8000/blog/${LATEST_YEAR}/${LATEST_MONTH}/${LATEST_DAY}/${LATEST_ISSUE}/"
-YELLOW_FONT='\033[1;32m'
-CYAN_FONT='\033[0;36m'
-PURPLE_FONT='\033[1;35m'
-NC='\033[0m' # No Color

--- a/publishing/run_server.sh
+++ b/publishing/run_server.sh
@@ -1,13 +1,12 @@
 #!/bin/sh
 
-source form_latest_url.sh
+source utils.sh
 
 printf "\n\n${CYAN_FONT}*****${PURPLE_FONT}*****${CYAN_FONT}*****${PURPLE_FONT}*****${NC}"
 printf "\n${CYAN_FONT}*****${PURPLE_FONT}*****${CYAN_FONT}*****${PURPLE_FONT}*****${NC}"
 printf "\n${CYAN_FONT}*****${PURPLE_FONT}*****${CYAN_FONT}*****${PURPLE_FONT}*****${NC}"
 printf "\nHEY TWiR PUBLISHER..."
 printf "\nLatest blog found at: ${YELLOW_FONT}'${LATEST_BLOG_URL}'${NC}"
-printf "\nIf publishing for email, copy the blog into the ${YELLOW_FONT}BLOG_DOWNLOAD${NC} variable in the Makefile!"
 printf "\n${CYAN_FONT}*****${PURPLE_FONT}*****${CYAN_FONT}*****${PURPLE_FONT}*****${NC}"
 printf "\n${CYAN_FONT}*****${PURPLE_FONT}*****${CYAN_FONT}*****${PURPLE_FONT}*****${NC}"
 printf "\n${CYAN_FONT}*****${PURPLE_FONT}*****${CYAN_FONT}*****${PURPLE_FONT}*****${NC}\n\n"

--- a/publishing/utils.sh
+++ b/publishing/utils.sh
@@ -1,0 +1,16 @@
+# Default OUTPUT_PREFIX, but allow overriding for email workflows.
+if [ -z "$OUTPUT_PREFIX" ]; then
+  OUTPUT_PREFIX="output"
+fi
+
+LATEST_YEAR=$(ls ${OUTPUT_PREFIX}/blog/ | sort | tail -2 | head -1)
+LATEST_MONTH=$(ls ${OUTPUT_PREFIX}/blog/${LATEST_YEAR} | sort | tail -1)
+LATEST_DAY=$(ls ${OUTPUT_PREFIX}/blog/${LATEST_YEAR}/${LATEST_MONTH} | sort | tail -1)
+LATEST_ISSUE_NUMBER=$(ls ${OUTPUT_PREFIX}/blog/${LATEST_YEAR}/${LATEST_MONTH}/${LATEST_DAY}/ | awk -F'-' '{print $5}')
+LATEST_ISSUE_FULL_PATH="${OUTPUT_PREFIX}/blog/${LATEST_YEAR}/${LATEST_MONTH}/${LATEST_DAY}/this-week-in-rust-${LATEST_ISSUE_NUMBER}/index.html"
+LATEST_BLOG_URL="http://localhost:8000/blog/${LATEST_YEAR}/${LATEST_MONTH}/${LATEST_DAY}/this-week-in-rust-${LATEST_ISSUE_NUMBER}/"
+
+YELLOW_FONT='\033[1;32m'
+CYAN_FONT='\033[0;36m'
+PURPLE_FONT='\033[1;35m'
+NC='\033[0m' # No Color


### PR DESCRIPTION
* Shift to three primary 'make' recipes:
      * `make website`: Generates and locally hosts website content, echoing the latest entry for easy access
      * `make copy-website-contents`: Takes above generated website, and syncs state with the input directory
      * `make email`: Generates website content formatted for email, then uses 'juice' for creating optimized format. Lands final email in new  directory, and echos the location
* Separate output directories to "output-website/" and "output-email-format/" to avoid potential confusion
* Bump node version 16 -> 20
    
**Notably, email generation no longer requires bringing up two windows, nor does it require updating a variable to fetch latest. All is handled automatically**