### PR TITLE
`event`: Add SciPy India x Rust Delhi Meetup

### DIFF
--- a/draft/2026-06-03-this-week-in-rust.md
+++ b/draft/2026-06-03-this-week-in-rust.md
@@ -244,6 +244,8 @@ Rusty Events between 2026-06-03 - 2026-07-01 🦀
 ### Asia
 * 2026-06-02 | Beijing, CN | [Voice AI and Rust Meetup (Rust for AI, lowcoderust.com)](https://www.meetup.com/wasm-rust-meetup/events/)
     * [**AI Agents and Open Source LLM (Call for Speakers)**](https://www.meetup.com/wasm-rust-meetup/events/314750465/)
+* 2026-08-22 | Noida, IN | [SciPy India](https://scipy.in/) X [Rust Delhi](https://rustdelhi.in/)
+    * [**Scientific Computing in Rust and Python**](https://scipy.in/sci-py-rs/)
 
 ### Europe
 * 2026-05-28 | Copenhagen, DK | [Copenhagen Rust Community](https://www.meetup.com/copenhagen-rust-community)


### PR DESCRIPTION
Adds the `SciPy India x Rust Delhi Meetup` to the Asia events section. It's a scientific computing in Rust and Python meetup co-organized by [SciPy India](https://scipy.in/) and [Rust Delhi](https://rustdelhi.in/), with RSVPs and the CFP currently [open](https://scipy.in/sci-py-rs/).

CC: @agriyakhetarpal, @gswebspace