### PR TITLE
Add Rust Security Handbook link to Rust Walkthroughs

### DIFF
--- a/draft/2025-06-25-this-week-in-rust.md
+++ b/draft/2025-06-25-this-week-in-rust.md
@@ -46,7 +46,7 @@ and just ask the editors to select the category.
 
 ### Rust Walkthroughs
 
-* [The Complete Rust Security Handbook](https://yevh.github.io/rust-security-handbook/) – 10-chapter guide to type-safety, panic-proofing, overflow traps & Web3 security.
+* [The Complete Rust Security Handbook](https://yevh.github.io/rust-security-handbook/)
 
 ### Research
 

--- a/draft/2025-06-25-this-week-in-rust.md
+++ b/draft/2025-06-25-this-week-in-rust.md
@@ -46,6 +46,8 @@ and just ask the editors to select the category.
 
 ### Rust Walkthroughs
 
+* [The Complete Rust Security Handbook](https://yevh.github.io/rust-security-handbook/) – 10-chapter guide to type-safety, panic-proofing, overflow traps & Web3 security.
+
 ### Research
 
 ### Miscellaneous


### PR DESCRIPTION
Adds a bullet to the **Rust Walkthroughs** section linking to my 10-chapter *Complete Rust Security Handbook* (type-safety, panic-proofing, integer overflow traps, Web3 security). Feedback welcome - happy to tweak wording if needed. Thanks!