### PR TITLE
Add Fall Updates newsletter link for vexide 0.8.0

### DIFF
--- a/draft/2025-12-03-this-week-in-rust.md
+++ b/draft/2025-12-03-this-week-in-rust.md
@@ -44,6 +44,7 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
+* [Fall Updates: Standard Library Support with vexide 0.8.0!](https://vexide.dev/blog/posts/thanksgiving-update-25/)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
Adds a link under Project Updates for the vexide 0.8.0 release blog post. https://vexide.dev/blog/posts/thanksgiving-update-25/