### PR TITLE
Add vf2 announcement to project/tooling updates

### DIFF
--- a/draft/2024-09-18-this-week-in-rust.md
+++ b/draft/2024-09-18-this-week-in-rust.md
@@ -37,6 +37,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [Announcing vf2: A subgraph isomorphism algorithm in Rust](https://github.com/OwenTrokeBillard/vf2/discussions/1)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
This pull request adds a link to the [vf2 release announcement](https://github.com/OwenTrokeBillard/vf2/discussions/1) to the "Project/Tooling Updates" section.

Please let me know if the link and/or announcement can be improved.