### PR TITLE
add serde-const-default v0.1 to Project/Tooling Updates

### DIFF
--- a/draft/2026-05-27-this-week-in-rust.md
+++ b/draft/2026-05-27-this-week-in-rust.md
@@ -45,6 +45,7 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [serde-const-default v0.1: Removes boilerplate when using const values as field defaults](https://github.com/ifsheldon/serde-const-default/releases/tag/v0.1)
 * [slintcn 0.22: shadcn/ui-style copy-paste components for Slint native apps](https://github.com/stevekwon211/slintcn/blob/main/docs/INTRODUCING_SLINTCN.md)
 
 ### Observations/Thoughts


### PR DESCRIPTION
Hi! this adds the release note of my tool `serde-const-default` which helps remove boilerplate when using const values as field defaults with `serde`. Thanks!