### PR TITLE
Add blog post for Programming Extensible Data Types in Rust with CGP, part 1 and 2

### DIFF
--- a/draft/2025-07-09-this-week-in-rust.md
+++ b/draft/2025-07-09-this-week-in-rust.md
@@ -40,6 +40,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [Programming Extensible Data Types in Rust with CGP, Part 1](https://contextgeneric.dev/blog/extensible-datatypes-part-1/) and [Part 2](https://contextgeneric.dev/blog/extensible-datatypes-part-2/)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
I'd like to add a link to the first two parts of my blog post series, [Programming Extensible Data Types in Rust with CGP](https://contextgeneric.dev/blog/extensible-datatypes-part-1/). Thanks!