### PR TITLE
Add dag_exec release + Rust concurrency writeups

### DIFF
--- a/draft/2026-03-04-this-week-in-rust.md
+++ b/draft/2026-03-04-this-week-in-rust.md
@@ -45,14 +45,14 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
-* [dag_exec: a std-only DAG executor for CPU-heavy pipelines (pruning + bounded parallelism)](https://www.reymom.xyz/blog/rust/2026-03-03-exec_dag-official-release)
+* [dag_exec: DAG executor for CPU-heavy pipelines](https://www.reymom.xyz/blog/rust/2026-03-03-exec_dag-official-release)
 
 ### Observations/Thoughts
 
-### Rust Walkthroughs
-
 * [Designing Backpressure in a Parallel DAG Executor](https://www.reymom.xyz/blog/rust/2026-02-21-backpressure-in-parallel-executor)
 * [Testing Concurrency Invariants in a Parallel Executor](https://www.reymom.xyz/blog/rust/2026-02-24-testing-invariants-atomics)
+
+### Rust Walkthroughs
 
 ### Research
 


### PR DESCRIPTION
Submitted links for TWiR:

- **dag_exec** official release post (std-only DAG executor: pruning + bounded parallelism + backpressure)
- Two Rust-focused deep dives from the build:
    - Designing Backpressure in a Parallel DAG Executor
    - Testing Concurrency Invariants in a Parallel Executor

All authored by me; public, not paywalled.