### PR TITLE
Add Wasefire blog post

### DIFF
--- a/draft/2025-11-19-this-week-in-rust.md
+++ b/draft/2025-11-19-this-week-in-rust.md
@@ -43,6 +43,8 @@ and just ask the editors to select the category.
 
 ### Newsletters
 
+* [Secure-by-design firmware development with Wasefire](https://opensource.googleblog.com/2025/11/secure-by-design-firmware-development-with-wasefire.html)
+
 ### Project/Tooling Updates
 
 ### Observations/Thoughts


### PR DESCRIPTION
https://opensource.googleblog.com/2025/11/secure-by-design-firmware-development-with-wasefire.html

This is a project announcement in the google open source blog, so I'm not sure if it should be under Newsletters (because of the format) or Project Updates (because of the content). I'm choosing the first as it's an announcement (the first update).