### PR TITLE
Enable warnings for links to github.com and crates.io & suppress existing warnings

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -13,6 +13,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
+          fetch-depth: 0
       - name: Install Python dependencies
         uses: py-actions/py-dependency-install@9c419aa98bfb42280bdae2b0a736befd9b01e3b1 # v4
         with:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,5 +1,5 @@
 name: Correctness Checks
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 permissions:
   contents: read

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,5 +1,13 @@
 name: Correctness Checks
-on: [push, pull_request]
+on:
+  pull_request:
+
+  # We avoid running the push event on PR branches so that
+  # they are instead run through pull_request and we get the merge base
+  # for use below.
+  push:
+    branches:
+      - main
 
 permissions:
   contents: read

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,5 +1,5 @@
 name: Correctness Checks
-on: [push, pull_request, workflow_dispatch]
+on: [push, pull_request]
 
 permissions:
   contents: read
@@ -20,7 +20,23 @@ jobs:
           update-pip: "false"
           update-setuptools: "false"
           update-wheel: "false"
+      - name: Compute diff base
+        id: base
+        shell: bash
+        run: |
+            if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+                BASE="$(git merge-base \
+                    "${{ github.event.pull_request.base.sha }}" \
+                    "${{ github.event.pull_request.head.sha }}")"
+            elif [[ "${{ github.event_name }}" == "push" ]]; then
+                BASE="${{ github.event.before }}"
+            else
+                echo "Unsupported event: ${{ github.event_name }}" >&2
+                exit 1
+            fi
+
+            echo "base=$BASE" >> "$GITHUB_OUTPUT"
       - name: inspect_links
-        run: python3 tools/inspect_links.py --num-warn 5
+        run: python3 tools/inspect_links.py --since "${{ steps.base.outputs.base }}"
       - name: inspect_markdown
         run: python3 tools/inspect_markdown.py --num-recent 5

--- a/tools/inspect_links.py
+++ b/tools/inspect_links.py
@@ -32,6 +32,9 @@ class Warnings:
         if not self.silent:
             self.warnings.append(msg)
 
+    def get(self):
+        return self.warnings
+
     def get_and_clear(self):
         to_return = self.warnings
         self.warnings = []

--- a/tools/inspect_links.py
+++ b/tools/inspect_links.py
@@ -7,12 +7,14 @@ Inspect a set of markdown files, and warn if there are:
 """
 
 import argparse
+from typing import Union
 import bs4
 import logging
 import markdown
 import os
 import re
 import sys
+import pygit2
 import urllib.parse
 
 LOG = logging.getLogger(__name__)
@@ -26,15 +28,14 @@ class Warnings:
         self.warnings = []
         self.silent = False
 
-    def silence(self, val):
-        self.silent = val
-
     def warn(self, msg):
         if not self.silent:
             self.warnings.append(msg)
 
-    def get(self):
-        return self.warnings
+    def get_and_clear(self):
+        to_return = self.warnings
+        self.warnings = []
+        return to_return
 
 
 # The singleton object that gathers warnings, for later reporting.
@@ -217,9 +218,17 @@ def parse_url(link):
 
     return reconstituted
 
-def inspect_file(filename):
+def inspect_file(filename, tree: Union[pygit2.Tree, None] = None):
     LOG.info(f'inspecting file {filename}')
-    md_text = open(filename).read()
+    if tree:
+        if filename in tree:
+            md_text = tree[filename].data.decode('utf-8')
+        else:
+            # When looking at old commits, missing files are ok -- they were just added later
+            LOG.debug(f'skipping missing file in tree: {filename}')
+            return []
+    else:
+        md_text = open(filename).read()
     html = markdown.markdown(md_text)
     links = extract_links(html)
     LOG.debug(f'examining {len(links)} links')
@@ -256,17 +265,12 @@ def get_recent_files(dirs, count):
     return listing
 
 
-def inspect_files(file_list, num_warn):
+def inspect_files(file_list: list[str], *, tree: Union[pygit2.Tree, None] = None):
     """ Inspect a set of files, storing warnings about duplicate links. """
     linkset = {}
 
-    # If we inspect 5 files (enumerated 0-4), and want to warn on 2,
-    # then the warnings start at N=3 (length - 1 - num_warn).
-    warn_index = len(file_list) - 1 - num_warn
-
     for index, file in enumerate(file_list):
-        warnings.silence(index < warn_index)
-        links = inspect_file(file)
+        links = inspect_file(file, tree=tree)
         LOG.debug(f'found links: {links}')
         for link in links:
             collision = linkset.get(link)
@@ -283,15 +287,36 @@ def main():
                         help="Directory paths to inspect (colon separated)")
     parser.add_argument('--num-recent', default=25, type=int,
                         help="Number of recent files to inspect")
-    parser.add_argument('--num-warn', default=1, type=int,
-                        help="Number of recent files to warn about")
+    parser.add_argument('--since', default=None, type=str,
+                        help="Show only warnings which appear after the given git commit")
     parser.add_argument('--debug', action='store_true')
     args = parser.parse_args()
     if args.debug:
         LOG.setLevel(logging.DEBUG)
     LOG.debug(f'command-line arguments: {args}')
     file_list = get_recent_files(args.paths, args.num_recent)
-    inspect_files(file_list, args.num_warn)
+    inspect_files(file_list)
+
+    warns = warnings.get_and_clear()
+
+    if args.since:
+        try:
+            tree = pygit2.Repository(".").revparse_single(args.since).tree
+        except KeyError:
+            raise ValueError(f'no such commit: {args.since}')
+
+        LOG.info(f"inspecting files since commit {args.since}")
+        inspect_files(file_list, tree=tree)
+        old_warns = set(warnings.get_and_clear())
+        warns = [w for w in warns if w not in old_warns]
+
+    if warns:
+        print("warnings exist:")
+        for w in warns:
+            print(w)
+        sys.exit(1)
+    else:
+        print("everything is ok!")
 
 
 def setup_logging():
@@ -302,12 +327,3 @@ def setup_logging():
 if __name__ == "__main__":
     setup_logging()
     main()
-
-    warns = warnings.get()
-    if warns:
-        print("warnings exist:")
-        for w in warns:
-            print(w)
-        sys.exit(1)
-    else:
-        print("everything is ok!")

--- a/tools/inspect_links.py
+++ b/tools/inspect_links.py
@@ -51,7 +51,7 @@ TRACKING_PARAMETERS = set([
     'utm_content',
 ])
 
-# A list of section titles that will trigger duplicate-tag detection.
+# A list of section titles that will trigger strict checks.
 STRICT_TITLES = [
     'updates from rust community',
 ]
@@ -82,13 +82,21 @@ def check_truncated_title(tag):
     if title and title.endswith('...') and len(title) == 70:
         warnings.warn(f'truncated link title: {repr(title)}')
 
+def check_domain(domain, url):
+  if domain.lower() == "github.com":
+    warnings.warn(f"link {url} is to github.com -- we do not usually include links directly to GitHub repos; "
+      "please double check our guidelines here: https://github.com/rust-lang/this-week-in-rust#projectstooling-updates")
+  elif domain.lower() == "crates.io":
+    warnings.warn(f"link {url} is to crates.io -- we do not usually include links directly to crates on crates.io; "
+      "please double check our guidelines here: https://github.com/rust-lang/this-week-in-rust#projectstooling-updates")
 
 def extract_links(html):
     """ Return a list of links from this file.
 
     Links will only be returned if they are within a section deemed "strict".
-    This allows us to ignore links that are deliberately repeated (to this
-    github repo and twitter account, for example).
+    This allows us to ignore links that are deliberately repeated or don't
+    follow usual contribution guidelines (to this github repo and twitter
+    account, for example).
 
     Side-effects:
     - If links are malformed, warnings may be recorded. See `parse_url`
@@ -205,8 +213,9 @@ def parse_url(link):
     # need to warn about
     reconstituted = urllib.parse.urlunsplit((scheme, loc, path, query, frag))
 
-    return reconstituted
+    check_domain(loc, link)
 
+    return reconstituted
 
 def inspect_file(filename):
     LOG.info(f'inspecting file {filename}')

--- a/tools/inspect_links.py
+++ b/tools/inspect_links.py
@@ -221,7 +221,7 @@ def parse_url(link):
 
     return reconstituted
 
-def inspect_file(filename, tree: Union[pygit2.Tree, None] = None):
+def inspect_file(filename, *, tree: Union[pygit2.Tree, None] = None):
     LOG.info(f'inspecting file {filename}')
     if tree:
         if filename in tree:

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,2 +1,3 @@
 beautifulsoup4==4.10.0
 Markdown==3.8.1
+pygit2==1.15.1


### PR DESCRIPTION
Makes the existing CI checks for suspicious links also produce warnings for links to github.com and crates.io, pointing to the [contribution guidelines](https://github.com/rust-lang/this-week-in-rust#projectstooling-updates). 

These are more likely to be false-positives than existing link checks (for example, the recent issue had a couple github.com links). To try and help with this problem, this also introduces a `--since` parameter for the link-checking script which suppresses warnings that already were checked into git. The GitHub Action now passes the merge base (for PRs) or previous HEAD SHA (for pushes) as this parameter. The net result is that contributors should only get *new* warnings, not see old ones. PRs can then be safely merged despite these warnings when appropriate without having them show up over and over. 

In the future we could separate hard warnings from softer ones, and perhaps have the latter just post a comment suggesting folks double check. 

Here is an example PR showing the new warnings: https://github.com/jder/this-week-in-rust/pull/3

cc @nellshamrell 

Fixes https://github.com/rust-lang/this-week-in-rust/issues/8148

I use LLMs regularly while coding, but I understand and vouch for this code. 