### PR TITLE
Add imgclip to Project/Tooling Updates

### DIFF
--- a/draft/2026-05-06-this-week-in-rust.md
+++ b/draft/2026-05-06-this-week-in-rust.md
@@ -46,6 +46,7 @@ and just ask the editors to select the category.
 * [Rust Trends Issue 77 - Rust Sharpens the Craft](https://rust-trends.com/newsletter/rust-sharpens-the-craft/)
 
 ### Project/Tooling Updates
+* [Imgclip: A Cross-Platform CLI for Clipboard ↔ Image File Conversion](https://dev.to/alex_yan_6135f8195a1a3b01/imgclip-a-cross-platform-cli-for-clipboard-image-file-conversion-2i1l)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
## Project

[Imgclip](https://github.com/alexyan0431/imgclip) — A cross-platform CLI tool for clipboard ↔ image file conversion.

## Link

[Introduction article on Dev.to](https://dev.to/alex_yan_6135f8195a1a3b01/imgclip-a-cross-platform-cli-for-clipboard-image-file-conversion-2i1l) — covers motivation, four modes (one-shot, watch, interactive, copy), installation, and pipeline usage examples.

Added to the `Project/Tooling Updates` section of issue #650.