### PR TITLE
Add RustNet update to this week in Rust

### DIFF
--- a/draft/2026-04-15-this-week-in-rust.md
+++ b/draft/2026-04-15-this-week-in-rust.md
@@ -139,7 +139,7 @@ If you are an event organizer hoping to expand the reach of your event, please s
 
 ## Updates from the Rust Project
 
-<!-- Rust updates go here -->
+* [RustNet: A Real-Time Network Traffic Analysis TUI](https://netbeez.net/blog/rustnet/)
 
 ### Rust Compiler Performance Triage
 

--- a/draft/2026-04-15-this-week-in-rust.md
+++ b/draft/2026-04-15-this-week-in-rust.md
@@ -45,6 +45,7 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 * [KAIO v0.2.0: Writing GPU Kernels in Rust at 92.5% of cuBLAS](https://netviper.gr/blog/kaio-v020/)
+* [RustNet: A Real-Time Network Traffic Analysis TUI](https://netbeez.net/blog/rustnet/)
 
 ### Observations/Thoughts
 
@@ -142,7 +143,7 @@ If you are an event organizer hoping to expand the reach of your event, please s
 
 ## Updates from the Rust Project
 
-* [RustNet: A Real-Time Network Traffic Analysis TUI](https://netbeez.net/blog/rustnet/)
+<!-- Rust updates go here -->
 
 ### Rust Compiler Performance Triage
 


### PR DESCRIPTION
Added a link to RustNet for real-time network traffic analysis.