### PR TITLE
Add Numax to Project/Tooling Updates

### DIFF
--- a/draft/2026-05-13-this-week-in-rust.md
+++ b/draft/2026-05-13-this-week-in-rust.md
@@ -44,7 +44,7 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
-* [numax v0.1.0-alpha.1](https://github.com/GianIac/numax/releases/tag/v0.1.0-alpha.1) - first public alpha of a portable Rust runtime for distributed apps: WebAssembly sandbox (Wasmtime), embedded local key/value store (sled), and CRDT-based state sync between peers over TLS 1.3 + mTLS.
+* [Numax - A portable Rust runtime for distributed apps](https://github.com/GianIac/numax/releases/tag/v0.1.0-alpha.1)
 
 ### Observations/Thoughts
 

--- a/draft/2026-05-13-this-week-in-rust.md
+++ b/draft/2026-05-13-this-week-in-rust.md
@@ -44,6 +44,7 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
+* [numax v0.1.0-alpha.1](https://github.com/GianIac/numax/releases/tag/v0.1.0-alpha.1) - first public alpha of a portable Rust runtime for distributed apps: WebAssembly sandbox (Wasmtime), embedded local key/value store (sled), and CRDT-based state sync between peers over TLS 1.3 + mTLS.
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
Adding the first public alpha release of **numax** to *Project/Tooling Updates*.

numax is a portable Rust runtime for distributed apps. It combines:

- a WebAssembly sandbox (Wasmtime + WASI preview1)
- an embedded local key/value store (sled)
- CRDT-based state synchronization between peers
- TLS 1.3 + mTLS with NodeID derived from the certificate's public key

The repo includes a [whitepaper](https://github.com/GianIac/numax/blob/main/WHITEPAPER.md) and a [public roadmap](https://github.com/GianIac/numax/blob/main/ROADMAP_v0.1.0.md). It's an honest alpha  what works is tested, and what's missing is explicitly tracked.

- Repo: https://github.com/GianIac/numax
- Release: https://github.com/GianIac/numax/releases/tag/v0.1.0-alpha.1

Happy to adjust the wording if the editors prefer something shorter.