### PR TITLE
Add cargo-codesign blog post to TWiR 642

### DIFF
--- a/draft/2026-03-11-this-week-in-rust.md
+++ b/draft/2026-03-11-this-week-in-rust.md
@@ -45,6 +45,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [Signing Rust Binaries Shouldn't Require Shell Scripts](https://d34dl0ck.me/cargo-codesign/index.html)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
Adds a link to [Signing Rust Binaries Shouldn't Require Shell Scripts](https://d34dl0ck.me/cargo-codesign/index.html) under **Project/Tooling Updates**.

`cargo-codesign` is a cross-platform binary signing CLI for Rust projects — sign, notarize, and staple macOS artifacts in one command.