### PR TITLE
Add Qorx project update

### DIFF
--- a/draft/2026-05-06-this-week-in-rust.md
+++ b/draft/2026-05-06-this-week-in-rust.md
@@ -45,6 +45,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [Qorx 1.0.2: local context resolution runtime in Rust](https://bbrainfuckk.github.io/qorx/QORX_1_0_2_RUST.html)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
Adds a Qorx 1.0.2 link under Project/Tooling Updates.

Disclosure: I maintain Qorx. I linked to a Rust-specific writeup rather than only the GitHub repository or crates.io page, because the submission guidelines ask for more than a plain repo/crate link.