### PR TITLE
Add kache v0.0.35 to TWiR 649

### DIFF
--- a/draft/2026-04-29-this-week-in-rust.md
+++ b/draft/2026-04-29-this-week-in-rust.md
@@ -45,6 +45,7 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [kache v0.0.35: safer setup and daemon restarts for Rust build caching](https://github.com/kunobi-ninja/kache/releases/tag/v0.0.35)
 * [menhera-cooldown: Announcing the crates.io Cooldown Proxy — mitigating supply-chain attacks through delayed availability](https://www.menhera.org/crates-io-cooldown-proxy-mitigating-supply-chain-attacks/)
 
 ### Observations/Thoughts


### PR DESCRIPTION
Adds kache v0.0.35 to the Project/Tooling Updates section.\n\nThe linked GitHub Release includes context beyond the changelog and notes that the release notes were drafted with LLM assistance, per TWiR guidance.