### PR TITLE
Add in streaming audio pt 4 blogpost

### DIFF
--- a/draft/2024-12-04-this-week-in-rust.md
+++ b/draft/2024-12-04-this-week-in-rust.md
@@ -39,6 +39,8 @@ and just ask the editors to select the category.
 
 ### Observations/Thoughts
 
+* [Streaming Audio APIs in Rust pt. 4: The Model](https://xd009642.github.io/2024/12/03/streaming-audio-APIs-the-model.html)
+
 ### Rust Walkthroughs
 
 ### Research


### PR DESCRIPTION
Adds in part 4 of a series about making streaming audio APIs in rust focusing on the stub for an AI model in the service and using it.