### PR TITLE
Add bincode-next v3.0.0-rc.1 to the Project Update Section

### DIFF
--- a/draft/2026-02-25-this-week-in-rust.md
+++ b/draft/2026-02-25-this-week-in-rust.md
@@ -45,6 +45,7 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 * [Introducing Almonds — Your Personal Workspace, Reimagined](https://opeolluwa.github.io/almonds/blog/hello-almonds)
+* [Releasing bincode-next v3.0.0-rc.1](https://users.rust-lang.org/t/releasing-bincode-next-v3-0-0-rc-1/138466)
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
Add bincode-next v3.0.0-rc.1 Release to the Project Update Section.

Hi TWiR team!

Since the original bincode project has been officially ceased (RUSTSEC-2025-0141), our team at Apich has forked it and continued its development.
After several months of development and discussion, we have finalize the release of v3.0.0-rc.1. The release post could be seen on the [rust user's forum](https://users.rust-lang.org/t/releasing-bincode-next-v3-0-0-rc-1/138466).
Hope you guys would appreciate it!

_Yours sincerely,
Apich Organization Development Team_