### PR TITLE
Fix the broken link to office2pdf (CotW) in 641

### DIFF
--- a/draft/2026-03-04-this-week-in-rust.md
+++ b/draft/2026-03-04-this-week-in-rust.md
@@ -84,7 +84,7 @@ and just ask the editors to select the category.
 
 ## Crate of the Week
 
-This week's crate is [office2pdf](office2pdf), a standalone library or binary to generate PDF from OOXML (docx, xlsx, etc.) files.
+This week's crate is [office2pdf](https://crates.io/crates/office2pdf), a standalone library or binary to generate PDF from OOXML (docx, xlsx, etc.) files.
 
 Thanks to [One](https://users.rust-lang.org/t/crate-of-the-week/2704/1562) for the suggestion!
 


### PR DESCRIPTION
This link is broken from [the beginning](https://github.com/rust-lang/this-week-in-rust/commit/29169d5cbe16c6f34ed82c11735163a5dd613223) in #7717.

On https://this-week-in-rust.org/blog/2026/03/04/this-week-in-rust-641/#crate-of-the-week, it links to https://this-week-in-rust.org/blog/2026/03/04/this-week-in-rust-641/office2pdf, which is 404.
