### PR TITLE
Add project Rust eBooks Nightly

### DIFF
--- a/draft/2025-07-30-this-week-in-rust.md
+++ b/draft/2025-07-30-this-week-in-rust.md
@@ -39,6 +39,7 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
+* [Rust eBooks Nightly: always up-to-date Rust books in EPUB, AZW3, MOBI, PDF](https://artur-sulej.github.io/rust-ebooks/)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
This PR proposes adding **Rust eBooks Nightly** ([page](https://artur-sulej.github.io/rust-ebooks/), [repo](https://github.com/Artur-Sulej/rust-ebooks)).

**Rust eBooks Nightly** automatically rebuilds and publishes the latest versions of the official Rust books every day, making them available for download in popular eBook formats (EPUB, AZW3, MOBI, PDF). This tool makes it easy for anyone learning Rust to access the most up-to-date books for offline reading on any device.