### PR TITLE
remove Dockerfile platform and update to latest python

### DIFF
--- a/publishing/Dockerfile
+++ b/publishing/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.8.16-slim
+FROM python:3.13.7-slim
 
 # Must run from base TWIR directory... makefile takes care of this.
 WORKDIR /usr/twir


### PR DESCRIPTION
The platform flag is likely unnecessary anymore as most docker images now publish multiple platforms to use. When running this on a relatively new mac (i.e. an M1), this will cause the code to go through docker hypervisor and the rosetta virtualization platform. This should in theory make things a little faster if you are working on a mac.

Also, [python 3.8 is now EOL](https://devguide.python.org/versions/), so this updates the version to the latest stable release.