### PR TITLE
Add link to Maelstrom blog post about spawning processes on Linux

### DIFF
--- a/draft/2024-11-13-this-week-in-rust.md
+++ b/draft/2024-11-13-this-week-in-rust.md
@@ -39,6 +39,8 @@ and just ask the editors to select the category.
 
 ### Observations/Thoughts
 
+* [Spawning Processes in Linux](https://maelstrom-software.com/blog/spawning-processes-on-linux/)
+
 ### Rust Walkthroughs
 
 ### Research


### PR DESCRIPTION
This blog contains a Rust focused look at using the Linux API for spawning processes.