### PR TITLE
Add sighook 0.7.0 to Project/Tooling Updates

### DIFF
--- a/draft/2026-02-18-this-week-in-rust.md
+++ b/draft/2026-02-18-this-week-in-rust.md
@@ -45,6 +45,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [sighook 0.9.0: prepatched hook APIs for iOS signed text pages](https://github.com/YinMo19/sighook/releases/tag/v0.9.0)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
Adds one Project/Tooling Updates item for `sighook 0.7.0` in the current draft.

Link target is a release notes page (not a repo-only link), with summary text highlighting:
- x86 length-aware patching
- new `patch_bytes` API
- clearer PC-relative instrumentation guidance
