### PR TITLE
Add cargo-cooldown 0.3.0 release announcement to Project/Tooling Updates

### DIFF
--- a/draft/2026-04-29-this-week-in-rust.md
+++ b/draft/2026-04-29-this-week-in-rust.md
@@ -48,6 +48,7 @@ and just ask the editors to select the category.
 ### Project/Tooling Updates
 
 * [menhera-cooldown: Announcing the crates.io Cooldown Proxy — mitigating supply-chain attacks through delayed availability](https://www.menhera.org/crates-io-cooldown-proxy-mitigating-supply-chain-attacks/)
+* [cargo-cooldown 0.3.0: a Cargo wrapper for supply-chain cooldowns, now faster and more stable](https://github.com/dertin/cargo-cooldown/releases/tag/v0.3.0)
 * [Nutype 0.7.0 - newtype with guarantees now supports conditional `cfg_attr` derives](https://github.com/greyblake/nutype/releases/tag/v0.7.0)
 * [AimDB: Reactive Pipelines as the Engine of the Data-First Architecture](https://aimdb.dev/blog/reactive-pipelines)
 


### PR DESCRIPTION
`cargo-cooldown` is a Cargo wrapper that enforces a cooldown window for freshly published crates. This release reworks the resolver so it can handle larger cooldown windows more efficiently, follows Cargo registry configuration, and includes reliability improvements around `Cargo.lock` handling.

The release notes include context on the new resolution flow and migration notes for the breaking changes.

This is related to the same supply-chain delay idea as the menhera-cooldown proxy entry, but from the local Cargo-wrapper side.