### PR TITLE
Add blog categorizing all the Rust tutorials

### DIFF
--- a/draft/2025-08-20-this-week-in-rust.md
+++ b/draft/2025-08-20-this-week-in-rust.md
@@ -52,7 +52,7 @@ and just ask the editors to select the category.
 ### Research
 
 ### Miscellaneous
-
+[All the Rust Tutorials](https://seanborg.tech/blog/huge-tutorial-list/)
 ## Crate of the Week
 
 <!-- COTW goes here -->


### PR DESCRIPTION
A Blog about gathering all the previous walkthroughs in TWIR and attempting to make them searchable.

Also a call for participation in finishing the categorization.


Wasn't 100% where to put this, the website is not built in Rust so I didn't put it in Observations/Thoughts, and although the blog is partly a call for participation its not a link to any specific issue, so I put it in miscellaneous.