### PR TITLE
Add Meilisearch 1.13

### DIFF
--- a/draft/2025-02-19-this-week-in-rust.md
+++ b/draft/2025-02-19-this-week-in-rust.md
@@ -38,6 +38,7 @@ and just ask the editors to select the category.
 ### Project/Tooling Updates
 
 - [Towards Practical Formal Verification for a General-Purpose OS in Rust](https://asterinas.github.io/2025/02/13/towards-practical-formal-verification-for-a-general-purpose-os-in-rust.html)
+* [Meilisearch 1.3 - AI-powered search stabilization, remote federated search, and dumpless version upgrades](https://www.meilisearch.com/blog/meilisearch-1-13)
 
 ### Observations/Thoughts
 

--- a/draft/2025-02-19-this-week-in-rust.md
+++ b/draft/2025-02-19-this-week-in-rust.md
@@ -39,7 +39,6 @@ and just ask the editors to select the category.
 ### Project/Tooling Updates
 * [Towards Practical Formal Verification for a General-Purpose OS in Rust](https://asterinas.github.io/2025/02/13/towards-practical-formal-verification-for-a-general-purpose-os-in-rust.html)
 * [Meilisearch 1.3 - AI-powered search stabilization, remote federated search, and dumpless version upgrades](https://www.meilisearch.com/blog/meilisearch-1-13)
-* [Towards Practical Formal Verification for a General-Purpose OS in Rust](https://asterinas.github.io/2025/02/13/towards-practical-formal-verification-for-a-general-purpose-os-in-rust.html)
 * [Slack Your REST Client with a couple of Serde Tricks](https://ideas.reify.ing/en/blog/rest-client-slack/)
 * [Welcome, Cot: the Rust web framework for lazy developers](https://mackow.ski/blog/cot-the-rust-web-framework-for-lazy-developers/)
 


### PR DESCRIPTION
Hi TWIR maintainers!

This PR adds a link to [Meilisearch 1.13 release notes](https://www.meilisearch.com/blog/meilisearch-1-13) in the next issue.

Thank you!