### PR TITLE
Add `Adding #[derive(From)] to Rust` blog post

### DIFF
--- a/draft/2025-09-03-this-week-in-rust.md
+++ b/draft/2025-09-03-this-week-in-rust.md
@@ -47,6 +47,8 @@ and just ask the editors to select the category.
 
 ### Observations/Thoughts
 
+* [Adding derive(From) to Rust](https://kobzol.github.io/rust/2025/09/02/adding-derive-from-to-rust.html)
+
 ### Rust Walkthroughs
 
 ### Research


### PR DESCRIPTION
https://kobzol.github.io/rust/2025/09/02/adding-derive-from-to-rust.html