### PR TITLE
Add Rust university course exercises

### DIFF
--- a/draft/2024-12-18-this-week-in-rust.md
+++ b/draft/2024-12-18-this-week-in-rust.md
@@ -47,6 +47,8 @@ and just ask the editors to select the category.
 
 ### Miscellaneous
 
+- [Rust exercises from an university course](https://github.com/Kobzol/rust-course-fei/tree/main/lessons)
+
 ## Crate of the Week
 
 <!-- COTW goes here -->


### PR DESCRIPTION
I shared a set of [Rust exercises](https://github.com/Kobzol/rust-course-fei/tree/main/lessons) (from a Rust university course that I teach) on [Reddit](https://www.reddit.com/r/rust/comments/1hgytpx/rust_university_course_exercises/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button), and it seems like it gathered some attention, so I thought that I might as well also put it into TWiR.

It doesn't have a blog post or a website or anything though, just a GitHub repository link to the exercise - if you don't think it's appropriate for TWiR, feel free to close the PR.