### PR TITLE
fix(587): Fix broken link due to brackets

### DIFF
--- a/content/2025-02-19-this-week-in-rust.md
+++ b/content/2025-02-19-this-week-in-rust.md
@@ -49,7 +49,7 @@ and just ask the editors to select the category.
 * [Part 6b: The Types of Lowered Rows](https://thunderseethe.dev/posts/lowering-rows-ty/)
 * [eserde: Don't stop at the first deserialization error](https://mainmatter.com/blog/2025/02/13/eserde/)
 * [Smuggling arbitrary data through an emoji](https://paulbutler.org/2025/smuggling-arbitrary-data-through-an-emoji/)
-* [Why I'm Writing a Scheme Implementation in 2025](https://maplant.com/2025-02-17-Why-I'm-Writing-a-Scheme-Implementation-in-2025-(The-Answer-is-Async-Rust).html)
+* [Why I'm Writing a Scheme Implementation in 2025](https://maplant.com/2025-02-17-Why-I'm-Writing-a-Scheme-Implementation-in-2025-%28The-Answer-is-Async-Rust%29.html)
 * [What's in a ring buffer? And using them in Rust](https://ntietz.com/blog/whats-in-a-ring-buffer)
 * [How Rust & Embassy Shine on Embedded Devices (Part 1): Insights for Everyone and Nine Rules for Embedded Programmers](https://medium.com/@carlmkadie/how-rust-embassy-shine-on-embedded-devices-part-1-9f4911c92007)
 * [Should I pin my Rust toolchain version?](https://swatinem.de/blog/rust-toolchain/)


### PR DESCRIPTION
The URL contains brackets, i.e., `()`, which seem to throw off the Markdown-to-HTML rendering, leading to the link being broken.

This commit simply URL-encodes the brackets, resulting in a link that works and is not ambiguous w.r.t. Markdown-to-HTML rendering.