### PR TITLE
Add rung to Call for Participation

### DIFF
--- a/draft/2026-01-14-this-week-in-rust.md
+++ b/draft/2026-01-14-this-week-in-rust.md
@@ -149,6 +149,12 @@ Some of these tasks may also have mentors available, visit the task page for mor
 * [GuardianDB - Create Benchmarks](https://github.com/wmaslonek/guardian-db/issues/7)
 * [GuardianDB - Create cohesive usage examples](https://github.com/wmaslonek/guardian-db/issues/5)
 * [GuardianDB - Translate documentation to English](https://github.com/wmaslonek/guardian-db/issues/3)
+* [rung - Add shell completions for bash/zsh/fish](https://github.com/auswm85/rung/issues/18)
+* [rung - Add --quiet flag to suppress non-essential output](https://github.com/auswm85/rung/issues/19)
+* [rung - Support NO_COLOR environment variable](https://github.com/auswm85/rung/issues/20)
+* [rung - Add rung top / rung bottom navigation commands](https://github.com/auswm85/rung/issues/21)
+* [rung - Add rung log command to show stack commits](https://github.com/auswm85/rung/issues/22)
+* [rung - Add integration test for sync with merge conflicts](https://github.com/auswm85/rung/issues/23)
 
 If you are a Rust project owner and are looking for contributors, please submit tasks [here][guidelines] or through a [PR to TWiR](https://github.com/rust-lang/this-week-in-rust) or by reaching out on [Bluesky](https://bsky.app/profile/thisweekinrust.bsky.social) or [Mastodon](https://mastodon.social/@thisweekinrust)!
 


### PR DESCRIPTION
Adding good first issues from [rung](https://github.com/auswm85/rung), a Git workflow tool for managing stacked PRs.

Rung helps developers work with dependent branches by tracking branch relationships, syncing child branches when parents update, and managing PR chains on GitHub.

All issues are labeled with difficulty levels (easy/medium) and are beginner-friendly.