### PR TITLE
Add ghr to Project/Tooling Updates

### DIFF
--- a/draft/2026-05-20-this-week-in-rust.md
+++ b/draft/2026-05-20-this-week-in-rust.md
@@ -46,7 +46,7 @@ and just ask the editors to select the category.
 ### Project/Tooling Updates
 
 * [ex_ratatui](https://hexdocs.pm/ex_ratatui): Elixir bindings for ratatui via Rustler NIFs.
-* [ghr](https://github.com/chenyukang/ghr): a Rust TUI for managing GitHub pull requests, issues, notifications, and reviews.
+* [ghr: a Rust TUI for managing GitHub pull requests, issues, notifications, and reviews](https://catcoding.me/ghr/)
 
 ### Observations/Thoughts
 

--- a/draft/2026-05-20-this-week-in-rust.md
+++ b/draft/2026-05-20-this-week-in-rust.md
@@ -46,6 +46,7 @@ and just ask the editors to select the category.
 ### Project/Tooling Updates
 
 * [ex_ratatui](https://hexdocs.pm/ex_ratatui): Elixir bindings for ratatui via Rustler NIFs.
+* [ghr](https://github.com/chenyukang/ghr): a Rust TUI for managing GitHub pull requests, issues, notifications, and reviews.
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
Adding ghr to Project/Tooling Updates.

[ghr](https://github.com/chenyukang/ghr) is a Rust TUI for managing GitHub pull requests, issues, notifications, and reviews.

Current release: https://github.com/chenyukang/ghr/releases/tag/v0.8.0