### PR TITLE
Improve the Meetup script venue detection

### DIFF
--- a/tools/events/meetup-automation/generate_events_meetup.py
+++ b/tools/events/meetup-automation/generate_events_meetup.py
@@ -103,8 +103,7 @@ class TwirMeetupClient:
         # TODO: maybe move this validation somewhere else?
         for edge_kwargs in edges:
             if not edge_kwargs["node"]["venue"]:
-                logger.error(f"Event response missing venue: {edge_kwargs}")
-                continue
+                logger.info(f"Event response missing venue: {edge_kwargs}")
 
             events.append(RawGqlEvent(**edge_kwargs))
 

--- a/tools/events/meetup-automation/main.py
+++ b/tools/events/meetup-automation/main.py
@@ -105,11 +105,18 @@ def group_virtual_continent(event_list):
 
     for event in event_list:
         # Separates Events by Virtual or by Continent
-        key = "Virtual" if event.virtual else country_code_to_continent(event.location.country)
+        key = determine_event_key(event)
         separated_event_list.setdefault(key, []).append(event)
     
     return separated_event_list
 
+def determine_event_key(event: Event):
+    if event.virtual:
+        return "Virtual" 
+    elif event.no_venue:
+        return "No Venue"
+    else:
+        return country_code_to_continent(event.location.country)
 
 def remove_duplicate_events(events: List[Event]) -> List[Event]:
     # Identifies possible duplicate Events within Event List.


### PR DESCRIPTION
Some Meetup events don't have a specified venue. These aren't always virtual or hybrid — organizers may put venue details only in the event description, so it's the editor's job to read the description and decide which section the event belongs in.

Previously the script treated missing-venue events as errors; editors had to inspect error logs, review the event, and write the markdown manually. This PR reduces that work by treating events with no venue as normal events and favoring the group's location over the event location when determining the grouping key. Generated draft Markdown now includes a new "No Venue" section for those events so editors can find and handle them more easily.