### PR TITLE
Add Hotaru 0.7.6 to Project/Tooling Updates

### DIFF
--- a/draft/2025-11-26-this-week-in-rust.md
+++ b/draft/2025-11-26-this-week-in-rust.md
@@ -45,7 +45,7 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
-* [Hotaru](https://crates.io/crates/hotaru) - A new lightweight full-stack Rust web framework by [@Redstone-D](https://github.com/Redstone-D) and [@JerrySu5379](https://github.com/JerrySu5379) at [Field-of-Dreams-Studio](https://github.com/Field-of-Dreams-Studio). Features declarative `endpoint!` and `middleware!` macros, multi-protocol support (HTTP/WebSocket/custom TCP on single port), the `..` pattern for middleware inheritance, and built-in Akari template engine. Includes comprehensive [documentation](https://fds.rs/hotaru), [changelog](https://fds.rs/hotaru/news/change_before_0.7.5/), [4-part Quick Tutorial](https://github.com/Field-of-Dreams-Studio/hotaru/blob/master/QUICK_TUTORIAL.md), [HTTP Documentation](https://github.com/Field-of-Dreams-Studio/hotaru/blob/master/HOTARU_HTTP_DOC.md), [Style Guide](https://github.com/Field-of-Dreams-Studio/hotaru/blob/master/HOTARU_STYLE.md), and [TechEmpower Benchmark Results vs Actix-web, Axum, Rocket](https://github.com/Field-of-Dreams-Studio/hotaru/blob/master/hotaru_bench/BENCHMARK_RESULTS.md)
+* [Hotaru](https://crates.io/crates/hotaru) - A new lightweight full-stack Rust web framework by [Field-of-Dreams-Studio (https://github.com/Field-of-Dreams-Studio).
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
Adding Hotaru 0.7.6 to the Project/Tooling Updates section.

**Hotaru** is a lightweight full-stack Rust web framework featuring:
- `endpoint!` macro for declarative routing
- `middleware!` macro with inheritance via `..` pattern
- Multi-protocol support (HTTP/custom TCP on single port)
- Built-in template engine
- New macros for lazy static declarations

- Crate: https://crates.io/crates/hotaru
- Docs: https://docs.rs/hotaru