### PR TITLE
Add lean-ctx v3.4.4 to Project/Tooling Updates

### DIFF
--- a/content/2026-04-22-this-week-in-rust.md
+++ b/content/2026-04-22-this-week-in-rust.md
@@ -56,6 +56,7 @@ and just ask the editors to select the category.
 * [Danube Messaging adds Key-Shared subscriptions](https://danube-docs.dev-state.com/architecture/key_shared_architecture/)
 * [Announcing mtp-mount: pure-Rust FUSE mount for MTP devices](https://www.veszelovszki.com/a/mtp-mount/)
 * [wrkflw v0.8.0 - Validate and Run GitHub Actions locally.](https://github.com/bahdotsh/wrkflw/releases/tag/v0.8.0)
+* [lean-ctx v3.4.4 - Context runtime for AI coding agents with 46 MCP tools, reducing LLM token costs by 60-99%](https://github.com/yvgude/lean-ctx)
 
 ### Observations/Thoughts
 * [Cryptographic Right Answers: Post Quantum and Rust Edition](https://kerkour.com/post-quantum-cryptography-recommendations-rust)


### PR DESCRIPTION
## Addition

Added lean-ctx v3.4.4 to the **Project/Tooling Updates** section.

## About lean-ctx

[lean-ctx](https://github.com/yvgude/lean-ctx) is a context runtime for AI coding agents written in Rust. It reduces LLM token consumption by 60-99% through session caching, shell compression (90+ patterns), and AST-aware parsing via tree-sitter.

- Single Rust binary with 46 MCP tools
- 10 read modes for context optimization
- Supports 24 AI coding tools
- 903 GitHub stars, Apache-2.0

### Install
```
cargo install lean-ctx
```

### Links
- GitHub: https://github.com/yvgude/lean-ctx
- crates.io: https://crates.io/crates/lean-ctx
- Website: https://leanctx.com

Made with [Cursor](https://cursor.com)