### PR TITLE
Add slash to . directory in Dockerfile

### DIFF
--- a/publishing/Dockerfile
+++ b/publishing/Dockerfile
@@ -36,7 +36,7 @@ COPY themes themes
 COPY pelicanconf.py pelicanconf.py
 
 # just website && just email needs these scripts
-COPY publishing/*.sh .
+COPY publishing/*.sh ./
 RUN chmod +x *.sh
 
 CMD ["pelican", "--delete-output-directory", "content"]


### PR DESCRIPTION
I'm having problems with a "When using COPY with more than one source file, the destination must be a directory and end with a /" error message, probably because of my usage of a either too-old or too-modern docker version (28.5.1)

Anyways, adding this improves compatibility with other Docker versions.