### PR TITLE
Fix incorrect Australian state/territory codes

### DIFF
--- a/content/2022-05-25-this-week-in-rust.md
+++ b/content/2022-05-25-this-week-in-rust.md
@@ -263,9 +263,9 @@ Rusty Events between 2022-05-25 - 2022-06-22 🦀
 
 ### Oceania
 
-* 2022-05-26 | Brisbane City, QL, AU | [Rust Brisbane](https://www.meetup.com/Rust-Brisbane/)
+* 2022-05-26 | Brisbane City, QLD, AU | [Rust Brisbane](https://www.meetup.com/Rust-Brisbane/)
     * [**May Meetup**](https://www.meetup.com/Rust-Brisbane/events/285665676/)
-* 2022-06-17 | Melbourne, VI, AU | [Rust Melbourne](https://www.meetup.com/Rust-Melbourne/)
+* 2022-06-17 | Melbourne, VIC, AU | [Rust Melbourne](https://www.meetup.com/Rust-Melbourne/)
     * [**June 2022 Meetup**](https://www.meetup.com/Rust-Melbourne/events/285962368/)
 
 If you are running a Rust event please add it to the [calendar] to get

--- a/content/2024-05-01-this-week-in-rust.md
+++ b/content/2024-05-01-this-week-in-rust.md
@@ -374,7 +374,7 @@ Rusty Events between 2024-05-01 - 2024-05-29 🦀
 
 ### Oceania
 
-* 2024-05-02 | Brisbane City, QL, AU | [Rust Brisbane](https://www.meetup.com/rust-brisbane/)
+* 2024-05-02 | Brisbane City, QLD, AU | [Rust Brisbane](https://www.meetup.com/rust-brisbane/)
     * [**May Meetup**](https://www.meetup.com/rust-brisbane/events/300647409/)
 
 If you are running a Rust event please add it to the [calendar] to get

--- a/content/2025-02-12-this-week-in-rust.md
+++ b/content/2025-02-12-this-week-in-rust.md
@@ -433,9 +433,9 @@ Rusty Events between 2025-02-12 - 2025-03-12 🦀
     * [**Davis Square Rust Lunch, Mar 10**](https://www.meetup.com/bostonrust/events/305805192)
 
 ### Oceania
-* 2025-02-24 | Collingwood, VI, AU | [Rust Melbourne](https://www.meetup.com/rust-melbourne/events/)
+* 2025-02-24 | Collingwood, VIC, AU | [Rust Melbourne](https://www.meetup.com/rust-melbourne/events/)
     * [**February 2025 Rust Melbourne Meetup**](https://www.meetup.com/rust-melbourne/events/306040785)
-* 2025-02-25 | Barton, AC, AU | [Canberra Rust User Group](https://www.meetup.com/rust-canberra/events/)
+* 2025-02-25 | Barton, ACT, AU | [Canberra Rust User Group](https://www.meetup.com/rust-canberra/events/)
     * [**February Meetup**](https://www.meetup.com/rust-canberra/events/306090406)
 * 2025-03-04 | Perth, WA, AU | [Rust Perth Meetup Group](https://www.meetup.com/perth-rust-meetup-group/events/)
     * [**How Orica is using Rust in their workplace**](https://www.meetup.com/perth-rust-meetup-group/events/306131753)

--- a/content/2025-02-19-this-week-in-rust.md
+++ b/content/2025-02-19-this-week-in-rust.md
@@ -445,9 +445,9 @@ Rusty Events between 2025-02-19 - 2025-03-19 🦀
     * [**Rust Hacking in Person **](https://www.meetup.com/san-francisco-rust-study-group/events/302638264)
 
 ### Oceania
-* 2025-02-24 | Collingwood, VI, AU | [Rust Melbourne](https://www.meetup.com/rust-melbourne/events/)
+* 2025-02-24 | Collingwood, VIC, AU | [Rust Melbourne](https://www.meetup.com/rust-melbourne/events/)
     * [**February 2025 Rust Melbourne Meetup**](https://www.meetup.com/rust-melbourne/events/306040785)
-* 2025-02-25 | Barton, AC, AU | [Canberra Rust User Group](https://www.meetup.com/rust-canberra/events/)
+* 2025-02-25 | Barton, ACT, AU | [Canberra Rust User Group](https://www.meetup.com/rust-canberra/events/)
     * [**February Meetup**](https://www.meetup.com/rust-canberra/events/306090406)
 * 2025-02-27 | Auckland, NZ | [Rust AKL](https://www.meetup.com/rust-akl/events/)
     * [**Rust:7 Years Maintaining a Commercial Unicode Tool + Peace: Automation Framework**](https://www.meetup.com/rust-akl/events/306198434)

--- a/content/2025-03-26-this-week-in-rust.md
+++ b/content/2025-03-26-this-week-in-rust.md
@@ -341,7 +341,7 @@ Rusty Events between 2025-03-26 - 2025-04-23 🦀
 ### Oceania
 * 2025-04-14 | Christchurch, NZ | [Christchurch Rust Meetup Group](https://www.meetup.com/christchurch-rustlang-meetup-group/events/)
     * [**Christchurch Rust Meetup**](https://www.meetup.com/christchurch-rustlang-meetup-group/events/306841248)
-* 2025-04-22 | Barton, AC, AU | [Canberra Rust User Group](https://www.meetup.com/rust-canberra/events/)
+* 2025-04-22 | Barton, ACT, AU | [Canberra Rust User Group](https://www.meetup.com/rust-canberra/events/)
     * [**April Meetup**](https://www.meetup.com/rust-canberra/events/306425557)
 
 ### South America

--- a/content/2025-04-02-this-week-in-rust.md
+++ b/content/2025-04-02-this-week-in-rust.md
@@ -331,11 +331,11 @@ Rusty Events between 2025-04-02 - 2025-04-30 🦀
     * [**Ball Square Rust Lunch, Apr 25**](https://www.meetup.com/bostonrust/events/306844343)
 
 ### Oceania
-* 2025-04-09 | Sydney, NS, AU | [Rust Sydney](https://www.meetup.com/rust-sydney/events/)
+* 2025-04-09 | Sydney, NSW, AU | [Rust Sydney](https://www.meetup.com/rust-sydney/events/)
     * [**Crab 🦀 X 🕳️🐇**](https://www.meetup.com/rust-sydney/events/306978026)
 * 2025-04-14 | Christchurch, NZ | [Christchurch Rust Meetup Group](https://www.meetup.com/christchurch-rustlang-meetup-group/events/)
     * [**Christchurch Rust Meetup**](https://www.meetup.com/christchurch-rustlang-meetup-group/events/306841248)
-* 2025-04-22 | Barton, AC, AU | [Canberra Rust User Group](https://www.meetup.com/rust-canberra/events/)
+* 2025-04-22 | Barton, ACT, AU | [Canberra Rust User Group](https://www.meetup.com/rust-canberra/events/)
     * [**April Meetup**](https://www.meetup.com/rust-canberra/events/306425557)
 
 ### South America

--- a/content/2025-04-09-this-week-in-rust.md
+++ b/content/2025-04-09-this-week-in-rust.md
@@ -297,11 +297,11 @@ Rusty Events between 2025-04-09 - 2025-05-07 🦀
     * [**Boston Common Rust Lunch, May 3**](https://www.meetup.com/bostonrust/events/306845368)
 
 ### Oceania
-* 2025-04-09 | Sydney, NS, AU | [Rust Sydney](https://www.meetup.com/rust-sydney/events/)
+* 2025-04-09 | Sydney, NSW, AU | [Rust Sydney](https://www.meetup.com/rust-sydney/events/)
     * [**Crab 🦀 X 🕳️🐇**](https://www.meetup.com/rust-sydney/events/306978026)
 * 2025-04-14 | Christchurch, NZ | [Christchurch Rust Meetup Group](https://www.meetup.com/christchurch-rustlang-meetup-group/events/)
     * [**Christchurch Rust Meetup**](https://www.meetup.com/christchurch-rustlang-meetup-group/events/306841248)
-* 2025-04-22 | Barton, AC, AU | [Canberra Rust User Group](https://www.meetup.com/rust-canberra/events/)
+* 2025-04-22 | Barton, ACT, AU | [Canberra Rust User Group](https://www.meetup.com/rust-canberra/events/)
     * [**April Meetup**](https://www.meetup.com/rust-canberra/events/306425557)
 
 If you are running a Rust event please add it to the [calendar] to get

--- a/content/2025-04-16-this-week-in-rust.md
+++ b/content/2025-04-16-this-week-in-rust.md
@@ -351,7 +351,7 @@ Rusty Events between 2025-04-16 - 2025-05-14 🦀
     * [**Porter Square Rust Lunch, May 11**](https://www.meetup.com/bostonrust/events/306845728)
 
 ### Oceania
-* 2025-04-22 | Barton, AC, AU | [Canberra Rust User Group](https://www.meetup.com/rust-canberra/events/)
+* 2025-04-22 | Barton, ACT, AU | [Canberra Rust User Group](https://www.meetup.com/rust-canberra/events/)
     * [**April Meetup**](https://www.meetup.com/rust-canberra/events/306425557)
 
 If you are running a Rust event please add it to the [calendar] to get

--- a/content/2025-06-11-this-week-in-rust.md
+++ b/content/2025-06-11-this-week-in-rust.md
@@ -389,7 +389,7 @@ Rusty Events between 2025-06-11 - 2025-07-09 🦀
     * [**Alewife Rust Lunch, July 6**](https://www.meetup.com/bostonrust/events/307936287)
 
 ### Oceania
-* 2025-06-11 | Sydney, NS, AU | [Rust Sydney](https://www.meetup.com/rust-sydney/events/)
+* 2025-06-11 | Sydney, NSW, AU | [Rust Sydney](https://www.meetup.com/rust-sydney/events/)
     * [**Crab time June 🦀**](https://www.meetup.com/rust-sydney/events/308325643)
 * 2025-06-16 | Christchurch, NZ | [Christchurch Rust Meetup Group](https://www.meetup.com/christchurch-rustlang-meetup-group)
     * [**Christchurch Rust Meetup**](https://www.meetup.com/christchurch-rustlang-meetup-group/events/307808896)

--- a/content/2025-06-18-this-week-in-rust.md
+++ b/content/2025-06-18-this-week-in-rust.md
@@ -403,9 +403,9 @@ Rusty Events between 2025-06-18 - 2025-07-16 🦀
     * [**Rust Hacking in Person**](https://www.meetup.com/san-francisco-rust-study-group/events/307931266)
 
 ### Oceania
-* 2025-06-24 | Barton, AC, AU | [Canberra Rust User Group](https://www.meetup.com/rust-canberra/events/)
+* 2025-06-24 | Barton, ACT, AU | [Canberra Rust User Group](https://www.meetup.com/rust-canberra/events/)
     * [**June Meetup**](https://www.meetup.com/rust-canberra/events/307520854)
-* 2025-06-30 | Collingwood, VI, AU | [Rust Melbourne](https://www.meetup.com/rust-melbourne/events/)
+* 2025-06-30 | Collingwood, VIC, AU | [Rust Melbourne](https://www.meetup.com/rust-melbourne/events/)
     * [**June 2025 Mini Rust Melbourne Meetup**](https://www.meetup.com/rust-melbourne/events/308546374)
 
 ### South America

--- a/content/2025-06-25-this-week-in-rust.md
+++ b/content/2025-06-25-this-week-in-rust.md
@@ -366,7 +366,7 @@ Rusty Events between 2025-06-25 - 2025-07-23 🦀
     * [**Rust Lunch - Fareground**](https://www.meetup.com/rust-atx/events/xvkdgtyhckbfc)
 
 ### Oceania
-* 2025-06-30 | Collingwood, VI, AU | [Rust Melbourne](https://www.meetup.com/rust-melbourne/events/)
+* 2025-06-30 | Collingwood, VIC, AU | [Rust Melbourne](https://www.meetup.com/rust-melbourne/events/)
     * [**June 2025 Mini Rust Melbourne Meetup**](https://www.meetup.com/rust-melbourne/events/308546374)
 * 2025-07-01 | Christchurch, NZ | [Christchurch Rust Meetup Group](https://www.meetup.com/christchurch-rustlang-meetup-group/events/)
     * [**July 2025 Christchurch Rust Meetup**](https://www.meetup.com/christchurch-rustlang-meetup-group/events/308605782)

--- a/content/2025-08-06-this-week-in-rust.md
+++ b/content/2025-08-06-this-week-in-rust.md
@@ -361,7 +361,7 @@ Rusty Events between 2025-08-06 - 2025-09-03 🦀
 
 * 2025-08-11 | Christchurch, NZ | [Christchurch Rust Meetup Group](https://www.meetup.com/christchurch-rustlang-meetup-group)
   * [**Christchurch Rust Meetup**](https://www.meetup.com/christchurch-rustlang-meetup-group/events/308880707)
-* 2025-08-26 | Barton, AC, AU | [Canberra Rust User Group (CRUG)](https://www.meetup.com/rust-canberra)
+* 2025-08-26 | Barton, ACT, AU | [Canberra Rust User Group (CRUG)](https://www.meetup.com/rust-canberra)
   * [**August Meetup**](https://www.meetup.com/rust-canberra/events/308746519)
 * 2025-08-27 * 2025-08-30 | Wellington, NZ | [Rust Forge](https://rustforgeconf.com/)
   * [**Rust Forge**](https://rustforgeconf.com/)

--- a/content/2025-10-29-this-week-in-rust.md
+++ b/content/2025-10-29-this-week-in-rust.md
@@ -438,7 +438,7 @@ Rusty Events between 2025-10-29 - 2025-11-26 🦀
 
 
 ### Oceania
-* 2025-10-29 | Barton, AC, AU | [Canberra Rust User Group](https://www.meetup.com/rust-canberra/events/)
+* 2025-10-29 | Barton, ACT, AU | [Canberra Rust User Group](https://www.meetup.com/rust-canberra/events/)
     * [**October Meetup**](https://www.meetup.com/rust-canberra/events/311234237/)
 * 2025-11-11 | Christchurch, NZ | [Christchurch Rust Meetup Group](https://www.meetup.com/christchurch-rustlang-meetup-group/events/)
     * [**Christchurch Rust Meetup**](https://www.meetup.com/christchurch-rustlang-meetup-group/events/311685331/)

--- a/content/2025-11-19-this-week-in-rust.md
+++ b/content/2025-11-19-this-week-in-rust.md
@@ -388,7 +388,7 @@ Rusty Events between 2025-11-19 - 2025-12-17 🦀
     * [**Rust Study/Hack/Hang-out**](https://www.meetup.com/vancouver-rust/events/309926569/)
 
 ### Oceania
-* 2025-12-11 | Brisbane City, QL, AU | [Rust Brisbane](https://www.meetup.com/rust-brisbane)
+* 2025-12-11 | Brisbane City, QLD, AU | [Rust Brisbane](https://www.meetup.com/rust-brisbane)
     * [**Rust Meetup Dec 2025**](https://www.meetup.com/rust-brisbane/events/312027415/)
 
 If you are running a Rust event please add it to the [calendar] to get

--- a/content/2025-11-26-this-week-in-rust.md
+++ b/content/2025-11-26-this-week-in-rust.md
@@ -421,7 +421,7 @@ Rusty Events between 2025-11-26 - 2025-12-24 🦀
     * [**Rust Lunch - Fareground**](https://www.meetup.com/rust-atx/events/312076080/)
 
 ### Oceania
-* 2025-12-11 | Brisbane City, QL, AU | [Rust Brisbane](https://www.meetup.com/rust-brisbane)
+* 2025-12-11 | Brisbane City, QLD, AU | [Rust Brisbane](https://www.meetup.com/rust-brisbane)
     * [**Rust Meetup Dec 2025**](https://www.meetup.com/rust-brisbane/events/312027415/)
 
 If you are running a Rust event please add it to the [calendar] to get

--- a/content/2025-12-03-this-week-in-rust.md
+++ b/content/2025-12-03-this-week-in-rust.md
@@ -366,7 +366,7 @@ Rusty Events between 2025-12-03 - 2025-12-31 🦀
     * [**Back Bay Rust Lunch, Dec 20**](https://www.meetup.com/bostonrust/events/311917280/)
 
 ### Oceania
-* 2025-12-11 | Brisbane City, QL, AU | [Rust Brisbane](https://www.meetup.com/rust-brisbane)
+* 2025-12-11 | Brisbane City, QLD, AU | [Rust Brisbane](https://www.meetup.com/rust-brisbane)
     * [**Rust Meetup Dec 2025**](https://www.meetup.com/rust-brisbane/events/312027415/)
 
 If you are running a Rust event please add it to the [calendar] to get

--- a/content/2025-12-10-this-week-in-rust.md
+++ b/content/2025-12-10-this-week-in-rust.md
@@ -330,7 +330,7 @@ Rusty Events between 2025-12-10 - 2026-01-07 🦀
     * [**Cancelled**](https://www.meetup.com/stl-rust/events/311396047/)
 
 ### Oceania
-* 2025-12-11 | Brisbane City, QL, AU | [Rust Brisbane](https://www.meetup.com/rust-brisbane)
+* 2025-12-11 | Brisbane City, QLD, AU | [Rust Brisbane](https://www.meetup.com/rust-brisbane)
     * [**Rust Meetup Dec 2025**](https://www.meetup.com/rust-brisbane/events/312027415/)
 
 If you are running a Rust event please add it to the [calendar] to get

--- a/content/2026-02-11-this-week-in-rust.md
+++ b/content/2026-02-11-this-week-in-rust.md
@@ -323,7 +323,7 @@ Rusty Events between 2026-02-11 - 2026-03-11 🦀
     * [**MIT Rust Lunch, Mar 7**](https://www.meetup.com/bostonrust/events/313208584/)
 
 ### Oceania
-* 2026-02-11 | Brisbane City, QL, AU | [Rust Brisbane](https://www.meetup.com/rust-brisbane)
+* 2026-02-11 | Brisbane City, QLD, AU | [Rust Brisbane](https://www.meetup.com/rust-brisbane)
     * [**Rust Brisbane Feb 2026**](https://www.meetup.com/rust-brisbane/events/313087789/)
 * 2026-02-11 | Sydney, AU | [Rust Sydney](https://www.meetup.com/rust-sydney)
     * [**Welcome 🦀 to 2026**](https://www.meetup.com/rust-sydney/events/313074935/)

--- a/content/2026-04-01-this-week-in-rust.md
+++ b/content/2026-04-01-this-week-in-rust.md
@@ -386,7 +386,7 @@ Rusty Events between 2026-04-01 - 2026-04-29 🦀
     * [**South Station Rust Lunch, Apr 25**](https://www.meetup.com/bostonrust/events/313883704/)
 
 ### Oceania
-* 2026-04-09 | Brisbane City, QL, AU | [Rust Brisbane](https://www.meetup.com/rust-brisbane)
+* 2026-04-09 | Brisbane City, QLD, AU | [Rust Brisbane](https://www.meetup.com/rust-brisbane)
     * [**Rust Brisbane Apr 2026**](https://www.meetup.com/rust-brisbane/events/313975190/)
 
 ### South America

--- a/content/2026-04-08-this-week-in-rust.md
+++ b/content/2026-04-08-this-week-in-rust.md
@@ -383,7 +383,7 @@ Rusty Events between 2026-04-08 - 2026-05-06 🦀
     * [**Rust-Atl**](https://www.meetup.com/rust-atl/events/311228662/)
 
 ### Oceania
-* 2026-04-09 | Brisbane City, QL, AU | [Rust Brisbane](https://www.meetup.com/rust-brisbane)
+* 2026-04-09 | Brisbane City, QLD, AU | [Rust Brisbane](https://www.meetup.com/rust-brisbane)
     * [**Rust Brisbane Apr 2026**](https://www.meetup.com/rust-brisbane/events/313975190/)
 
 ### South America

--- a/content/2026-04-29-this-week-in-rust.md
+++ b/content/2026-04-29-this-week-in-rust.md
@@ -329,7 +329,7 @@ Rusty Events between 2026-04-29 - 2026-05-27 🦀
 ### Oceania
 * 2026-05-14 | Melbourne, AU | [Rust Melbourne](https://www.meetup.com/rust-melbourne)
     * [**Rust Melbourne - May 2026**](https://www.meetup.com/rust-melbourne/events/314260890/)
-* 2026-05-26 | Barton, AC, AU | [Canberra Rust User Group](https://www.meetup.com/rust-canberra)
+* 2026-05-26 | Barton, ACT, AU | [Canberra Rust User Group](https://www.meetup.com/rust-canberra)
     * [**May Meetup**](https://www.meetup.com/rust-canberra/events/314050576/)
 
 ### South America

--- a/draft/2026-05-06-this-week-in-rust.md
+++ b/draft/2026-05-06-this-week-in-rust.md
@@ -332,7 +332,7 @@ Rusty Events between 2026-05-06 - 2026-06-03 🦀
 ### Oceania
 * 2026-05-14 | Melbourne, AU | [Rust Melbourne](https://www.meetup.com/rust-melbourne)
     * [**Rust Melbourne - May 2026**](https://www.meetup.com/rust-melbourne/events/314260890/)
-* 2026-05-26 | Barton, AC, AU | [Canberra Rust User Group](https://www.meetup.com/rust-canberra)
+* 2026-05-26 | Barton, ACT, AU | [Canberra Rust User Group](https://www.meetup.com/rust-canberra)
     * [**May Meetup**](https://www.meetup.com/rust-canberra/events/314050576/)
 
 ### South America


### PR DESCRIPTION
Some countries have two-letter state/territory codes, such as the United States of America and India;
but Australia’s aren’t fixed width.

It so happens that the western ones are all two letters: WA, NT, SA;
but the eastern ones are all three letters: QLD, NSW, ACT, VIC, TAS.

This has been bothering me for a long time.
It took me *way* too long to finally get round to doing this!