### PR TITLE
Add link to Weighing up Zngur and CXX for Rust/C++ Interop

### DIFF
--- a/draft/2026-03-11-this-week-in-rust.md
+++ b/draft/2026-03-11-this-week-in-rust.md
@@ -47,6 +47,8 @@ and just ask the editors to select the category.
 
 ### Observations/Thoughts
 
+* [Weighing up Zngur and CXX for Rust/C++ Interop](https://www.kdab.com/weighing-up-zngur-and-cxx-for-rustc-interop/)
+
 ### Rust Walkthroughs
 
 ### Research


### PR DESCRIPTION
We wrote a blog weighing up zngur and CXX as different Rust/C++ introp approaches with some examples, it may be of interest to your reasons. Wasn't sure which section to put it under so went with `Observations/Thoughts`.