### PR TITLE
Add 'Developing UEFI in Rust with Patina' to draft

### DIFF
--- a/draft/2025-11-05-this-week-in-rust.md
+++ b/draft/2025-11-05-this-week-in-rust.md
@@ -44,6 +44,7 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
+* [Developing UEFI in Rust with Patina](https://opendevicepartnership.github.io/patina/introduction.html)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
Patina is a project that writes [UEFI](https://uefi.org) firmware from the ground up in Rust. It was announced at the [UEFI 2025 Developers Conference and Plugfest](https://uefi.org/events/uefi-2025-developers-conference-and-plugfest).

This adds a link the Introduction to Patina documentation the upcoming draft. The main Patina repository is at https://github.com/OpenDevicePartnership/patina.