### PR TITLE
Add openai-oxide to Project/Tooling Updates and Observations

### DIFF
--- a/draft/2026-03-25-this-week-in-rust.md
+++ b/draft/2026-03-25-this-week-in-rust.md
@@ -44,7 +44,6 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
-* [openai-oxide v0.9.8: Idiomatic OpenAI client for Rust with persistent WebSockets, structured outputs, WASM support, and Node/Python bindings](https://github.com/fortunto2/openai-oxide)
 
 ### Observations/Thoughts
 * [I ported the OpenAI Python SDK to Rust in 5 days with Claude Code](https://dev.to/fortunto2/squeezing-every-millisecond-from-the-openai-api-in-rust-4b11)


### PR DESCRIPTION
Adding two items to TWiR #644:

**Project/Tooling Updates:**
- [openai-oxide v0.9.8](https://github.com/fortunto2/openai-oxide) — Idiomatic OpenAI client for Rust with persistent WebSockets, structured outputs (`parse::<T>()`), WASM support, and Node/Python bindings. Published on crates.io, npm, PyPI.

**Observations/Thoughts:**
- [I ported the OpenAI Python SDK to Rust in 5 days with Claude Code](https://dev.to/fortunto2/squeezing-every-millisecond-from-the-openai-api-in-rust-4b11) — Article covering the porting process, benchmarks, and Rust-specific wins (zero-copy SSE, tagged enums, feature flags).