### PR TITLE
Add nutype 0.6.0 to 2025-02-12-this-week-in-rust.md

### DIFF
--- a/draft/2025-02-12-this-week-in-rust.md
+++ b/draft/2025-02-12-this-week-in-rust.md
@@ -37,6 +37,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [Nutype 0.6.0 - newtype with guarantees supports const functions now](https://github.com/greyblake/nutype/releases/tag/v0.6.0)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
## Changes

- Create `2025-02-12-this-week-in-rust.md` from `DRAFT_TEMPLATE`
- Add note about nutype 0.6.0 release