### PR TITLE
Add video link about personal project from the Rust Seoul meetup

### DIFF
--- a/draft/2025-12-10-this-week-in-rust.md
+++ b/draft/2025-12-10-this-week-in-rust.md
@@ -45,6 +45,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [video] [Recording from the Rust Seoul meetup: Zia, a programming language that defines itself (written in Rust)](https://www.youtube.com/watch?v=LbFTP3pITWU)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
This is the talk I gave at the most recent Rust Seoul meetup about my personal Rust project. I assume that "Project/Tooling Updates" is the most appropriate section for this. The source code for the Rust library crate powering this project can be found [here](https://github.com/Charles-Johnson/zia_programming/blob/master/zia/README.md) and the website I used in the video can be accessed [here](https://zia-lang.org/), which is also open sourced [here](https://github.com/Charles-Johnson/zia_programming/blob/master/zia-lang.org/README.md). I assume I only get to include one link and line so I've just included a link to the YouTube video of the talk I gave demoing what I've been working on.