### PR TITLE
Add streaming audio blogpost

### DIFF
--- a/draft/2025-01-22-this-week-in-rust.md
+++ b/draft/2025-01-22-this-week-in-rust.md
@@ -39,6 +39,8 @@ and just ask the editors to select the category.
 
 ### Observations/Thoughts
 
+* [Streaming Audio APIs in Rust pt.5: The Axum Server](https://xd009642.github.io/2025/01/20/streaming-audio-APIs-the-axum-server.html)
+
 ### Rust Walkthroughs
 
 ### Research


### PR DESCRIPTION
Another entry in the series on making bidirectional audio streaming APIs in Rust. This one handles setting up the axum server code to receive websocket connections and integrating with the work from the previous entries. 