### PR TITLE
add device driver walkthrough

### DIFF
--- a/draft/2025-01-15-this-week-in-rust.md
+++ b/draft/2025-01-15-this-week-in-rust.md
@@ -41,6 +41,8 @@ and just ask the editors to select the category.
 
 ### Rust Walkthroughs
 
+[Creating an embedded device driver in Rust](https://blog.mjolner.tech/device-driver-rust/)
+
 ### Research
 
 ### Miscellaneous

--- a/draft/2025-01-15-this-week-in-rust.md
+++ b/draft/2025-01-15-this-week-in-rust.md
@@ -41,7 +41,7 @@ and just ask the editors to select the category.
 
 ### Rust Walkthroughs
 
-[Creating an embedded device driver in Rust](https://blog.mjolner.tech/device-driver-rust/)
+* [Creating an embedded device driver in Rust](https://blog.mjolner.tech/device-driver-rust/)
 
 ### Research
 


### PR DESCRIPTION
Adds link to my blog post on writing a device driver for an embedded systems touch sensor chip using the `device-driver` crate