### PR TITLE
Add project update: "rpgp 0.14.0"

### DIFF
--- a/draft/2024-10-02-this-week-in-rust.md
+++ b/draft/2024-10-02-this-week-in-rust.md
@@ -16,6 +16,8 @@ Want TWIR in your inbox? [Subscribe here](https://this-week-in-rust.us11.list-ma
 
 ## Updates from Rust Community
 
+[rPGP 0.14.0 (a pure Rust implementation of OpenPGP) now supports the new RFC 9580](https://fosstodon.org/@hko/113198947595455844)
+
 <!--
 
 Dear community contributors:


### PR DESCRIPTION
A short report (in a mastodon thread) about extending the rPGP library to support the (relatively substantial) new OpenPGP RFC 9580