### PR TITLE
Add SafePilot v0.1 to Project/Tooling Updates

### DIFF
--- a/draft/2026-02-25-this-week-in-rust.md
+++ b/draft/2026-02-25-this-week-in-rust.md
@@ -45,6 +45,7 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 * [Introducing Almonds — Your Personal Workspace, Reimagined](https://opeolluwa.github.io/almonds/blog/hello-almonds)
+* [SafePilot v0.1: self-hosted AI operations assistant (release)](https://github.com/3DCF-Labs/safepilot/releases/tag/v0.1)
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
Adds SafePilot v0.1 release in the current draft under Project/Tooling Updates.\n\nRelease link: https://github.com/3DCF-Labs/safepilot/releases/tag/v0.1