### PR TITLE
Add PRECC to Project/Tooling Updates

### DIFF
--- a/draft/2026-06-03-this-week-in-rust.md
+++ b/draft/2026-06-03-this-week-in-rust.md
@@ -45,6 +45,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [PRECC: a PreToolUse hook that fixes coding-agent shell commands before they run](https://github.com/precc-cli/precc)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
Adds one line to **Project/Tooling Updates**:

* [PRECC: a PreToolUse hook that fixes coding-agent shell commands before they run](https://github.com/precc-cli/precc)

PRECC is an open-source (MIT/Apache) Rust tool — a `PreToolUse` hook for Claude Code / Codex that rewrites shell commands before they run: wrong-directory correction (`cd <project-root>`), failure→fix mining into reusable skills, and pluggable output compression (built on RTK). The engine, `precc-core`, is on crates.io.

Happy to adjust the wording or drop it if it's not a fit — thanks for curating TWiR!
