### PR TITLE
Add link to RustLab 2025 CGP presentation and transcript

### DIFF
--- a/draft/2026-03-11-this-week-in-rust.md
+++ b/draft/2026-03-11-this-week-in-rust.md
@@ -46,6 +46,7 @@ and just ask the editors to select the category.
 ### Project/Tooling Updates
 
 ### Observations/Thoughts
+* [[video](https://www.youtube.com/watch?v=gXIfP-W9074)] [How to stop fighting with coherence and start writing context-generic trait impls - RustLab 2025 transcript](https://contextgeneric.dev/blog/rustlab-2025-coherence)
 
 ### Rust Walkthroughs
 


### PR DESCRIPTION
Adding links to my RustLab 2025 presentation titled **[How to stop fighting with coherence and start writing context-generic trait impls](https://contextgeneric.dev/blog/rustlab-2025-coherence/)**. This includes a blog post containing the transcript and slides, and a link to the YouTube vide.