### PR TITLE
Add loadgen-rs HTTP benchmark client update

### DIFF
--- a/draft/2026-03-18-this-week-in-rust.md
+++ b/draft/2026-03-18-this-week-in-rust.md
@@ -44,6 +44,7 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
+* [loadgen-rs - h2load-compatible HTTP benchmark client written in Rust, supporting HTTP/1.1, HTTP/2, and HTTP/3 (QUIC)](https://blog.none.at/blog/2026/2026-03-01-loadgen-rs/)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
How I built an HTTP benchmark client in Rust that supports HTTP/1.1, HTTP/2, and HTTP/3 — machine-readable output, distributed multi-node mode, Terraform/Ansible cloud deployment, and what CPU profiling revealed about the performance ceiling.