### PR TITLE
Add Meilisearch 1.15

### DIFF
--- a/draft/2025-06-11-this-week-in-rust.md
+++ b/draft/2025-06-11-this-week-in-rust.md
@@ -40,6 +40,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [Meilisearch 1.15 - new typo tolerance setting, comparison operators for string filters, and improved support for Chinese](https://www.meilisearch.com/blog/meilisearch-1-15)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
Hi TWIR maintainers!

This PR adds a link to [Meilisearch 1.15 release notes](https://www.meilisearch.com/blog/meilisearch-1-15) in the next issue.

Thank you!