### PR TITLE
Add ex_ratatui to Project/Tooling Updates

### DIFF
--- a/draft/2026-05-13-this-week-in-rust.md
+++ b/draft/2026-05-13-this-week-in-rust.md
@@ -45,6 +45,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [ex_ratatui](https://github.com/mcass19/ex_ratatui) — Elixir bindings for ratatui via Rustler NIFs. Including cell-buffer session API for non-terminal renderers (e.g. embedded framebuffers) and built-in SSH and Erlang-distribution transport for remote attach. Precompiled NIFs for Linux, macOS, Windows.
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
Adds ex_ratatui to Project/Tooling Updates.

Elixir bindings for ratatui via Rustler NIFs, listed in awesome-ratatui under Bindings recently.

Highlights:
- CellSession: cell-buffer snapshots + diffs for non-terminal renderers
- Built-in erlang-distribution and SSH transport: remote attach to a running TUI from another node
- Precompiled NIFs for Linux, macOS, Windows

Repo: https://github.com/mcass19/ex_ratatui
Docs: https://hexdocs.pm/ex_ratatui/getting_started.html