### PR TITLE
Add genedex crate to draft for next issue

### DIFF
--- a/draft/2025-10-01-this-week-in-rust.md
+++ b/draft/2025-10-01-this-week-in-rust.md
@@ -45,6 +45,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [genedex: A Small and Fast FM-Index for Rust](https://github.com/feldroop/genedex)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
I created this library and would like to share it with the community. I also created a benchmark of all existing Rust implementations of the same data structure. Do you think it makes sense to also include that benchmark in the Observations/Thoughts or even Research category? You can find it [here](https://github.com/feldroop/rust-fmindex-benchmark). Or better leave it at a single entry and let people find the benchmark on their own via the README of the library?