### PR TITLE
Add 3DCF/doc2dataset to Project/Tooling Updates

### DIFF
--- a/draft/2025-12-03-this-week-in-rust.md
+++ b/draft/2025-12-03-this-week-in-rust.md
@@ -45,6 +45,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [3DCF/doc2dataset v0.1.0 – Rust document-to-dataset pipeline for RAG & LLM fine-tuning](https://github.com/3DCF-Labs/doc2dataset/releases/tag/v0.1.0)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
This PR adds a link to 3DCF/doc2dataset in the "Project/Tooling Updates" section.

- 3DCF/doc2dataset v0.1.0 is a Rust-based document-to-dataset pipeline for RAG & LLM fine-tuning (Rust core + CLI + HTTP service).
- Link: https://github.com/3DCF-Labs/doc2dataset/releases/tag/v0.1.0