### PR TITLE
Add link for "Verify Arch Linux artifacts using VOA/OpenPGP"

### DIFF
--- a/draft/2026-01-14-this-week-in-rust.md
+++ b/draft/2026-01-14-this-week-in-rust.md
@@ -44,6 +44,7 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
+* [Verify Arch Linux artifacts using VOA/OpenPGP](https://devblog.archlinux.page/2026/verify-arch-linux-artifacts-using-voa-openpgp/)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
Add a link to an article explaining in-depth the use of the Rust-based `voa` CLI for the verification of Arch Linux artifacts (e.g. package files and installation medium) using the OpenPGP backend and a dedicated voa configuration file.