### PR TITLE
Add kache 0.4.1 to Project/Tooling Updates

### DIFF
--- a/draft/2026-06-03-this-week-in-rust.md
+++ b/draft/2026-06-03-this-week-in-rust.md
@@ -51,6 +51,7 @@ and just ask the editors to select the category.
 * [xa11y: cross-platform desktop automation via native accessibility APIs](https://crowecawcaw.github.io/general/2026/05/30/accessibility-for-computer-use.html)
 * [halloy 2026.7 - now supports IRCv3 reply, redact, metadata, bot mode and more!](https://github.com/squidowl/halloy/releases/tag/2026.7)
 * [Building a Native Markdown Previewer for AI-Generated Docs with Rust and WebView](https://vorojar.github.io/md-preview/rust-webview-ai-docs.html)
+* [kache 0.4.1: kache key correctness, C/C++ caching, and first-class Windows](https://kunobi.ninja/blog/kache-v0-4-1)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
Adds kache 0.4.1 to Project/Tooling Updates for issue from 2026-06-03

kache is a zero-copy, content-addressed Rust build cache (a drop-in RUSTC_WRAPPER) that deduplicates build artifacts across worktrees. 
The 0.4.1 release fixes two cache key correctness bugs found in real workloads (linker path leaking into cross-agent keys, RUSTFLAGS whitespace producing divergent hashes), adds reliability hardening for CI (atomic entry registration, remote artifact hash verification, compiler fallback on cache errors), ships experimental C/C++ object caching behind a declarative flag classification table, and lands first-class Windows support with a durability fix.

Follow-up to the kache 0.3.0 entry. The correctness bugs were surfaced by the feedback from last time, thanks to everyone who sent build traces.

Disclosure: I'm part of the team maintaining kache 