### PR TITLE
Add rustsec.debian.net

### DIFF
--- a/draft/2026-06-03-this-week-in-rust.md
+++ b/draft/2026-06-03-this-week-in-rust.md
@@ -47,6 +47,7 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [Debian Rust Security Tracker launched](https://rustsec.debian.net/)
 * [One year of Roto, the compiled scripting language for Rust](https://blog.nlnetlabs.nl/one-year-of-roto-the-compiled-scripting-language-for-rust/)
 * [xa11y: cross-platform desktop automation via native accessibility APIs](https://crowecawcaw.github.io/general/2026/05/30/accessibility-for-computer-use.html)
 * [halloy 2026.7 - now supports IRCv3 reply, redact, metadata, bot mode and more!](https://github.com/squidowl/halloy/releases/tag/2026.7)


### PR DESCRIPTION
The project has been around for some time but wasn't properly announced. I have submitted it to r/rust this week:

https://www.reddit.com/r/rust/comments/1tuly3z/debian_rust_security_tracker/

If you want I can write some more how this projects works so it would be suitable for it's own section.

Thanks!