### PR TITLE
Fix perf table website only format issue

### DIFF
--- a/draft/2025-05-21-this-week-in-rust.md
+++ b/draft/2025-05-21-this-week-in-rust.md
@@ -183,6 +183,7 @@ Triage done by **@kobzol**.
 Revision range: [718ddf66..59372f2c](https://perf.rust-lang.org/?start=718ddf660e6a1802c39b4962cf7eaa4db57025ef&end=59372f2c81ba74554d9a71b12a4ed7f29adb33a2&absolute=false&stat=instructions%3Au)
 
 **Summary**:
+
 | (instructions:u)                   | mean  | range          | count |
 |:----------------------------------:|:-----:|:--------------:|:-----:|
 | Regressions ❌ <br /> (primary)    | 0.6%  | [0.1%, 1.8%]   | 25    |


### PR DESCRIPTION
The missing newline before the table causes formatting issues on the website (but not on GitHub).

Isn't having multiple slightly different rendering standards great? 🙃

![IMG_4544](https://github.com/user-attachments/assets/53314896-f24e-4aa9-b572-cf3f0997b363)
