### PR TITLE
fix: issue 6879 - to allow Firefox offline translation tool

### DIFF
--- a/themes/rusted/templates/base.html
+++ b/themes/rusted/templates/base.html
@@ -1,5 +1,5 @@
-<!DOCTYPE html>
-<html>
+<!doctype html>
+<html lang="en">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width" />


### PR DESCRIPTION
this was an easy fix: adding <html lang="en"> to https://github.com/rust-lang/this-week-in-rust/blob/master/themes/rusted/templates/base.html -- all pages should inherit this afterwards.

I have run the Makefile and Docker environment to see the tag correctly applied. Someone using Firefox in another lang: could you please confirm thir has the intended behavior? 