### PR TITLE
Add event: in-person 10 years of Rust 1.0 celebration in Berlin, DE

### DIFF
--- a/draft/2025-05-14-this-week-in-rust.md
+++ b/draft/2025-05-14-this-week-in-rust.md
@@ -257,6 +257,8 @@ Rusty Events between 2025-05-14 - 2025-06-11 🦀
     * [**RustWeek 2025**](https://rustweek.org)
 * 2025-05-14 | Reading, UK | [Reading Rust Workshop](https://www.meetup.com/reading-rust-workshop/events/)
     * [**Reading Rust Meetup**](https://www.meetup.com/reading-rust-workshop/events/305045447)
+* 2025-05-15 | Berlin, DE | [Rust Berlin](https://berline.rs/)
+    * [**10 years anniversary of Rust 1.0**](https://www.c-base.org/calendar/#view=month&date=2025-05-15&event=92df14e3-c21c-477a-a150-84be085ed411)
 * 2025-05-15 | Oslo, NO | [Rust Oslo](https://www.meetup.com/rust-oslo/events/)
     * [**Rust 10-year anniversary @ Appear**](https://www.meetup.com/rust-oslo/events/307427014)
 * 2025-05-16 | Amsterdam, NL | [RustNL](https://www.meetup.com/rust-amsterdam/events/)


### PR DESCRIPTION
Adding announcement for 2025-05-15 19:00 in Berlin at the c-base hackspace:


# Celebrating 10 years of Rust 1.0 in person at c-base Berlin

We are celebrating the 10 years anniversary of Rust 1.0!

In this event, we are going to meet, eat,
and attend the [international online celebration][1] together with many other local Rust interest groups.

Everybody is welcome! No matter if you are very
experienced in Rust or have never had contact with it before, please come join in and celebrate with us!

[1]: https://berline.rs/2025/05/15/celebrating-10-years-of-rust-10.html