### PR TITLE
Add cuda-oxide project update

### DIFF
--- a/draft/2026-05-13-this-week-in-rust.md
+++ b/draft/2026-05-13-this-week-in-rust.md
@@ -45,6 +45,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [cuda-oxide](https://github.com/NVlabs/cuda-oxide) - We just open-sourced cuda-oxide, an experimental rustc backend for writing CUDA kernels in pure Rust: no DSLs, no FFI bindings, and no source-to-source step. Host code and `#[kernel]` device code can live in the same `.rs` file, and `cargo oxide build` produces a host binary plus PTX through a Rust MIR -> Pliron -> LLVM -> PTX pipeline.
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
## Summary

Adds cuda-oxide to the Project/Tooling Updates section for issue 651. We recently open-sourced it as an experimental rustc backend for writing CUDA kernels in Rust, and the linked README includes the project intro and quick-start example.

## Test plan

- `/tmp/twir-markdown-venv/bin/python tools/inspect_markdown.py --file draft/2026-05-13-this-week-in-rust.md`