### PR TITLE
Add TeaQL Robot Task Board entry

### DIFF
--- a/draft/2026-06-03-this-week-in-rust.md
+++ b/draft/2026-06-03-this-week-in-rust.md
@@ -51,6 +51,7 @@ and just ask the editors to select the category.
 * [xa11y: cross-platform desktop automation via native accessibility APIs](https://crowecawcaw.github.io/general/2026/05/30/accessibility-for-computer-use.html)
 * [halloy 2026.7 - now supports IRCv3 reply, redact, metadata, bot mode and more!](https://github.com/squidowl/halloy/releases/tag/2026.7)
 * [Building a Native Markdown Previewer for AI-Generated Docs with Rust and WebView](https://vorojar.github.io/md-preview/rust-webview-ai-docs.html)
+* [TeaQL Robot Task Board](https://github.com/teaql/robot-task-board) - A runnable Rust + Ratatui + SQLite TUI demo showing visible query intent, generated SQL, faceted counts, optimistic updates, and audit-style traces for business-domain code.
 
 ### Observations/Thoughts
 

--- a/draft/2026-06-03-this-week-in-rust.md
+++ b/draft/2026-06-03-this-week-in-rust.md
@@ -51,7 +51,7 @@ and just ask the editors to select the category.
 * [xa11y: cross-platform desktop automation via native accessibility APIs](https://crowecawcaw.github.io/general/2026/05/30/accessibility-for-computer-use.html)
 * [halloy 2026.7 - now supports IRCv3 reply, redact, metadata, bot mode and more!](https://github.com/squidowl/halloy/releases/tag/2026.7)
 * [Building a Native Markdown Previewer for AI-Generated Docs with Rust and WebView](https://vorojar.github.io/md-preview/rust-webview-ai-docs.html)
-* [TeaQL Robot Task Board](https://github.com/teaql/robot-task-board) - A runnable Rust + Ratatui + SQLite TUI demo showing visible query intent, generated SQL, faceted counts, optimistic updates, and audit-style traces for business-domain code.
+* [TeaQL Robot Task Board](https://github.com/teaql/robot-task-board) - A runnable Rust + Ratatui + SQLite TUI demo for visible SQL, facets, optimistic updates, and audit traces.
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
This adds TeaQL Robot Task Board to the Project/Tooling Updates section.

It is a runnable Rust TUI demo built with Ratatui and SQLite. The demo focuses on visible SQL, facets, optimistic updates, and audit-style runtime traces.

The repository includes runnable code, examples, Docker setup, a short video, and a deeper-dive write-up.

If this is too late for the current issue, I’m happy for it to be considered for the next one.