### PR TITLE
Add zyn to Project/Tooling Updates

### DIFF
--- a/draft/2026-03-11-this-week-in-rust.md
+++ b/draft/2026-03-11-this-week-in-rust.md
@@ -45,6 +45,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [zyn — a template engine for Rust proc macros with zero-overhead components, diagnostics, and typed attribute parsing](https://github.com/aacebo/zyn)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
Adds [zyn](https://github.com/aacebo/zyn) to the Project/Tooling Updates section — a template engine for Rust proc macros.