### PR TITLE
Add 'The Sync bound nobody asked for' to Observations/Thoughts

### DIFF
--- a/draft/2026-05-06-this-week-in-rust.md
+++ b/draft/2026-05-06-this-week-in-rust.md
@@ -49,6 +49,8 @@ and just ask the editors to select the category.
 
 ### Observations/Thoughts
 
+* [The `Sync` bound nobody asked for](https://verrchu.github.io/blog/1-the-sync-bound-nobody-asked-for/)
+
 ### Rust Walkthroughs
 
 * [Writing Middlewares for Rust Lambda Functions](https://loige.co/writing-middlewares-for-rust-lambda-functions/)


### PR DESCRIPTION
Self-submission of a short Rust post for the 2026-05-06 issue.

The post explains how `&self` on an async trait method whose returned
future must be `Send` implicitly forces `Sync` on the impl type, and
why switching to `&mut self` is usually the cleaner fix than reaching
for a `Mutex`/`RwLock`.