### PR TITLE
Add Meilisearch 1.14

### DIFF
--- a/draft/2025-04-16-this-week-in-rust.md
+++ b/draft/2025-04-16-this-week-in-rust.md
@@ -40,6 +40,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [Meilisearch 1.14 - composite embedders, embedding cache, granular filterable attributes, and batch document retrieval by ID](https://www.meilisearch.com/blog/meilisearch-1-14)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
Hi TWIR maintainers!

This PR adds a link to [Meilisearch 1.14 release notes](https://www.meilisearch.com/blog/meilisearch-1-14) in the next issue.

Thank you!