### PR TITLE
Add kache 0.3.0 to Project/Tooling Updates

### DIFF
--- a/draft/2026-05-20-this-week-in-rust.md
+++ b/draft/2026-05-20-this-week-in-rust.md
@@ -50,6 +50,7 @@ and just ask the editors to select the category.
 * [cargo-crap: Finding Untested Complexity in AI-Generated Rust Code](https://minikin.me/blog/cargo-crap)
 * [What the Graph Owes](https://aimdb.dev/blog/graph-owes): Connectors That Drive Outputs
 * [swpui: a TUI for case-aware search and replace](https://beeb.li/blog/introducing-swpui)
+* [kache 0.3.0: zero-copy efficient worktree compilation](https://kunobi.ninja/blog/kache-update)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
Adds **kache 0.3.0** to Project/Tooling Updates for issue 652.

kache is a zero-copy, content-addressed Rust build cache (a drop-in `RUSTC_WRAPPER`) that deduplicates build artifacts across worktrees. The 0.3.0 release adds reflink-first restores, an optional `sccache` fallback for passthroughs, and early native C/C++ object caching.

Follow-up to the kache 0.2.0 entry that ran in issue 650 (2026-05-06). We got excellent feedback last time and this new release addresses many of those requests.

Disclosure: I'm one of the kache maintainers.