### PR TITLE
2026-05-13: Fix QOTW link

### DIFF
--- a/content/2026-05-13-this-week-in-rust.md
+++ b/content/2026-05-13-this-week-in-rust.md
@@ -395,8 +395,7 @@ Please see the latest [Who's Hiring thread on r/rust](https://www.reddit.com/r/r
 > 
 > Without stronger compile-time guarantees, this stays a cat-and-mouse game. The proposal is to remove the largest bug class structurally rather than fix instances of it indefinitely.
 
-– [Jarred Sumner on the bun github](https://github.com/oven-sh/bun/blob/b953dfcee813d5004411630df2f218e5d19e5fd0/docs/rust-rewrite-plan.md#why)
-
+– [Jarred Sumner on the bun github](https://github.com/oven-sh/bun/blob/eeb4d9fdf6e9a7bdd45388d7f3a03dcf570839ad/docs/rust-rewrite-plan.md#why)
 Thanks to [Brian Kung](https://users.rust-lang.org/t/twir-quote-of-the-week/328/1765) for the suggestion!
 
 [Please submit quotes and vote for next week!](https://users.rust-lang.org/t/twir-quote-of-the-week/328)

--- a/content/2026-05-13-this-week-in-rust.md
+++ b/content/2026-05-13-this-week-in-rust.md
@@ -395,7 +395,7 @@ Please see the latest [Who's Hiring thread on r/rust](https://www.reddit.com/r/r
 > 
 > Without stronger compile-time guarantees, this stays a cat-and-mouse game. The proposal is to remove the largest bug class structurally rather than fix instances of it indefinitely.
 
-– [Jarred Sumner on the bun github](https://github.com/oven-sh/bun/blob/claude/phase-a-port/docs/rust-rewrite-plan.md#why)
+– [Jarred Sumner on the bun github](https://github.com/oven-sh/bun/blob/b953dfcee813d5004411630df2f218e5d19e5fd0/docs/rust-rewrite-plan.md#why)
 
 Thanks to [Brian Kung](https://users.rust-lang.org/t/twir-quote-of-the-week/328/1765) for the suggestion!
 


### PR DESCRIPTION
The original file was removed from the repo. The new link points to the (AFAICT) last commit before deletion.