### PR TITLE
Add Oryxis 0.7 to Project/Tooling Updates

### DIFF
--- a/draft/2026-05-20-this-week-in-rust.md
+++ b/draft/2026-05-20-this-week-in-rust.md
@@ -46,6 +46,7 @@ and just ask the editors to select the category.
 ### Project/Tooling Updates
 
 * [ex_ratatui](https://hexdocs.pm/ex_ratatui): Elixir bindings for ratatui via Rustler NIFs.
+* [Oryxis 0.7](https://github.com/wilsonglasser/oryxis/releases/tag/v0.7.0): a Rust-native SSH client.
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
Submitting Oryxis 0.7 for the Project/Tooling Updates section of the 2026-05-20 draft.

Description trimmed per feedback on #8061.

Release: https://github.com/wilsonglasser/oryxis/releases/tag/v0.7.0
Repo: https://github.com/wilsonglasser/oryxis