### PR TITLE
Add `Disable debuginfo to improve Rust compile times` blog post

### DIFF
--- a/draft/2025-05-21-this-week-in-rust.md
+++ b/draft/2025-05-21-this-week-in-rust.md
@@ -42,6 +42,8 @@ and just ask the editors to select the category.
 
 ### Observations/Thoughts
 
+* [Disable debuginfo to improve Rust compile times](https://kobzol.github.io/rust/rustc/2025/05/20/disable-debuginfo-to-improve-rust-compile-times.html)
+
 ### Rust Walkthroughs
 
 ### Research


### PR DESCRIPTION
https://kobzol.github.io/rust/rustc/2025/05/20/disable-debuginfo-to-improve-rust-compile-times.html