### PR TITLE
Add scientific computing in rust newsletter #14

### DIFF
--- a/draft/2026-01-21-this-week-in-rust.md
+++ b/draft/2026-01-21-this-week-in-rust.md
@@ -43,6 +43,7 @@ and just ask the editors to select the category.
 
 ### Newsletters
 * [The Embedded Rustacean Issue #63](https://www.theembeddedrustacean.com/p/the-embedded-rustacean-issue-63)
+* [Scientific Computing in Rust #14 (January 2026)](https://scientificcomputing.rs/monthly/2026-01)
 
 ### Project/Tooling Updates
 


### PR DESCRIPTION
Adds the January 2026 newsletter on scientific computing in rust to TWIR.