### PR TITLE
Add `CocoIndex` blog post to Rust Walkthroughs

### DIFF
--- a/draft/2025-12-10-this-week-in-rust.md
+++ b/draft/2025-12-10-this-week-in-rust.md
@@ -45,6 +45,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [CocoIndex: Thinking in Rust - Ownership, Access, and Memory Safety](https://cocoindex.io/blogs/rust-ownership-access)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
The article covers Ownership, Access, and Memory Safety w/ relevant code examples.

@badmonster0 @georgeh0 — would love your input on this! A few questions:

1. Does this entry look good, or would you prefer different wording anywhere?
2. Would you also prefer to have CocoIndex featured in a another section, like [Calls for Testing](https://this-week-in-rust.org/blog/2025/12/03/this-week-in-rust-628/#calls-for-testing) or [Calls for Participation](https://github.com/rust-lang/this-week-in-rust?tab=readme-ov-file#call-for-participation-guidelines)?

cc @ericseppanen @llogiq (hope you don't mind the ping).

_PS: CocoIndex made it to [GitHub's Rust Trending](https://github.com/trending/rust) !_