### PR TITLE
haproxy-spoe-rs: A Rust SPOA Agent Library for HAProxy

### DIFF
--- a/draft/2026-04-15-this-week-in-rust.md
+++ b/draft/2026-04-15-this-week-in-rust.md
@@ -44,6 +44,7 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
+* [haproxy-spoe-rs: A Rust SPOA Agent Library for HAProxy](https://blog.none.at/blog/2026/2026-04-12-haproxy-spoa-rs/)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
haproxy-spoe-rs is a Rust library for writing HAProxy SPOE agents. This post covers what SPOE is, the design decisions behind the library, and how its throughput compares to the Go reference implementation.