### PR TITLE
Add pvec-rs blog post to Rust Walkthroughs in the next issue

### DIFF
--- a/draft/2026-02-18-this-week-in-rust.md
+++ b/draft/2026-02-18-this-week-in-rust.md
@@ -55,6 +55,7 @@ and just ask the editors to select the category.
 ### Rust Walkthroughs
 
 * [Shipping My Rust CLI to Windows: Lessons Learned (feat. Windows 98 and APE Bonus)](https://ivaniscoding.github.io/posts/rustpackaging4/)
+* [Visualizing Persistent Vectors with Rust and WebAssembly](https://abishov.com/blog/pvec-rs-visualizing-structural-sharing/)
 
 ### Research
 


### PR DESCRIPTION
I recently wrote a post that provides an overview of how persistent vectors work under the hood. It covers path copying, structural sharing, and RRB trees, with an interactive visualization that compiles pvec-rs to WebAssembly and renders the tree in the browser.

  - Blog post: https://abishov.com/blog/pvec-rs-visualizing-structural-sharing/
  - GitHub: https://github.com/ArazAbishov/pvec-rs