### PR TITLE
Add KKTerm CFP

### DIFF
--- a/draft/2026-05-27-this-week-in-rust.md
+++ b/draft/2026-05-27-this-week-in-rust.md
@@ -121,6 +121,7 @@ Some of these tasks may also have mentors available, visit the task page for mor
 <!-- CFPs go here, use this format: * [project name - title of issue](URL to issue) -->
 <!-- * [ - ]() -->
 <!-- or if none - *No Calls for participation were submitted this week.* -->
+* [KKTerm - Add tests for installer checksum parsing in the smoke test script](https://github.com/ryantsai/KKTerm/issues/145)
 
 If you are a Rust project owner and are looking for contributors, please submit tasks [here][guidelines] or through a [PR to TWiR](https://github.com/rust-lang/this-week-in-rust) or by reaching out on [Bluesky](https://bsky.app/profile/thisweekinrust.bsky.social) or [Mastodon](https://mastodon.social/@thisweekinrust)!
 


### PR DESCRIPTION
Adds a Call for Participation entry for KKTerm.

The linked issue is a bounded PowerShell/release-gate testing task with:

- OSI-approved MIT license in the project repo
- public issue tracker
- `good first issue` and `help wanted` labels
- difficulty noted in the issue body
- contributor requirements and `CONTRIBUTING.md` link noted in the issue body

This is intended as a CFP item rather than a project/tooling announcement.
