### PR TITLE
Add "Rust resources" to TWIR draft

### DIFF
--- a/draft/2025-04-16-this-week-in-rust.md
+++ b/draft/2025-04-16-this-week-in-rust.md
@@ -48,6 +48,8 @@ and just ask the editors to select the category.
 
 ### Miscellaneous
 
+* [Rust resources](https://ongardie.net/misc/rust/)
+
 ## Crate of the Week
 
 <!-- COTW goes here -->


### PR DESCRIPTION
I created this page of Rust resources this week and thought I'd share. I don't know if this is the kind of content you're looking for or how you'd categorize it.

If you'd like to disambiguate the "Rust resources" title, feel free to use "ongardie.net", "ongardie", "Diego Ongaro", or "Diego".

BTW, thanks for putting TWIR together. I've been reading it for years and have obviously recommended it on my page.