### PR TITLE
Add webrtc-doctor announcement to Project/Tooling Updates

### DIFF
--- a/draft/2026-06-03-this-week-in-rust.md
+++ b/draft/2026-06-03-this-week-in-rust.md
@@ -44,6 +44,7 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
+* [When "ICE failed" is the only error you ever see — a case for hand-rolling protocols in a diagnostic tool](https://medium.com/@jamalag/when-ice-failed-is-the-only-error-you-ever-see-0e7ac8e794b7)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
Adds a project announcement for webrtc-doctor, a single-binary Rust CLI for diagnosing WebRTC connectivity (STUN/TURN/TURNS/signaling/ICE/DTLS). Apache-2.0. The linked article explains the design decision to hand-roll the STUN/TURN wire codecs against the RFCs rather than depend on a high-level WebRTC library, and discusses when that trade-off is correct.
