### PR TITLE
Add custom 404 page

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -50,6 +50,8 @@ scattered about.
 """
 }
 
+DIRECT_TEMPLATES = ['index', 'tags', 'categories', 'authors', 'archives', '404']
+
 PLUGIN_PATHS = ["plugins"]
 
 # Don't add next/previous buttons search functionality for email.

--- a/themes/rusted/templates/404.html
+++ b/themes/rusted/templates/404.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+
+{% block title %}
+Page not found · {{ super() }}
+{% endblock title %}
+
+{% block content %}
+<div class="col-md-12">
+  <h2>Page not found</h2>
+  <p>Sorry, but the page you are looking for cannot be found.</p>
+  <p>
+    If you were linked here from a post on r/rust, please check back in a
+    few minutes. The reddit post is put up before the blog post goes live,
+    so that a link to the former can be put at the bottom of the latter.
+  </p>
+</div>
+{% endblock content %}


### PR DESCRIPTION
When TWIR gets posted to r/rust, there are often comments about it being a dead link, because the reddit post goes up before the blog post. I figure that with a custom 404 page which explains that, some of that confusion could be negated.