### PR TITLE
Updated closing date for RustWeek 2026 CFP

### DIFF
--- a/draft/2025-12-24-this-week-in-rust.md
+++ b/draft/2025-12-24-this-week-in-rust.md
@@ -131,6 +131,7 @@ If you are a Rust project owner and are looking for contributors, please submit 
 Are you a new or experienced speaker looking for a place to share something cool? This section highlights events that are being planned and are accepting submissions to join their event as a speaker.
 
 <!-- CFPs go here, use this format: * [**event name**](URL to CFP)| Date CFP closes in YYYY-MM-DD | city,state,country | Date of event in YYYY-MM-DD -->
+* [**RustWeek 2026**](https://sessionize.com/rustweek-2026/) | CFP closes 2026-01-18 | Utrecht, The Netherlands | 2026-05-19 - 2026-05-20
 <!-- or if none - *No Calls for papers or presentations were submitted this week.* -->
 
 If you are an event organizer hoping to expand the reach of your event, please submit a link to the website through a [PR to TWiR](https://github.com/rust-lang/this-week-in-rust) or by reaching out on [Bluesky](https://bsky.app/profile/thisweekinrust.bsky.social) or [Mastodon](https://mastodon.social/@thisweekinrust)!


### PR DESCRIPTION
CFP extended from Dec 31 to Jan 18.
Thanks!