### PR TITLE
Add link to the release of Hypershell

### DIFF
--- a/draft/2025-06-18-this-week-in-rust.md
+++ b/draft/2025-06-18-this-week-in-rust.md
@@ -39,6 +39,7 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
+* [Hypershell: A Type-Level DSL for Shell-Scripting in Rust powered by Context-Generic Programming](https://contextgeneric.dev/blog/hypershell-release/)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
Hi! I'd like to submit a link to the release blog post for my project, [Hypershell](https://contextgeneric.dev/blog/hypershell-release/).