### PR TITLE
Add lean-ctx to Project/Tooling Updates

### DIFF
--- a/draft/2026-04-29-this-week-in-rust.md
+++ b/draft/2026-04-29-this-week-in-rust.md
@@ -52,6 +52,7 @@ and just ask the editors to select the category.
 * [Nutype 0.7.0 - newtype with guarantees now supports conditional `cfg_attr` derives](https://github.com/greyblake/nutype/releases/tag/v0.7.0)
 * [AimDB: Reactive Pipelines as the Engine of the Data-First Architecture](https://aimdb.dev/blog/reactive-pipelines)
 
+* [lean-ctx: Building a Context Runtime for AI Coding Agents in Rust — tree-sitter, Thompson Sampling, and shell pattern compression](https://github.com/yvgude/lean-ctx/blob/main/blog/twir-lean-ctx.md)
 * [pyscan v2.1.0: Python Dependency Vulnerability Scanner - Released with SBOM support and Reachability Heuristics](https://ohaswin.github.io/blog/pyscan-v2/)
 * [flodl 0.5.3: HuggingFace, both ways (30 head cells bit-exact, universal `Trainer` for transparent fine-tuning)](https://flodl.dev/blog/huggingface-both-ways)
 


### PR DESCRIPTION
Adding lean-ctx to Project/Tooling Updates.

The linked article is a technical deep-dive into Rust-specific implementation details of lean-ctx (a context runtime for AI coding agents). It covers:

- Tree-sitter integration: two patterns (manual node walking vs. declarative queries with thread-local Parser)
- Thompson Sampling bandits with hand-rolled Beta/Gamma sampling (Marsaglia/Tsang) for adaptive compression
- Shell pattern compression using OnceLock macros and modular dispatch across 90+ command patterns
- Dual-signal cache invalidation (MD5 content hash + filesystem mtime)
- Platform-specific output decoding (Windows ACP via FFI, Unix container detection)
- Cargo feature flags for modular binary composition
- Shannon entropy computed over both characters and BPE token IDs

Note: This is a resubmission following feedback on #7996. The previous PR linked only to the GitHub repo. This PR links to a detailed technical writeup with Rust code examples and implementation learnings.

The article was written with AI assistance and this is disclosed at the end of the post.

Made with [Cursor](https://cursor.com)