### PR TITLE
Add buffa and connect-rust announcement to issue 644

### DIFF
--- a/draft/2026-03-25-this-week-in-rust.md
+++ b/draft/2026-03-25-this-week-in-rust.md
@@ -45,6 +45,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [Zero-copy Protobuf and ConnectRPC for Rust](https://dev.to/iainmcgin/zero-copy-protobuf-and-connectrpc-for-rust-1m3e)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
Adds an entry to Project/Tooling Updates for two new Rust crates:

- [buffa](https://crates.io/crates/buffa) — a pure-Rust Protocol Buffers implementation with editions support and zero-copy message views
- [connect-rust](https://crates.io/crates/connectrpc) — a Tower-based ConnectRPC implementation supporting Connect, gRPC, and gRPC-Web

Blog post: https://dev.to/iainmcgin/zero-copy-protobuf-and-connectrpc-for-rust-1m3e