### PR TITLE
Add rkik v1.0.0 release to Project/Tooling Updates

### DIFF
--- a/draft/2025-09-03-this-week-in-rust.md
+++ b/draft/2025-09-03-this-week-in-rust.md
@@ -44,6 +44,7 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
+* [rkik v1.0.0](https://github.com/aguacero7/rkik) - A stateless NTPv4/v6 inspection CLI in Rust, handles JSON output, continuous monitoring flags, and library integration. Just like dig or ping, but for NTP.
 
 ### Observations/Thoughts
 

--- a/draft/2025-09-03-this-week-in-rust.md
+++ b/draft/2025-09-03-this-week-in-rust.md
@@ -44,7 +44,7 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
-* [rkik v1.0.0](https://github.com/aguacero7/rkik) - A stateless NTPv4/v6 inspection CLI in Rust, handles JSON output, continuous monitoring flags, and library integration. Just like dig or ping, but for NTP.
+* [rkik v1.0.0 - stateless NTPv4/v6 inspection CLI in Rust](https://github.com/aguacero7/rkik)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
Hi, I'd like to announce the first stable release of **rkik** (Rusty Klock Inspection Kit).

rkik is a stateless NTP inspection tool written in Rust - think of it as `dig` for NTP.  
It lets you in a simple way query and compare NTP servers without running a daemon or requiring root, with JSON output for automation.

The new v1.0.0 release brings:
- JSON output modes (`--json`, `--pretty`, `--short`)
- Continuous monitoring flags (`--count`, `--interval`, `--infinite`)
- A clean library API, so rkik can also be used as a crate
- Refactored codebase, better error messages
- Port specification integration `ip.server.ntp:<port>`

It already has +2k downloads on [crates.io](https://crates.io/crates/rkik)

Roadmap: upcoming support for **NTS (Network Time Security)** and **PTP (Precision Time Protocol)** in v2.0.

Thanks for considering!
