### PR TITLE
Add "Rust in Intersec's lib-common, Part 1: Integrating Rust in a C Build System"

### DIFF
--- a/draft/2026-03-25-this-week-in-rust.md
+++ b/draft/2026-03-25-this-week-in-rust.md
@@ -48,6 +48,7 @@ and just ask the editors to select the category.
 ### Observations/Thoughts
 
 ### Rust Walkthroughs
+* [Rust in Intersec's lib-common, Part 1: Integrating Rust in a C Build System](https://techtalk.intersec.com/2026/03/rust-in-lib-common-part-1-integrating-rust-in-a-waf-based-c-build-system/)
 
 ### Research
 


### PR DESCRIPTION
Blog article about integrating Rust in Intersec's lib-common, a mature large C codebase.
This is the part 1 of the series covering the integration of Rust/Cargo in the existing Waf-based build system.