### PR TITLE
ci: update GitHub Actions

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -2,12 +2,12 @@ name: Correctness Checks
 on: [push, pull_request]
 jobs:
   Run-Markdown-Checks:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install Python dependencies
-        uses: py-actions/py-dependency-install@v3
+        uses: py-actions/py-dependency-install@v4
         with:
           path: "tools/requirements.txt"
           update-pip: "false"


### PR DESCRIPTION
ubuntu-20 will be removed in April. See the announcement [here](https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#ubuntu-20-image-is-closing-down).

I also updated all the GitHub Actions used.