### PR TITLE
Add link for "A year of work on the ALPM project"

### DIFF
--- a/draft/2026-01-14-this-week-in-rust.md
+++ b/draft/2026-01-14-this-week-in-rust.md
@@ -44,6 +44,7 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
+* [A year of work on the ALPM project](https://devblog.archlinux.page/2026/a-year-of-work-on-the-alpm-project/)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
Add a link to the article wrapping the funded work on the STF funded, Rust-based ALPM project in 2024 and 2025.