### PR TITLE
Add `Combining struct literal syntax with read-only field access` blog post

### DIFF
--- a/draft/2025-09-03-this-week-in-rust.md
+++ b/draft/2025-09-03-this-week-in-rust.md
@@ -47,6 +47,8 @@ and just ask the editors to select the category.
 
 ### Observations/Thoughts
 
+* [Combining struct literal syntax with read-only field access](https://kobzol.github.io/rust/2025/09/01/combining-struct-literal-syntax-with-read-only-field-access.html)
+
 ### Rust Walkthroughs
 
 ### Research


### PR DESCRIPTION
https://kobzol.github.io/rust/2025/09/01/combining-struct-literal-syntax-with-read-only-field-access.html