### PR TITLE
Add zxc proxy

### DIFF
--- a/draft/2025-04-09-this-week-in-rust.md
+++ b/draft/2025-04-09-this-week-in-rust.md
@@ -36,7 +36,7 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
-* [zxc](https://github.com/hail-hydrant/zxc) A Terminal based mitm proxy written in rust with Tmux and Vim as user interface.
+* [zxc](https://github.com/hail-hydrant/zxc): A Terminal based mitm proxy written in rust with Tmux and Vim as user interface.
 
 ### Observations/Thoughts
 

--- a/draft/2025-04-09-this-week-in-rust.md
+++ b/draft/2025-04-09-this-week-in-rust.md
@@ -36,7 +36,7 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
-* [zxc](https://github.com/hail-hydrant/zxc): A Terminal based mitm proxy written in rust with Tmux and Vim as user interface.
+* [zxc: A Terminal based mitm proxy written in rust with Tmux and Vim as user interface](https://hail-hydrant.github.io/zxc/)
 
 ### Observations/Thoughts
 

--- a/draft/2025-04-09-this-week-in-rust.md
+++ b/draft/2025-04-09-this-week-in-rust.md
@@ -36,6 +36,7 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
+* [zxc](https://github.com/hail-hydrant/zxc) A Terminal based mitm proxy written in rust with Tmux and Vim as user interface.
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
Add [zxc](https://github.com/hail-hydrant/zxc) A Terminal based mitm proxy written in rust with Tmux and Vim as user interface to the tooling section