### PR TITLE
Add compiler PR introducing #[diagnostic::on_move(message)]

### DIFF
--- a/draft/2026-03-25-this-week-in-rust.md
+++ b/draft/2026-03-25-this-week-in-rust.md
@@ -137,6 +137,10 @@ If you are an event organizer hoping to expand the reach of your event, please s
 
 ## Updates from the Rust Project
 
+#### Compiler
+
+* [Introduce #[diagnostic::on_move(message)]](https://github.com/rust-lang/rust/pull/150935)
+
 <!-- Rust updates go here -->
 
 ### Rust Compiler Performance Triage


### PR DESCRIPTION
This adds a link to a feature recently merged into the compiler (feature gated, nightly only).