### PR TITLE
Rust Foundation: RustConf 2025 is Almost Here - Register Now

### DIFF
--- a/draft/2025-07-30-this-week-in-rust.md
+++ b/draft/2025-07-30-this-week-in-rust.md
@@ -36,7 +36,7 @@ and just ask the editors to select the category.
 
 ### Foundation
 
-[RustConf 2025 is Almost Here — Register Now!](https://rustfoundation.org/media/rustconf-2025-is-almost-here-register-now/)
+* [RustConf 2025 is Almost Here — Register Now!](https://rustfoundation.org/media/rustconf-2025-is-almost-here-register-now/)
 
 ### Newsletters
 

--- a/draft/2025-07-30-this-week-in-rust.md
+++ b/draft/2025-07-30-this-week-in-rust.md
@@ -36,6 +36,8 @@ and just ask the editors to select the category.
 
 ### Foundation
 
+[RustConf 2025 is Almost Here — Register Now!](https://rustfoundation.org/media/rustconf-2025-is-almost-here-register-now/)
+
 ### Newsletters
 
 ### Project/Tooling Updates


### PR DESCRIPTION
Wasn't sure if there was a way to include a tracking link for the post and/or a message, but, if so, here they are:

Tracking Link: https://ti.to/rustconf/2025?source=twir


The Rust Foundation is pleased to present [RustConf 2025](https://rustconf.com/), taking place in Seattle and online from Sept 2-5. Expect immersive workshops, talks, activities, and conversations around where Rust is headed next.
Learn more in this blog post: https://rustfoundation.org/media/rustconf-2025-is-almost-here-register-now/ and register here: https://rustconf.com/register/