### PR TITLE
Add to TWiR 2024-10-16 new event: "Rust Hack and Learn" on 7. november

### DIFF
--- a/draft/2024-10-16-this-week-in-rust.md
+++ b/draft/2024-10-16-this-week-in-rust.md
@@ -187,6 +187,8 @@ Rusty Events between 2024-10-16 - 2024-11-13 🦀
     * [**Last Tuesday**](https://www.meetup.com/dallasrust/events/301585671/)
 * 2022-10-31 | Virtual (Nürnberg, DE) | [Rust Nurnberg DE](https://www.meetup.com/rust-noris/)
     * [**Rust Nürnberg online**](https://www.meetup.com/rust-noris/events/300820274/)
+* 2024-11-07 | Virtual (Berlin, DE) | [OpenTechSchool Berlin](https://berline.rs/) + [Rust Berlin](https://www.meetup.com/rust-berlin/)
+    * [**Rust Hack and Learn**](https://meet.jit.si/RustHackAndLearnBerlin) | [**Mirror: Rust Hack n Learn Meetup**](https://www.meetup.com/rust-berlin/events/298633272/)
 
 ### Africa
 * 2024-11-02 | Kampala, UG | [Rust Circle Kampala](https://www.eventbrite.com/o/rust-circle-kampala-65249289033/)


### PR DESCRIPTION
This adds a new virtual event to TWiR 2024-10-16: "Rust Hack and Learn" on 7. november