### PR TITLE
Add link to Rust mutexes blog post

### DIFF
--- a/draft/2025-11-05-this-week-in-rust.md
+++ b/draft/2025-11-05-this-week-in-rust.md
@@ -49,6 +49,8 @@ and just ask the editors to select the category.
 
 ### Rust Walkthroughs
 
+* [Inside Rust's std and parking_lot mutexes - who wins?](https://blog.cuongle.dev/p/inside-rusts-std-and-parking-lot-mutexes-who-win)
+
 ### Research
 
 ### Miscellaneous


### PR DESCRIPTION
Hi!

I'd like to submit my Rust walkthrough for inclusion in the next issue.

Article: Inside Rust's std and parking_lot mutexes - who wins?

Url: https://blog.cuongle.dev/p/inside-rusts-std-and-parking-lot-mutexes-who-win

What it covers:
- Mutex basic
- How std implements its mutex
- How parking_lot does it
- Benchmarking & decision guide

Thanks!