### PR TITLE
Add rgx v0.12.3 to Project/Tooling Updates

### DIFF
--- a/draft/2026-05-27-this-week-in-rust.md
+++ b/draft/2026-05-27-this-week-in-rust.md
@@ -45,6 +45,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [rgx v0.12.3 released — terminal regex debugger with step-through execution, 3 engines, code generation, and live stream filtering](https://github.com/brevity1swos/rgx/releases/tag/v0.12.3)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs

--- a/draft/2026-05-27-this-week-in-rust.md
+++ b/draft/2026-05-27-this-week-in-rust.md
@@ -45,7 +45,7 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
-* [rgx v0.12.3 released — terminal regex debugger with step-through execution, 3 engines, code generation, and live stream filtering](https://github.com/brevity1swos/rgx/releases/tag/v0.12.3)
+* [rgx v0.12.3 — Building a regex debugger for the terminal in Rust](https://dev.to/brevity1swos/building-a-regex-debugger-for-the-terminal-in-rust-977)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
Adding **rgx v0.12.3** under Project/Tooling Updates.

rgx is a terminal regex debugger written in Rust (ratatui + crossterm). v0.12.3 ships:

- Context-aware `Ctrl+Y` copy (pattern or selected match depending on focused panel)
- Reorganized Quick Reference help page (3 labeled sections, `\t \n \r`, lookahead hint)
- Filter subsystem hardening: bounded 64 KiB drain to prevent OOM on oversized lines, consistent `detect_minimum_engine()` across TUI and non-interactive paths, split truncation warning (byte vs line-count), UTF-8-correct escape error reporting in the JSON path parser

Release: https://github.com/brevity1swos/rgx/releases/tag/v0.12.3  
Crate: https://crates.io/crates/rgx-cli