### PR TITLE
Add aladin lite astronomical sky viewer to projects

### DIFF
--- a/draft/2025-10-01-this-week-in-rust.md
+++ b/draft/2025-10-01-this-week-in-rust.md
@@ -45,7 +45,7 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
-* [Aladin Lite - navigate into TBs of astronomical data coming from various space missions](https://github.com/cds-astro/aladin-lite)
+* [Aladin Lite - navigate into TBs of astronomical data coming from various space missions](https://aladin.cds.unistra.fr/AladinLite/doc/)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
Hello,

I would like to know if it is possible to mention the project [Aladin Lite](https://github.com/cds-astro/aladin-lite) in the week in Rust. It is a scientific web application to view TBs of astronomical data in the sky coming from many spatial missions (Hubble, JWST, Vera Rubin and others). It heavily uses Rust for the rendering part. It offers a JS API wrapping a Rust core that has been compiled to WASM thanks to wasm-bindgen.

Many thanks,