### PR TITLE
 Add RustConf schedule and registration to 2026-04-22 issue

### DIFF
--- a/content/2026-04-15-this-week-in-rust.md
+++ b/content/2026-04-15-this-week-in-rust.md
@@ -40,6 +40,9 @@ and just ask the editors to select the category.
 ### Official
 * [Infrastructure Team 2026 Q1 Recap and Q2 Plan](https://blog.rust-lang.org/inside-rust/2026/04/14/infrastructure-team-q1-recap-and-q2-plan/)
 
+### Foundation
+* RustConf 2026 [schedule](https://rustconf.com/schedule/) and [registration](https://rustconf.com/register?utm_source=this_week_in_rust&utm_medium=newsletter&utm_campaign=week_apr13) are live! Early bird ticket prices are available through April 29.
+
 ### Project/Tooling Updates
 * [pquantum.dev: Post-Quantum Cryptography in Rust](https://pquantum.dev/)
 * [haproxy-spoe-rs: A Rust SPOA Agent Library for HAProxy](https://blog.none.at/blog/2026/2026-04-12-haproxy-spoa-rs/)

--- a/content/2026-04-15-this-week-in-rust.md
+++ b/content/2026-04-15-this-week-in-rust.md
@@ -41,7 +41,7 @@ and just ask the editors to select the category.
 * [Infrastructure Team 2026 Q1 Recap and Q2 Plan](https://blog.rust-lang.org/inside-rust/2026/04/14/infrastructure-team-q1-recap-and-q2-plan/)
 
 ### Foundation
-* RustConf 2026 [schedule](https://rustconf.com/schedule/) and [registration](https://rustconf.com/register?utm_source=this_week_in_rust&utm_medium=newsletter&utm_campaign=week_apr13) are live! Early bird ticket prices are available through April 29.
+* RustConf 2026 [schedule](https://rustconf.com/schedule/) and [registration](https://rustconf.com/register) are live! Early bird ticket prices are available through April 29.
 
 ### Project/Tooling Updates
 * [pquantum.dev: Post-Quantum Cryptography in Rust](https://pquantum.dev/)

--- a/content/2026-04-15-this-week-in-rust.md
+++ b/content/2026-04-15-this-week-in-rust.md
@@ -41,7 +41,6 @@ and just ask the editors to select the category.
 * [Infrastructure Team 2026 Q1 Recap and Q2 Plan](https://blog.rust-lang.org/inside-rust/2026/04/14/infrastructure-team-q1-recap-and-q2-plan/)
 
 ### Foundation
-* RustConf 2026 [schedule](https://rustconf.com/schedule/) and [registration](https://rustconf.com/register) are live! Early bird ticket prices are available through April 29.
 
 ### Project/Tooling Updates
 * [pquantum.dev: Post-Quantum Cryptography in Rust](https://pquantum.dev/)

--- a/content/2026-04-15-this-week-in-rust.md
+++ b/content/2026-04-15-this-week-in-rust.md
@@ -40,8 +40,6 @@ and just ask the editors to select the category.
 ### Official
 * [Infrastructure Team 2026 Q1 Recap and Q2 Plan](https://blog.rust-lang.org/inside-rust/2026/04/14/infrastructure-team-q1-recap-and-q2-plan/)
 
-### Foundation
-
 ### Project/Tooling Updates
 * [pquantum.dev: Post-Quantum Cryptography in Rust](https://pquantum.dev/)
 * [haproxy-spoe-rs: A Rust SPOA Agent Library for HAProxy](https://blog.none.at/blog/2026/2026-04-12-haproxy-spoa-rs/)

--- a/draft/2026-04-22-this-week-in-rust.md
+++ b/draft/2026-04-22-this-week-in-rust.md
@@ -41,6 +41,8 @@ and just ask the editors to select the category.
 
 ### Foundation
 
+* RustConf 2026 [schedule](https://rustconf.com/schedule/) and [registration](https://rustconf.com/register) are live! Early bird ticket prices are available through April 29.
+
 ### Newsletters
 
 ### Project/Tooling Updates


### PR DESCRIPTION
I closed a similar PR from last week that didn't make it into the previous issue. Resubmitting the same RustConf schedule and registration info here for the April 22 issue. 