### PR TITLE
Add MD Preview engineering note

### DIFF
--- a/draft/2026-06-03-this-week-in-rust.md
+++ b/draft/2026-06-03-this-week-in-rust.md
@@ -45,6 +45,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [Building a Native Markdown Previewer for AI-Generated Docs with Rust and WebView](https://vorojar.github.io/md-preview/rust-webview-ai-docs.html)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs
@@ -121,6 +123,7 @@ Some of these tasks may also have mentors available, visit the task page for mor
 <!-- CFPs go here, use this format: * [project name - title of issue](URL to issue) -->
 <!-- * [ - ]() -->
 <!-- or if none - *No Calls for participation were submitted this week.* -->
+* [MD Preview - Package MD Preview for Homebrew Cask](https://github.com/vorojar/md-preview/issues/19)
 
 If you are a Rust project owner and are looking for contributors, please submit tasks [here][guidelines] or through a [PR to TWiR](https://github.com/rust-lang/this-week-in-rust) or by reaching out on [Bluesky](https://bsky.app/profile/thisweekinrust.bsky.social) or [Mastodon](https://mastodon.social/@thisweekinrust)!
 


### PR DESCRIPTION
Adds an engineering note about MD Preview to the Project/Tooling Updates section and a real contribution task to CFP.

The post covers Rust-specific implementation choices behind a small native Markdown previewer:

- Rust + wry + system WebView instead of Electron
- pulldown-cmark for the base Markdown pass
- offline KaTeX/Mermaid/syntax highlighting loaded only when needed
- notify-based live reload for local Markdown files
- cross-platform desktop packaging tradeoffs

The post includes a disclosure that it was drafted with Codex assistance and reviewed in project context.

CFP task added: package MD Preview for Homebrew Cask, labeled `help wanted` / `good first issue`.