### PR TITLE
Fix markdown rendering

### DIFF
--- a/content/2025-11-12-this-week-in-rust.md
+++ b/content/2025-11-12-this-week-in-rust.md
@@ -227,7 +227,7 @@ which are reaching a decision. Express your opinions now.
 * [Stabilize `-Zremap-path-scope`](https://github.com/rust-lang/rust/pull/147611)
 * [error out when `repr(align)` exceeds COFF limit](https://github.com/rust-lang/rust/pull/142638)
 
-[Compiler Team](https://github.com/rust-lang/compiler-team/issues?q=label%3Amajor-change%20%20label%3Afinal-comment-period) [(MCPs only)](https://forge.rust-lang.org/compiler/mcp.html)
+##### [Compiler Team](https://github.com/rust-lang/compiler-team/issues?q=label%3Amajor-change%20%20label%3Afinal-comment-period) [(MCPs only)](https://forge.rust-lang.org/compiler/mcp.html)
 * [target tier 3 support for hexagon-unknown-qurt](https://github.com/rust-lang/compiler-team/issues/919)
 * [Proposal for a dedicated test suite for the parallel frontend](https://github.com/rust-lang/compiler-team/issues/906)
 * [Proposal for Adapt Stack Protector for Rust](https://github.com/rust-lang/compiler-team/issues/841)


### PR DESCRIPTION
The "Compiler Team (MCPs only)" subsection in the current newsletter issue is [not rendered correctly](https://this-week-in-rust.org/blog/2025/11/12/this-week-in-rust-625/#tracking-issues-prs):

<img width="772" height="412" alt="image" src="https://github.com/user-attachments/assets/530070f2-c9bb-4031-a3bd-c3527800f698" />

(Rust subsection included for reference)

This PR makes it an actual heading so that it should be rendered like the "Rust" subsection.

Alternatively, we could add a newline between the title and the list items. I think this would also fix the rendering of the list. Just let me know what you prefer.