### PR TITLE
disable link domain checks

### DIFF
--- a/tools/inspect_links.py
+++ b/tools/inspect_links.py
@@ -217,7 +217,8 @@ def parse_url(link):
     # need to warn about
     reconstituted = urllib.parse.urlunsplit((scheme, loc, path, query, frag))
 
-    check_domain(loc, link)
+    # Disabled since it's currently failing on the main branch: checks are too strict
+    # check_domain(loc, link)
 
     return reconstituted
 


### PR DESCRIPTION
This check is too strict (warns on links we currently accept) and is causing CI to fail on the main branch.

CC: @jder 