### PR TITLE
Rust Walkthroughs: add An Introduction to Programming, using ECS & EB…

### DIFF
--- a/draft/2026-05-13-this-week-in-rust.md
+++ b/draft/2026-05-13-this-week-in-rust.md
@@ -49,6 +49,8 @@ and just ask the editors to select the category.
 
 ### Rust Walkthroughs
 
+* [An Introduction to Programming, using ECS & EBP in Rust](https://root-11.github.io/intro-book/) - a 44-chapter book that teaches programming from first principles of data-oriented design, entity-component-systems, and existence-based processing, with Rust as the only language. No prior programming experience assumed. The through-line is a small ecosystem simulator that grows from one hundred creatures to a hundred million streamed ones.
+
 ### Research
 
 ### Miscellaneous


### PR DESCRIPTION
Adds a link under Rust Walkthroughs to a recently-finished first draft of a Rust book that teaches programming from scratch using ECS and EBP. The book sits between "Rust tutorial" and "data-oriented design textbook" - every concept is introduced through a runnable exercise, and the language is taught as the exercises need it rather than up-front. CC BY 4.0; code MIT/Apache-2.0.