### PR TITLE
Add unix-ancillary 0.2.2 to Project/Tooling Updates

### DIFF
--- a/draft/2026-05-06-this-week-in-rust.md
+++ b/draft/2026-05-06-this-week-in-rust.md
@@ -45,7 +45,7 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
-* [unix-ancillary 0.2.2 — safe SCM_RIGHTS fd-passing for Rust, hardened against fd leaks on macOS and fuzz-tested](https://github.com/MohibShaikh/unix-ancillary/releases/tag/v0.2.2)
+* [unix-ancillary 0.2.2 — safe SCM_RIGHTS fd-passing for Rust](https://github.com/MohibShaikh/unix-ancillary/releases/tag/v0.2.2)
 
 ### Observations/Thoughts
 

--- a/draft/2026-05-06-this-week-in-rust.md
+++ b/draft/2026-05-06-this-week-in-rust.md
@@ -45,6 +45,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [unix-ancillary 0.2.2 — safe SCM_RIGHTS fd-passing for Rust, hardened against fd leaks on macOS and fuzz-tested](https://github.com/MohibShaikh/unix-ancillary/releases/tag/v0.2.2)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
Adds an entry under **Project/Tooling Updates** for [unix-ancillary 0.2.2](https://github.com/MohibShaikh/unix-ancillary/releases/tag/v0.2.2).

`unix-ancillary` is a small crate for safe `SCM_RIGHTS` file-descriptor passing over Unix domain sockets — `OwnedFd`/`BorrowedFd` only, no `RawFd` in the public API.

Two things in this release that may be of interest to TWiR readers:

1. **Bulletproof fd-leak protection on macOS.** macOS doesn't enforce a fixed per-message SCM_RIGHTS fd cap, so an under-sized cmsg buffer can leak fds the kernel deposits into the process. 0.2.2 sizes the receive buffer to `RLIMIT_NOFILE` so truncation is kernel-impossible — surplus fds beyond the caller's `N` are auto-closed via `OwnedFd::drop`.
2. **Fuzz-found soundness fixes.** A `cargo-fuzz` harness against the cmsg parser found two bugs (unchecked `cmsg_len` overflowing `CMSG_NXTHDR`'s pointer math, and `OwnedFd::from_raw_fd(-1)` UB on negative fd values from malformed input). Both fixed; 54M fuzz executions clean post-fix.

Crate: https://crates.io/crates/unix-ancillary
Repo: https://github.com/MohibShaikh/unix-ancillary