### PR TITLE
Add "Breakage! in the Cargo.toml" post

### DIFF
--- a/draft/2024-12-04-this-week-in-rust.md
+++ b/draft/2024-12-04-this-week-in-rust.md
@@ -38,6 +38,7 @@ and just ask the editors to select the category.
 ### Project/Tooling Updates
 
 ### Observations/Thoughts
+- [Breakage! in the Cargo.toml — How Rust Package Features Work (And Break)](https://predr.ag/blog/breakage-in-the-cargo-toml-how-rust-package-features-work/)
 
 ### Rust Walkthroughs
 


### PR DESCRIPTION
It's a feature highlight post for the newly-released `cargo-semver-checks v0.37`, which is now able to check package manifests for breakage.