### PR TITLE
added Memory Analysis in Rust post

### DIFF
--- a/draft/2025-08-20-this-week-in-rust.md
+++ b/draft/2025-08-20-this-week-in-rust.md
@@ -49,6 +49,8 @@ and just ask the editors to select the category.
 
 ### Rust Walkthroughs
 
+* [Memory analysis in Rust](https://rumcajs.dev/posts/memory-analysis-in-rust/)
+
 ### Research
 
 ### Miscellaneous


### PR DESCRIPTION
Added https://rumcajs.dev/posts/memory-analysis-in-rust/ article to links. Hopefully, I chose the right category.