### PR TITLE
Add hyper user survey 2025 link to CFP

### DIFF
--- a/draft/2025-12-03-this-week-in-rust.md
+++ b/draft/2025-12-03-this-week-in-rust.md
@@ -119,7 +119,7 @@ Every week we highlight some tasks from the Rust community for you to pick and g
 Some of these tasks may also have mentors available, visit the task page for more information.
 
 <!-- CFPs go here, use this format: * [project name - title of issue](URL to issue) -->
-<!-- * [ - ]() -->
+* [hyper - User Survey 2025](https://www.surveyhero.com/c/vvnhc7j7)
 <!-- or if none - *No Calls for participation were submitted this week.* -->
 
 If you are a Rust project owner and are looking for contributors, please submit tasks [here][guidelines] or through a [PR to TWiR](https://github.com/rust-lang/this-week-in-rust) or by reaching out on [Bluesky](https://bsky.app/profile/thisweekinrust.bsky.social) or [Mastodon](https://mastodon.social/@thisweekinrust)!


### PR DESCRIPTION
I think CFP is the right place to for this. It'd greatly help out the project the more that fill out the survey.

For reference, it should only take about 5 minutes, no questions are required, responses are anonymous, and it runs till December 17th.