### PR TITLE
Add link to Rust's standard library on the GPU

### DIFF
--- a/draft/2026-01-28-this-week-in-rust.md
+++ b/draft/2026-01-28-this-week-in-rust.md
@@ -46,6 +46,7 @@ and just ask the editors to select the category.
 ### Project/Tooling Updates
 
 ### Observations/Thoughts
+* [Rust's standard library on the GPU](https://www.vectorware.com/blog/rust-std-on-gpu/)
 
 ### Rust Walkthroughs
 


### PR DESCRIPTION
Added a link to an article about Rust's standard library on the GPU.