### PR TITLE
Add BoquilaHUB 0.5 to Project/Tooling Updates

### DIFF
--- a/draft/2026-05-27-this-week-in-rust.md
+++ b/draft/2026-05-27-this-week-in-rust.md
@@ -45,6 +45,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [BoquilaHUB 0.5: AIs for Nature. Now it includes SOTA AI bioacoustics models and embeddings models](https://github.com/boquila/boquilahub/releases/tag/v0.5)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
Adding a new release to Project/Tooling Updates

BoquilaHUB is a cross-platform desktop app to run AI models locally, with a focus in biodiversity and nature 

The repo: https://github.com/boquila/boquilahub/

The release: https://github.com/boquila/boquilahub/releases/tag/v0.5