### PR TITLE
Revert PR 7620

### DIFF
--- a/draft/2026-02-11-this-week-in-rust.md
+++ b/draft/2026-02-11-this-week-in-rust.md
@@ -51,7 +51,6 @@ and just ask the editors to select the category.
 * [Rustbridge v0.9: Building and bundling Rust shared libraries](https://github.com/jrobhoward/rustbridge/blob/v0.9.1/docs/RELEASE_NOTES_0.9.md)
 * [Ariel OS v0.3.0: BLE, Sensors, UART, and More!](https://ariel-os.org/blog/ariel-os-0.3.0/)
 * [CipherStash Proxy 2.1.20 - Postgres Searchable Encryption in pure Rust](https://github.com/cipherstash/proxy/discussions/361)
-* [Introducing Honeymelon: A Case Study in Building a Better Media Converter](https://dev.to/thavarshan/introducing-honeymelon-a-case-study-in-building-a-better-media-converter-51d9)
 
 ### Observations/Thoughts
 * [Linux 7.0 Officially Concluding The Rust Experiment](https://www.phoronix.com/news/Linux-7.0-Rust)


### PR DESCRIPTION
Changing TWIR 638 per editorial process, reverts #7620