### PR TITLE
TWiR 571 - Add Meilisearch 1.11

### DIFF
--- a/draft/2024-10-30-this-week-in-rust.md
+++ b/draft/2024-10-30-this-week-in-rust.md
@@ -37,6 +37,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [Meilisearch 1.11 - AI-powered search & federated search improvements](https://www.meilisearch.com/blog/meilisearch-1-11)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
Hi TWIR maintainers!

This PR adds a link to [Meilisearch 1.11 release notes](https://www.meilisearch.com/blog/meilisearch-1-11) in the next issue (571).

Thank you!