### PR TITLE
Meetup json output, minor fixes

### DIFF
--- a/tools/events/meetup-automation/event.py
+++ b/tools/events/meetup-automation/event.py
@@ -82,6 +82,18 @@ class Event:
     self.name = self.name.strip()
     self.organizer_name = self.organizer_name.strip()
 
+  def to_dict(self) -> dict:
+    """ Method for serializing to a dict which can be further serialized to json """
+    return {
+      "name": self.name,
+      "location": self.location.to_str(),
+      "date": self.date.strftime("%Y-%m-%d"),
+      "url": self.url,
+      "virtual": self.virtual,
+      "organizer_name": self.organizer_name,
+      "organizer_url": self.organizer_url
+    }
+
   def to_markdown_string(self) -> str:
     location = f"Virtual ({self.location.to_str()})" if self.virtual else self.location.to_str()
 

--- a/tools/events/meetup-automation/event.py
+++ b/tools/events/meetup-automation/event.py
@@ -1,4 +1,5 @@
 import logging
+import string
 from dataclasses import dataclass
 from datetime import datetime
 
@@ -11,6 +12,32 @@ class Location:
   city: None | str
   state: None | str
   country: None | str
+
+  def __post_init__(self):
+    """ Normalize our location strings here """
+    if self.city:
+      # capwords does the "heavy lifting" of our formatting here https://docs.python.org/3/library/string.html#string.capwords
+      self.city = string.capwords(self.city)
+    else:
+      self.city = None
+
+    if self.state:
+      self.state = self.state.strip()
+      self.state = self.state.upper()
+    else:
+      self.state = None
+
+    if self.country:
+      self.country = self.country.strip()
+      self.country = self.country.upper()
+    else:
+      self.country = None
+
+    if self.country == "GB":
+      # looks like in GB meetup considers part of the post code as the "state", which is not a common way to write
+      # locations in GB (or that's my understanding at least)
+      self.state = None
+
 
   def fields_present(self) -> int:
     """ Check how many fields are present, used to determine which Location has more information when comparing """
@@ -29,13 +56,13 @@ class Location:
     s = ''
 
     if self.city:
-      s += self.city.lower().capitalize()
+      s += self.city
     if self.state:
       s += ', '
-      s += self.state.upper()
+      s += self.state
     if self.country:
       s += ', '
-      s += self.country.upper()
+      s += self.country
 
     return s
 
@@ -49,6 +76,11 @@ class Event:
   virtual: bool
   organizer_name: str
   organizer_url: str
+
+  def __post_init__(self):
+    """ Normalize the event data here """
+    self.name = self.name.strip()
+    self.organizer_name = self.organizer_name.strip()
 
   def to_markdown_string(self) -> str:
     location = f"Virtual ({self.location.to_str()})" if self.virtual else self.location.to_str()

--- a/tools/events/meetup-automation/main.py
+++ b/tools/events/meetup-automation/main.py
@@ -4,6 +4,7 @@
 # print to console / output to file formatted markdown
 
 import argparse
+import json
 import logging
 from typing import List
 
@@ -48,8 +49,13 @@ def main():
     # Group by virtual or by continent.
     events = group_virtual_continent(events)
 
-    # Output Sorted Event List.
-    output_to_screen(events)
+    # if json is specified, output as json. Otherwise print in a nice TWIR-formatted way
+    if args.json:
+        # convert our events to a json-friendly format
+        formatted = {continent: [event.to_dict() for event in event_list] for continent, event_list in events.items()}
+        print(json.dumps(formatted))
+    else:
+        output_to_screen(events)
 
 
 def parse_args() -> argparse.Namespace:
@@ -57,6 +63,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("-d", "--debug", action="store_true", dest="debug", help="Enable debug logging")
     parser.add_argument("-g", "--groups", action="store", type=str, dest="groups_file", required=True, help="File with a JSON array of meetup group URLS")
     parser.add_argument("-w", "--weeks", action="store", type=int, dest="weeks", default=5, help="Number of weeks to search for events from, starting next Wednesday")
+    parser.add_argument("-j", "--json", action="store_true", dest="json", help="Output events as JSON rather than TWIR-formatted")
 
     return parser.parse_args()
 


### PR DESCRIPTION
This fixes some of the event location capitalization issues. The meetup API returns strings like "San francisco", so this fix will format these things a bit more correctly. Also in GB part of the postal code was used as the state, this is ignored now. Additionally, the meetup API returns an empty string if a part of a location is missing, which we now switch to `None`.

This also adds a way to output the events as json so they can be used in further automation. Currently we're just merging the lists together manually, having a better output format to use will let us create other tools to merge the lists together and save us some time.

Change was tested manually, example json partial output:
```
{"Virtual": [{"name": "Indy.rs - with Social Distancing", "location": "Indianapolis, IN, US", "date": "2025-02-05", "url": "https://www.meetup.com/indyrs/events/302031658", "virtual": true, "organizer_name": "Indy Rust", "organizer_url": "https://www.meetup.com/indyrs/events/"}, ...
```