### PR TITLE
Add in streaming audio decoding blog entry

### DIFF
--- a/draft/2024-11-06-this-week-in-rust.md
+++ b/draft/2024-11-06-this-week-in-rust.md
@@ -39,6 +39,8 @@ and just ask the editors to select the category.
 
 ### Observations/Thoughts
 
+* [Streaming Audio APIs in Rust pt. 3: Audio Decoding](https://xd009642.github.io/2024/11/04/streaming-audio-APIs-audio-decoding.html)
+
 ### Rust Walkthroughs
 
 ### Research


### PR DESCRIPTION
Adds in part 3 of a series about making streaming audio APIs in rust focusing on audio decoding and resampling. 