### PR TITLE
Add slintcn 0.22 to Project/Tooling Updates

### DIFF
--- a/draft/2026-05-27-this-week-in-rust.md
+++ b/draft/2026-05-27-this-week-in-rust.md
@@ -45,6 +45,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [slintcn 0.22: shadcn/ui-style copy-paste components for Slint native apps](https://github.com/stevekwon211/slintcn/blob/main/docs/INTRODUCING_SLINTCN.md)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
Adds slintcn 0.22 to the Project/Tooling Updates section for issue 653.

The linked page is a Rust/Slint-specific introduction with install commands, a Slint code example, and notes on the copy-paste registry workflow.