### PR TITLE
2025-08-13: Add newly released serde-ply

### DIFF
--- a/draft/2025-08-13-this-week-in-rust.md
+++ b/draft/2025-08-13-this-week-in-rust.md
@@ -41,7 +41,7 @@ and just ask the editors to select the category.
 ### Project/Tooling Updates
 * [TangleGuard: Software Architecture Monitoring exclusively for Rust](https://tangleguard.com/)
 * [redb v3.0.0 - pure Rust embedded key-value store](https://github.com/cberner/redb/releases/tag/v3.0.0)
-* [serde-ply - Modern serde (de)serializer for Ply files](https://github.com/ArthurBrussee/serde_ply)
+* [serde-ply - Modern serde (de)serializer for Ply files]([https://github.com/ArthurBrussee/serde_ply](https://www.reddit.com/r/rust/comments/1mp147s/serdeply_modern_speed_convenience_for_a_90s_format/))
 
 ### Observations/Thoughts
 * [Building an asynchronous FUSE Filesystem in Rust](https://r2cn.dev/blog/building-an-asynchronous-fuse-filesystem-in-rust)

--- a/draft/2025-08-13-this-week-in-rust.md
+++ b/draft/2025-08-13-this-week-in-rust.md
@@ -41,7 +41,7 @@ and just ask the editors to select the category.
 ### Project/Tooling Updates
 * [TangleGuard: Software Architecture Monitoring exclusively for Rust](https://tangleguard.com/)
 * [redb v3.0.0 - pure Rust embedded key-value store](https://github.com/cberner/redb/releases/tag/v3.0.0)
-* [serde-ply - Modern serde deserializer for Ply files](https://github.com/ArthurBrussee/serde_ply)
+* [serde-ply - Modern serde (de)serializer for Ply files](https://github.com/ArthurBrussee/serde_ply)
 
 ### Observations/Thoughts
 * [Building an asynchronous FUSE Filesystem in Rust](https://r2cn.dev/blog/building-an-asynchronous-fuse-filesystem-in-rust)

--- a/draft/2025-08-13-this-week-in-rust.md
+++ b/draft/2025-08-13-this-week-in-rust.md
@@ -39,7 +39,7 @@ and just ask the editors to select the category.
 ### Project/Tooling Updates
 * [TangleGuard: Software Architecture Monitoring exclusively for Rust](https://tangleguard.com/)
 * [redb v3.0.0 - pure Rust embedded key-value store](https://github.com/cberner/redb/releases/tag/v3.0.0)
-* [serde-ply - Modern serde (de)serializer for Ply files]([https://github.com/ArthurBrussee/serde_ply](https://www.reddit.com/r/rust/comments/1mp147s/serdeply_modern_speed_convenience_for_a_90s_format/))
+* [serde-ply - Modern serde (de)serializer for Ply files](https://www.reddit.com/r/rust/comments/1mp147s/serdeply_modern_speed_convenience_for_a_90s_format/))
 * [Bevy's Fifth Birthday](https://bevy.org/news/bevys-fifth-birthday/)
 * [warp v0.4](https://seanmonstar.com/blog/warp-v04/)
 

--- a/draft/2025-08-13-this-week-in-rust.md
+++ b/draft/2025-08-13-this-week-in-rust.md
@@ -41,6 +41,7 @@ and just ask the editors to select the category.
 ### Project/Tooling Updates
 * [TangleGuard: Software Architecture Monitoring exclusively for Rust](https://tangleguard.com/)
 * [redb v3.0.0 - pure Rust embedded key-value store](https://github.com/cberner/redb/releases/tag/v3.0.0)
+* [serde-ply - Modern serde deserializer for Ply files](https://github.com/ArthurBrussee/serde_ply)
 
 ### Observations/Thoughts
 * [Building an asynchronous FUSE Filesystem in Rust](https://r2cn.dev/blog/building-an-asynchronous-fuse-filesystem-in-rust)


### PR DESCRIPTION
I've just released serde-ply and would love it to be in TWIR. Not sure if link to the repo is good, to the release post (https://www.reddit.com/r/rust/comments/1mp147s/serdeply_modern_speed_convenience_for_a_90s_format/), or to the 0.2 release page (which isn't very informative, it's really 0.1 but I futzed with release-plz too much).

First time so hope this is the correct way to do it!