### PR TITLE
Add cargo-chronoscope to Project/Tooling Updates

### DIFF
--- a/draft/2026-05-06-this-week-in-rust.md
+++ b/draft/2026-05-06-this-week-in-rust.md
@@ -45,6 +45,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [cargo-chronoscope: a live TUI + GitHub Action for tracking Cargo build-time regressions](https://github.com/ymw0407/cargo-chronoscope) — records each `cargo build` to a local SQLite database, classifies per-crate compile times against historical baselines (mean ± 2σ), and posts a sticky PR comment with the diff. Differs from `cargo --timings` in that it tracks builds across time rather than analysing a single one.
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
Adds an entry under `Project/Tooling Updates` for the next issue.

`cargo-chronoscope` is a Cargo build performance observer (CLI + GitHub Action) that records each build to a local SQLite database, runs a live ratatui TUI dashboard with anomaly detection during the build, and posts a sticky PR comment with per-crate build-time regressions. The entry text in the draft notes how it differs from `cargo --timings` (cross-build trends vs single-build analysis).

Repo: https://github.com/ymw0407/cargo-chronoscope
Crate: https://crates.io/crates/cargo-chronoscope