### PR TITLE
security: Run zizmor on CI, resolve actions

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,5 +1,9 @@
 name: Correctness Checks
 on: [push, pull_request]
+
+permissions:
+  contents: read
+
 jobs:
   Run-Markdown-Checks:
     runs-on: ubuntu-24.04

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -6,6 +6,8 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Install Python dependencies
         uses: py-actions/py-dependency-install@v4
         with:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -6,6 +6,7 @@ permissions:
 
 jobs:
   Run-Markdown-Checks:
+    name: Run Markdown Checks
     runs-on: ubuntu-24.04
     steps:
       - name: checkout
@@ -13,7 +14,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install Python dependencies
-        uses: py-actions/py-dependency-install@v4
+        uses: py-actions/py-dependency-install@9c419aa98bfb42280bdae2b0a736befd9b01e3b1 # v4
         with:
           path: "tools/requirements.txt"
           update-pip: "false"


### PR DESCRIPTION
[zizmor](https://github.com/zizmorcore/zizmor) runs static analysis on GitHub actions with proposed remediation steps. I ran on the TWiR repo, and attached remediations for each:
* https://docs.zizmor.sh/audits/#artipacked `actions/checkout` will by default persist git configuration for the duration of the workflow, which is not necessary in this case.
* https://docs.zizmor.sh/audits/#excessive-permissions detects excessive permissions in workflows, both at the workflow level and individual job levels.
* https://docs.zizmor.sh/audits/#unpinned-uses Tag- or branch-pinned actions can be changed by the upstream repository, either by force-pushing over the tag or updating the branch.