### PR TITLE
Correct 2024-10-16-this-week-in-rust.md to show title for article properly

### DIFF
--- a/content/2024-10-16-this-week-in-rust.md
+++ b/content/2024-10-16-this-week-in-rust.md
@@ -52,7 +52,7 @@ and just ask the editors to select the category.
 * [Rethinking Builders… with Lazy Generics](https://geo-ant.github.io/blog/2024/rust-rethinking-builders-lazy-generics/)
 * [IPC in Rust](https://pranitha.rs/posts/rust-ipc-ping-pong/)
 * [Serde Trait - Part 3: Deserialization](https://voelklmichael.github.io/Blog/serde-trait-part3.html)
-* [Memory for Nothing: Why Vec\<usize> is (probably) a bad idea](https://pwy.io/posts/memory-for-nothing/)
+* [Memory for Nothing: Why Vec&lt;usize&gt; is (probably) a bad idea](https://pwy.io/posts/memory-for-nothing/)
 * [Upgrade the Logging in your Rust Tests](https://tylerjw.dev/posts/20241012-rust-logging-in-tests/)
 * [Nine Rules for Running Rust on Embedded Systems](https://medium.com/towards-data-science/nine-rules-for-running-rust-on-embedded-systems-b0c247ee877e)
 * [Why Rust is taking the data engineering world by storm](https://kerkour.com/rust-data-engineering)

--- a/content/2024-10-16-this-week-in-rust.md
+++ b/content/2024-10-16-this-week-in-rust.md
@@ -52,7 +52,7 @@ and just ask the editors to select the category.
 * [Rethinking Builders… with Lazy Generics](https://geo-ant.github.io/blog/2024/rust-rethinking-builders-lazy-generics/)
 * [IPC in Rust](https://pranitha.rs/posts/rust-ipc-ping-pong/)
 * [Serde Trait - Part 3: Deserialization](https://voelklmichael.github.io/Blog/serde-trait-part3.html)
-* [Memory for Nothing: Why Vec is (probably) a bad idea](https://pwy.io/posts/memory-for-nothing/)
+* [Memory for Nothing: Why Vec\<usize> is (probably) a bad idea](https://pwy.io/posts/memory-for-nothing/)
 * [Upgrade the Logging in your Rust Tests](https://tylerjw.dev/posts/20241012-rust-logging-in-tests/)
 * [Nine Rules for Running Rust on Embedded Systems](https://medium.com/towards-data-science/nine-rules-for-running-rust-on-embedded-systems-b0c247ee877e)
 * [Why Rust is taking the data engineering world by storm](https://kerkour.com/rust-data-engineering)


### PR DESCRIPTION
The "Memory for Nothing" title said "Why Vec is (probably) a bad idea," however, it should say "Why Vec\<usize> is (probably) a bad idea. I assume this happened due to \<usize> being in the form of an html opening tag, and someone didn't escape it.