### PR TITLE
vendoring c/cpp dependencies in rust

### DIFF
--- a/draft/2025-03-26-this-week-in-rust.md
+++ b/draft/2025-03-26-this-week-in-rust.md
@@ -41,6 +41,8 @@ and just ask the editors to select the category.
 
 ### Rust Walkthroughs
 
+* [Vendoring C/C++ Dependencies in Rust](https://blog.veeso.dev/blog/en/vendoring-c-cpp-dependencies-in-rust/)
+
 ### Research
 
 ### Miscellaneous


### PR DESCRIPTION
added https://blog.veeso.dev/blog/en/vendoring-c-cpp-dependencies-in-rust/