### PR TITLE
Add "I packaged my Rust CLI to too many places, here's what I learned" to Miscellaneous

### DIFF
--- a/draft/2026-01-28-this-week-in-rust.md
+++ b/draft/2026-01-28-this-week-in-rust.md
@@ -53,6 +53,8 @@ and just ask the editors to select the category.
 
 ### Miscellaneous
 
+* [I packaged my Rust CLI to too many places, here's what I learned](https://ivaniscoding.github.io/posts/rustpackaging1/)
+
 ## Crate of the Week
 
 <!-- COTW goes here -->


### PR DESCRIPTION
This is the spiritual successor of #7529. Hopefully it fits this time? The Misc category should be more broad.