### PR TITLE
Add article to TWIR draft

### DIFF
--- a/draft/2025-04-09-this-week-in-rust.md
+++ b/draft/2025-04-09-this-week-in-rust.md
@@ -38,6 +38,7 @@ and just ask the editors to select the category.
 ### Project/Tooling Updates
 
 ### Observations/Thoughts
+* [Replicating state changes across language barriers with Rust, UniFFI, and proc macros](https://www.tantaluspath.com/tech/rust_to_swift_state_syncing/)
 
 ### Rust Walkthroughs
 


### PR DESCRIPTION
Adds an article I wrote about how Serendipity Systems LLC uses Rust as the primary language business logic language. Is this in the right section? It might fit better under walkthroughs section, but I'll defer to maintainers on which section is best.