### PR TITLE
Add release notes for dtact and rssn-advanced

### DIFF
--- a/draft/2026-05-27-this-week-in-rust.md
+++ b/draft/2026-05-27-this-week-in-rust.md
@@ -46,6 +46,7 @@ and just ask the editors to select the category.
 ### Project/Tooling Updates
 
 * [slintcn 0.22: shadcn/ui-style copy-paste components for Slint native apps](https://github.com/stevekwon211/slintcn/blob/main/docs/INTRODUCING_SLINTCN.md)
+* [Releasing dtact v0.2.2 and rssn-advanced v0.1.0: the next generation async concurrent engine and scientific computing engine](https://users.rust-lang.org/t/releasing-dtact-v0-2-2-and-rssn-advanced-v0-1-0/140278)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
Hi!
We are developers from the Apich Organization Development Team and would like to submit our release post for this week's This Week in Rust. We would really appreciate it if you could include it.
Some details about it:
https://users.rust-lang.org/t/releasing-dtact-v0-2-2-and-rssn-advanced-v0-1-0/140278
https://dtact.apich.org/
https://github.com/Apich-Organization/rssn-advanced
https://github.com/Apich-Organization/dtact
https://www.bestpractices.dev/en/projects/12962/passing

Thanks for your time！