### PR TITLE
Add Minarrow to Project/Tooling Updates

### DIFF
--- a/draft/2026-05-13-this-week-in-rust.md
+++ b/draft/2026-05-13-this-week-in-rust.md
@@ -45,6 +45,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [Minarrow](https://github.com/pbower/minarrow) is a Rust-first columnar data library with Apache Arrow compatibility. It provides concrete typed arrays, SIMD-aligned buffer storage, fast clean and incremental builds, low dependency weight, Arrow-compatible layout and interop, and zero-copy paths into Polars and Python tooling.
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
Adds Minarrow to the Project/Tooling Updates section of the next This Week in Rust draft.

Minarrow is a Rust-first columnar data library with Apache Arrow compatibility, focused on concrete typed arrays, SIMD-aligned buffers, fast compile times, low dependency weight, and zero-copy interop with Polars and Python tooling.

Repo: https://github.com/pbower/minarrow
Crate: https://crates.io/crates/minarrow
Docs: https://docs.rs/minarrow