### PR TITLE
Add blog post to Rust Walkthroughs

### DIFF
--- a/draft/2026-04-15-this-week-in-rust.md
+++ b/draft/2026-04-15-this-week-in-rust.md
@@ -51,6 +51,8 @@ and just ask the editors to select the category.
 
 ### Rust Walkthroughs
 
+* [Fixing DNS tail latency with a 5-line config and a 50-line function](https://numa.rs/blog/posts/fixing-doh-tail-latency.html)
+
 ### Research
 
 ### Miscellaneous


### PR DESCRIPTION
Adding a Rust walkthrough blog post about fixing DNS-over-HTTPS tail latency with reqwest/hyper HTTP/2 window tuning and request hedging.