### PR TITLE
Add link for update blogpost for CGP v0.4

### DIFF
--- a/draft/2025-05-14-this-week-in-rust.md
+++ b/draft/2025-05-14-this-week-in-rust.md
@@ -40,6 +40,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [CGP v0.4 is Here: Unlocking Easier Debugging, Extensible Presets, and More](https://contextgeneric.dev/blog/v0-4-0-release/)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
I'd like to add a link to the [v0.4 update blog post](https://contextgeneric.dev/blog/v0-4-0-release/) for context-generic programming.