### PR TITLE
Add "Homebrew and One-Line Installers for My Rust CLI: Lessons Learned" to Rust Walkthroughs

### DIFF
--- a/draft/2026-02-04-this-week-in-rust.md
+++ b/draft/2026-02-04-this-week-in-rust.md
@@ -49,6 +49,8 @@ and just ask the editors to select the category.
 
 ### Rust Walkthroughs
 
+* [Homebrew and One-Line Installers for My Rust CLI: Lessons Learned](https://ivaniscoding.github.io/posts/rustpackaging2/)
+
 ### Research
 
 ### Miscellaneous


### PR DESCRIPTION
Follow up of #7560

I am adding it to the same category as in the January 28 newsletter.