### PR TITLE
Embedding shared objects in Rust

### DIFF
--- a/draft/2025-04-02-this-week-in-rust.md
+++ b/draft/2025-04-02-this-week-in-rust.md
@@ -43,6 +43,8 @@ and just ask the editors to select the category.
 
 ### Observations/Thoughts
 
+* [Embedding shared objects in Rust](https://blog.veeso.dev/blog/en/embedding-shared-objects-in-rust/)
+
 ### Rust Walkthroughs
 * [Solving the ABA Problem in Rust with Hazard Pointers](https://minikin.me/blog/solving-the-aba-problem-in-rust-hazard-pointers)
 * [Building a CoAP application on Ariel OS](https://christian.amsuess.com/blog/website/2025-03-27_ariel_coap/)


### PR DESCRIPTION
Added https://blog.veeso.dev/blog/en/embedding-shared-objects-in-rust/