### PR TITLE
Remove mistaken stable ICE file dumps FCP

### DIFF
--- a/content/2025-10-29-this-week-in-rust.md
+++ b/content/2025-10-29-this-week-in-rust.md
@@ -281,7 +281,6 @@ which are reaching a decision. Express your opinions now.
 * [target tier 3 support for hexagon-unknown-qurt](https://github.com/rust-lang/compiler-team/issues/919)
 * [Proposal for a dedicated test suite for the parallel frontend](https://github.com/rust-lang/compiler-team/issues/906)
 * [Give integer literals a sign instead of relying on negation expressions](https://github.com/rust-lang/compiler-team/issues/835)
-* [Also enable ICE file dumps on stable](https://github.com/rust-lang/compiler-team/issues/809)
 * [New Tier-3 target proposal: `loongarch64-linux-android`](https://github.com/rust-lang/compiler-team/issues/806)
 
 ##### [Leadership Council](https://github.com/rust-lang/leadership-council/issues?q=state%3Aopen%20label%3Afinal-comment-period)


### PR DESCRIPTION
That ticket has been closed as not planned since 2024, not sure how it ended up in the list:
https://github.com/rust-lang/compiler-team/issues/809