### PR TITLE
Add announcing mocktail blog post for 2025-03-19

### DIFF
--- a/draft/2025-03-19-this-week-in-rust.md
+++ b/draft/2025-03-19-this-week-in-rust.md
@@ -36,6 +36,7 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
+* [Announcing mocktail: HTTP & gRPC server mocking for Rust](https://danclark.io/blog/announcing-mocktail/)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
This PR adds a link to blog post [Announcing mocktail: HTTP & gRPC server mocking for Rust](https://danclark.io/blog/announcing-mocktail/), a new server mocking library for Rust that I'm building.

Thanks!