### PR TITLE
Add kache 0.2.0 to Project/Tooling Updates

### DIFF
--- a/draft/2026-05-06-this-week-in-rust.md
+++ b/draft/2026-05-06-this-week-in-rust.md
@@ -45,6 +45,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [kache 0.2.0: zero-copy, content-addressed Rust build cache (RUSTC_WRAPPER)](https://github.com/kunobi-ninja/kache/releases/tag/v0.2.0)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
`kache` is a zero-copy, content-addressed Rust build cache. Drop-in `RUSTC_WRAPPER`; restores cache hits via hardlinks instead of copies. Local-first, blake3 content-addressed, optional S3 sync.

Release notes: https://github.com/kunobi-ninja/kache/releases/tag/v0.2.0