### PR TITLE
added blog about SIMD in zlib-rs

### DIFF
--- a/draft/2025-04-16-this-week-in-rust.md
+++ b/draft/2025-04-16-this-week-in-rust.md
@@ -43,6 +43,7 @@ and just ask the editors to select the category.
 ### Observations/Thoughts
 
 ### Rust Walkthroughs
+* [SIMD in zlib-rs (part 1): Autovectorization and target features](https://tweedegolf.nl/en/blog/153/simd-in-zlib-rs-part-1-autovectorization-and-target-features)
 
 ### Research
 


### PR DESCRIPTION
My colleage Folkert de Vries is writing a blog series explaining SIMD, using examples from zlib-rs. This blog, part 1, was published yesterday.