### PR TITLE
Sync perf-triage with latest rustc-perf version

### DIFF
--- a/draft/2025-09-17-this-week-in-rust.md
+++ b/draft/2025-09-17-this-week-in-rust.md
@@ -151,7 +151,7 @@ If you are an event organizer hoping to expand the reach of your event, please s
 
 ### Rust Compiler Performance Triage
 
-Difficult week to interpret, because a positive change in [#145910](https://github.com/rust-lang/rust/pull/145910) skewes the results more negative in our benchmarks. Overall result is probably still slightly negative, because there's more work from added features. On the other hand, we also have a nice improvement in reducing the number of query dependencies in compiler's tracking system in [#145186](https://github.com/rust-lang/rust/pull/145186).
+Difficult week to interpret, because a positive change in [#145910](https://github.com/rust-lang/rust/pull/145910) performs a bit worse in our benchmarks than it would in the real world. Overall result is probably still slightly negative, because there's more work from added features. On the other hand, we also have a nice improvement in reducing the number of query dependencies in compiler's incremental system in [#145186](https://github.com/rust-lang/rust/pull/145186).
 
 Triage done by **@panstromek**.
 Revision range: [f13ef0d7..52618eb3](https://perf.rust-lang.org/?start=f13ef0d75d834c826c9479a5d244bcfb9891df45&end=52618eb338609df44978b0ca4451ab7941fd1c7a&absolute=false&stat=instructions%3Au)
@@ -170,7 +170,7 @@ Revision range: [f13ef0d7..52618eb3](https://perf.rust-lang.org/?start=f13ef0d75
 1 Regression, 1 Improvement, 6 Mixed; 3 of them in rollups
 36 artifact comparisons made in total
 
-[Full report here](https://github.com/rust-lang/rustc-perf/blob/e0539d750ab104f1bd884f60a21a1e0355981d20/triage/2025/2025-09-15.md)
+[Full report here](https://github.com/rust-lang/rustc-perf/blob/888c0a24417c3883373ae0844f760f8300176b90/triage/2025/2025-09-15.md)
 
 ### [Approved RFCs](https://github.com/rust-lang/rfcs/commits/master)
 


### PR DESCRIPTION
I got some suggestions in the review in rustc-perf repo, so the final text and full document link has changed.
