### PR TITLE
Add Netstack.FM podcast episode link to observations

### DIFF
--- a/draft/2025-12-31-this-week-in-rust.md
+++ b/draft/2025-12-31-this-week-in-rust.md
@@ -47,6 +47,8 @@ and just ask the editors to select the category.
 
 ### Observations/Thoughts
 
+* [audio] [Netstack.FM episode 20 — Netstack.FM New Year Special, 2025 Wrap-Up](https://netstack.fm/#episode-20)
+
 ### Rust Walkthroughs
 
 ### Research


### PR DESCRIPTION
Added a link to Netstack.FM episode 20 in the observations section. Contains a lot of Rust lessons learned from our past 19 episodes in 2025 and also for once putting Rama a bit more in the spotlight to give some updates and related info on that (rust) project.