### PR TITLE
CFP: add wacp-platform clippy-drifts good first issue

### DIFF
--- a/draft/2026-04-22-this-week-in-rust.md
+++ b/draft/2026-04-22-this-week-in-rust.md
@@ -124,6 +124,7 @@ Some of these tasks may also have mentors available, visit the task page for mor
 <!-- * [ - ]() -->
 
 * [rust-cookbook - Add Asynchronous section with tokio runtime recipes](https://github.com/rust-lang-nursery/rust-cookbook/issues/759) ([other high impact examples](https://github.com/rust-lang-nursery/rust-cookbook/issues?q=is%3Aissue%20state%3Aopen%20label%3Aexample))
+* [wacp-platform - Fix test-only clippy drifts in `wacp-runtime/tests.rs` + `console-db/queries/tests.rs`](https://github.com/AAkil98/wacp-platform/issues/2) ([other good first issues](https://github.com/AAkil98/wacp-platform/labels/good%20first%20issue))
 
 If you are a Rust project owner and are looking for contributors, please submit tasks [here][guidelines] or through a [PR to TWiR](https://github.com/rust-lang/this-week-in-rust) or by reaching out on [Bluesky](https://bsky.app/profile/thisweekinrust.bsky.social) or [Mastodon](https://mastodon.social/@thisweekinrust)!
 


### PR DESCRIPTION
Adding a Call for Participation entry to the `draft/2026-04-22-this-week-in-rust.md` draft for [wacp-platform](https://github.com/AAkil98/wacp-platform).

**Submitted task:** [#2 — Fix test-only clippy drifts in `wacp-runtime/tests.rs` + `console-db/queries/tests.rs`](https://github.com/AAkil98/wacp-platform/issues/2)

**Why it's a good CFP fit per the [guidelines](https://github.com/rust-lang/this-week-in-rust?tab=readme-ov-file#call-for-participation-guidelines):**
- ✅ OSI-approved license: Apache-2.0 ([`LICENSE`](https://github.com/AAkil98/wacp-platform/blob/main/LICENSE))
- ✅ Public issue tracker
- ✅ Difficulty stated (easy — mechanical clippy-suggested replacements)
- ✅ Contribution guide linked from the task body ([`CONTRIBUTING.md`](https://github.com/AAkil98/wacp-platform/blob/main/CONTRIBUTING.md))
- ✅ Scoped, specific: 6 drifts with line-level pointers; newcomer can ship in ~30 min

Also added an "(other good first issues)" link at the end of the bullet — the project has 4 total `good first issue` entries live, including a `CHANGELOG.md` skeleton, an SVG architecture diagram, and per-vertical README drafting. Same pattern as the existing rust-cookbook entry's trailing-link.

**About the project** (short version): wacp-platform is the reference implementation of the Workspace Agent Coordination Protocol — a Rust + React monorepo shipping a protocol runtime (4 gRPC services) and an operator workbench for multi-agent systems. v0.1, built solo with Claude as implementation co-author (credited). 23-crate workspace, ~2,400 tests, mutation-testing on 4 critical modules (3 at 100%, 1 at 98%).

Happy to reshape the entry if editors prefer a different wording or slot.