### PR TITLE
Add Savitri Network to Project and CFP section

### DIFF
--- a/draft/2026-05-20-this-week-in-rust.md
+++ b/draft/2026-05-20-this-week-in-rust.md
@@ -46,7 +46,7 @@ and just ask the editors to select the category.
 ### Project/Tooling Updates
 
 * [ex_ratatui](https://hexdocs.pm/ex_ratatui): Elixir bindings for ratatui via Rustler NIFs.
-
+* [Savitri Network](https://github.com/Savitri-Network/savitri-network) : A Rust DAG network that trains AI via federated learning embedded in its consensus mechanism.
 ### Observations/Thoughts
 
 ### Rust Walkthroughs
@@ -120,8 +120,8 @@ Every week we highlight some tasks from the Rust community for you to pick and g
 
 Some of these tasks may also have mentors available, visit the task page for more information.
 
-<!-- CFPs go here, use this format: * [project name - title of issue](URL to issue) -->
-<!-- * [ - ]() -->
+<!-- CFPs go here, use this format: * [project name - title of issue](URL to issue) -->  
+<!-- * [ Savitri Network - Phase 2.6 sub-task 6 — Quality-detection FSM]([https://github.com/Savitri-Network/savitri-network/issues/40]) --> 
 <!-- or if none - *No Calls for participation were submitted this week.* -->
 
 If you are a Rust project owner and are looking for contributors, please submit tasks [here][guidelines] or through a [PR to TWiR](https://github.com/rust-lang/this-week-in-rust) or by reaching out on [Bluesky](https://bsky.app/profile/thisweekinrust.bsky.social) or [Mastodon](https://mastodon.social/@thisweekinrust)!


### PR DESCRIPTION
Add Savitri Network in section Projects/Tooling Updates :

Savitri is an experimental Rust DAG network that trains AI via federated learning embedded directly in its consensus mechanism: the same Proof-of-Uptime signal that gates block production also weights FL aggregation rounds. The networking layer splits control vs. data plane in a single libp2p swarm (gossipsub for transactions, request-response for consensus votes/certs) to keep forward queues from saturating under load.

And also in CFP section with the issue : https://github.com/Savitri-Network/savitri-network/issues/40

(Note: built end-to-end in safe Rust — tokio, libp2p, rocksdb, ed25519-dalek — no FFI/Unsafe.)

Repo: https://github.com/Savitri-Network/savitri-network