### PR TITLE
Add link to 2024 annual survey

### DIFF
--- a/draft/2024-12-04-this-week-in-rust.md
+++ b/draft/2024-12-04-this-week-in-rust.md
@@ -31,6 +31,8 @@ and just ask the editors to select the category.
 
 ### Official
 
+- [2024 Annual Rust Survey](https://blog.rust-lang.org/2024/12/05/annual-survey-2024-launch.html)
+
 ### Foundation
 
 ### Newsletters

--- a/draft/2024-12-04-this-week-in-rust.md
+++ b/draft/2024-12-04-this-week-in-rust.md
@@ -31,7 +31,7 @@ and just ask the editors to select the category.
 
 ### Official
 
-- [2024 Annual Rust Survey](https://blog.rust-lang.org/2024/12/05/annual-survey-2024-launch.html)
+- [2024 Annual State of Rust Survey](https://blog.rust-lang.org/2024/12/05/annual-survey-2024-launch.html)
 
 ### Foundation
 


### PR DESCRIPTION
Would be nice if it could still get to this week's TWiR, but if it slips into next week, no problem.