### PR TITLE
Removed Markdown Ninja Announcement

### DIFF
--- a/content/2025-05-21-this-week-in-rust.md
+++ b/content/2025-05-21-this-week-in-rust.md
@@ -39,7 +39,6 @@ and just ask the editors to select the category.
 * [Celebrating Rust’s Birthday with Karen Tölva: Creator of Ferris the Rustacean!](https://rustfoundation.org/media/celebrating-rusts-birthday-with-karen-tolva-creator-of-ferris-the-rustacean/)
 
 ### Project/Tooling Updates
-* [Announcing Markdown Ninja: Open Source alternative to Substack, Mailchimp and Netlify](https://kerkour.com/announcing-markdown-ninja)
 * [Hypervisor as a Library](https://seiya.me/blog/hypervisor-as-a-library)
 
 ### Observations/Thoughts


### PR DESCRIPTION
(Rebased PR of #6669)

I don't believe that the announcement about Markdown Ninja is appropriate for TWiR, as the project isn't written in Rust (it's written in Go and Vue mostly), and it's not a project for use with Rust in any way that I can see. It's a cool-looking tool, I just don't feel like TWiR is the place for it.

If I'm mistaken and it does have something to do with Rust, please feel free to close this PR, but I can't see anything related to Rust.