### PR TITLE
chore: Should we get rid of clippy::manual_try_fold? from blog.veeso.dev

### DIFF
--- a/draft/2025-12-10-this-week-in-rust.md
+++ b/draft/2025-12-10-this-week-in-rust.md
@@ -47,6 +47,8 @@ and just ask the editors to select the category.
 
 ### Observations/Thoughts
 
+* [Should we get rid of clippy::manual_try_fold?](https://blog.veeso.dev/blog/en/should-we-get-rid-of-clippy-manual-try-fold/)
+
 ### Rust Walkthroughs
 
 ### Research


### PR DESCRIPTION
Added this article <https://blog.veeso.dev/blog/en/should-we-get-rid-of-clippy-manual-try-fold/> from my blog.

Thank you!