### PR TITLE
Fix URL to cargo cat

### DIFF
--- a/content/2025-11-19-this-week-in-rust.md
+++ b/content/2025-11-19-this-week-in-rust.md
@@ -79,7 +79,7 @@ and just ask the editors to select the category.
 
 ## Crate of the Week
 
-This week's crate is [cargo cat](crates.io/crates/cat-ascii-faces), a cargo-subcommand to put a random ascii cat face on your terminal.
+This week's crate is [cargo cat](https://crates.io/crates/cat-ascii-faces), a cargo-subcommand to put a random ascii cat face on your terminal.
 
 Thanks to [Alejandra Gonzáles](https://users.rust-lang.org/t/crate-of-the-week/2704/1490) for the self-suggestion!
 


### PR DESCRIPTION
The URL to `cargo cat` lacks `https://`, add that.