### PR TITLE
Add pquantum.dev to Project/Tooling Updates

### DIFF
--- a/draft/2026-04-15-this-week-in-rust.md
+++ b/draft/2026-04-15-this-week-in-rust.md
@@ -44,6 +44,7 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
+* [pquantum.dev: Post-Quantum Cryptography in Rust](https://pquantum.dev/)
 * [haproxy-spoe-rs: A Rust SPOA Agent Library for HAProxy](https://blog.none.at/blog/2026/2026-04-12-haproxy-spoa-rs/)
 * [Fresh 0.2.23: Terminal IDE adds Windows-1251 encoding, customizable status bar, and faster file finder](https://github.com/sinelaw/fresh/releases/tag/v0.2.23)
 * [KAIO v0.2.0: Writing GPU Kernels in Rust at 92.5% of cuBLAS](https://netviper.gr/blog/kaio-v020/)


### PR DESCRIPTION
pquantum.dev is an index of post-quantum cryptography crates in Rust. Each crate has a quantum-safe status (Quantum-Safe, Safe Today, Research), algorithm info and a short description. Single page. I built this because there was no single place to see which Rust crates are ready for PQC migration and which are still research-stage.