### PR TITLE
Add stickup v0.2.0 to TWIR Updates section

### DIFF
--- a/content/2025-05-21-this-week-in-rust.md
+++ b/content/2025-05-21-this-week-in-rust.md
@@ -1,0 +1,47 @@
+# This Week in Rust 2025-05-21
+
+Hello and welcome to another issue of *This Week in Rust*! ❤️
+
+If you want to get involved with the Rust community, join us on [Discord](https://discord.gg/rust-lang) and check out the [Rust Community Calendar](https://calendar.rust-lang.org/)!
+
+---
+
+### Updates
+
+- [stickup v0.2.0](https://crates.io/crates/stickup) – Modular input framework for Rust devs. Includes HID and virtual device support, stable device identity, and real-time state snapshots. Built for overlays, sim gear, and tool integration.  
+  Source: [gitlab.com/belegrades/stickup-rs](https://gitlab.com/belegrades/stickup-rs)
+
+---
+
+### New Crates
+
+*(Add other new crate entries here if you're contributing multiple)*
+
+---
+
+### Articles, News, & Blog Posts
+
+*(You can leave this empty or add a link to a blog post or Ko-fi devlog if you like)*
+
+---
+
+### Call for Participation
+
+*(Can be left empty)*
+
+---
+
+### Jobs
+
+*(Leave this section unless you want to list something specific)*
+
+---
+
+### Rust in the Wild
+
+*(Optional stories of Rust being used in unique projects)*
+
+---
+
+Thanks for reading! 💙  
+– The Rust Community Team


### PR DESCRIPTION
This adds `stickup v0.2.0` to the Updates section of This Week in Rust for May 21, 2025.

**Crate**: https://crates.io/crates/stickup  
**Source**: https://gitlab.com/belegrades/stickup-rs  

StickUp is a modular input framework for Rust, supporting HID and virtual devices, persistent identity, and real-time state snapshots. Built for game overlays, sim gear, and developer tools.

Thanks for considering!