### PR TITLE
Add BerryCode v0.4.1 to Project/Tooling Updates

### DIFF
--- a/draft/2026-04-29-this-week-in-rust.md
+++ b/draft/2026-04-29-this-week-in-rust.md
@@ -52,6 +52,7 @@ and just ask the editors to select the category.
 * [AimDB: Reactive Pipelines as the Engine of the Data-First Architecture](https://aimdb.dev/blog/reactive-pipelines)
 
 * [pyscan v2.1.0: Python Dependency Vulnerability Scanner - Released with SBOM support and Reachability Heuristics](https://ohaswin.github.io/blog/pyscan-v2/)
+* [BerryCode v0.4.1: A native IDE for the Bevy game engine, written in Bevy + bevy_egui + egui itself and rendered end-to-end on WGPU](https://github.com/KyosukeIshizu1008/berryscode)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
Adds an entry for BerryCode v0.4.1 to the Project/Tooling Updates section of the 2026-04-29 draft.

BerryCode is a native IDE built specifically for the Bevy game engine, written in the same stack it edits — Bevy 0.18 + bevy_egui 0.39 + egui 0.33, rendered end-to-end on WGPU. v0.4.1 was just released to crates.io.

- Repo: https://github.com/KyosukeIshizu1008/berryscode
- crates.io: https://crates.io/crates/berrycode/0.4.1
- License: MIT