### PR TITLE
Add Rustikon 2025 CFP

### DIFF
--- a/draft/2024-10-02-this-week-in-rust.md
+++ b/draft/2024-10-02-this-week-in-rust.md
@@ -93,6 +93,7 @@ Are you a new or experienced speaker looking for a place to share something cool
 
 <!-- CFPs go here, use this format: * [**event name**](URL to CFP)| Date CFP closes in YYYY-MM-DD | city,state,country | Date of event in YYYY-MM-DD -->
 <!-- or if none - *No Calls for papers or presentations were submitted this week.* -->
+* [**Rustikon CFP**](https://sessionize.com/rustikon-2025) | [Event Page](https://www.rustikon.dev/) | Closes 2024-10-13 | Warsaw, PL | Event 2025-03-26
 
 If you are an event organizer hoping to expand the reach of your event, please submit a link to the website through a [PR to TWiR](https://github.com/rust-lang/this-week-in-rust) or by reaching out on [X (formerly Twitter)](https://x.com/ThisWeekInRust) or [Mastodon](https://mastodon.social/@thisweekinrust)!
 


### PR DESCRIPTION
Following from #5976 ; adding this to the CFP section for TWIR 567. 