### PR TITLE
Allow code snippets to wrap arbitrarily

### DIFF
--- a/themes/rusted/static/css/_base.scss
+++ b/themes/rusted/static/css/_base.scss
@@ -141,6 +141,7 @@ code {
 code {
     padding: 1px 5px;
     color: $code-color;
+    overflow-wrap: break-word;
 }
 
 pre {


### PR DESCRIPTION
Was looking through old issues and #2627 seemed an easy fix. Tested on Firefox on an Android phone and on Safari on an iPhone simulator on a Macbook.

### Problem

CSS defines certain characters (such as whitespace and hyphens) as "soft breaks" that it will use to break long words to wrap them, keeping the overall content width consistent. However, in a programming language that makes [extensive use of `snake_case`](https://doc.rust-lang.org/beta/style-guide/advice.html#names), you can often get long strings spaced with underscores, which are not considered "soft breaks".

Now, a function name should never be long enough to cause wrapping issues on your average computer monitor (if you have written such a function, I recommend `rm -rf /`), but it's a much more likely issue on a mobile device screen. For example, in [ TWiR issue 417](https://this-week-in-rust.org/blog/2021/11/17/this-week-in-rust-417/), under `Updates from the Rust Project > Tracking Issues & PRs`, you can find the impressively long snippet `#![feature(maybe_uninit_extra,const_maybe_uninit_write)]`. While this snippet should render fine on a computer, viewing it on a mobile device can cause overflow issues, which make the newsletter render a bit strangely.

### Solution

CSS specifies the property [`overflow-wrap`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/overflow-wrap), which allows us to tell the browser to break the text as needed to keep it from overflowing. Adding that property to the CSS for `code` blocks specifically means that only code snippets are affected by the change, keeping the rest of the text on the site unchanged.

In this case, I've opted to set the property to `break-word`, which (I believe) limits the word to only one arbitrary break, but it could also be set to `anywhere`, which would allow as many arbitrary breaks as the browser wants to size the content properly.

### Cons

This change does mean that, depending on the width of the screen and the length of the code snippet, some snippets can be broken in awkward ways.

For example, when viewing [issue 632](https://this-week-in-rust.org/blog/2025/12/31/this-week-in-rust-632/) on one of the mobile devices I used for testing, one of the snippets in the `Updates from the Rust Project` section was just long enough to break immediately before the final character in the snippet, resulting in a single character of the snippet sitting on its own line. In this case, overflowing and causing the newsletter to load slightly "zoomed out" was almost certain acceptable if not the preferred behavior. While this kind of issue could be avoided with code that conditionally breaks snippets over a certain length, such a solution would be much more involved and likely not worth the effort to avoid a relatively minor issue.

### Final Thoughts

If you want more info about this problem, I strongly recommend looking at the [original issue](https://github.com/rust-lang/this-week-in-rust/issues/2627) as well as [this MDN Docs page](https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Text/Wrapping_breaking_text) about wrapping and breaking text.

If you have any questions, comments, concerns, etc., don't hesitate to reach out.