### PR TITLE
add ep31 of netstack.fm podcast episode

### DIFF
--- a/draft/2026-03-18-this-week-in-rust.md
+++ b/draft/2026-03-18-this-week-in-rust.md
@@ -47,6 +47,8 @@ and just ask the editors to select the category.
 
 ### Observations/Thoughts
 
+* [audio] [Netstack.FM episode 31 — Protocol Shorts: MITM Proxies and Transparent L4 Interception](https://netstack.fm/#episode-31)
+
 ### Rust Walkthroughs
 
 ### Research


### PR DESCRIPTION
Episode 31 of Netstack.FM is out: another Protocol Shorts episode, this time on MITM proxies and transparent interception, and how Rama approaches this with BridgeIo