### PR TITLE
Add VillageSQL Rust extension walkthrough

### DIFF
--- a/draft/2026-06-10-this-week-in-rust.md
+++ b/draft/2026-06-10-this-week-in-rust.md
@@ -49,6 +49,8 @@ and just ask the editors to select the category.
 
 ### Rust Walkthroughs
 
+* [Extend MySQL Using Rust](https://villagesql.com/blog/rust/)
+
 ### Research
 
 ### Miscellaneous
@@ -258,7 +260,7 @@ Rusty Events between 2026-06-10 - 2026-07-08 🦀
     * [**Rustmeet**](https://rustmeet.eu/)
 * 2026-06-16 | Leipzig, DE | [Rust - Modern Systems Programming in Leipzig](https://www.meetup.com/rust-modern-systems-programming-in-leipzig)
     * [**Interactive: Everything is Open Source**](https://www.meetup.com/rust-modern-systems-programming-in-leipzig/events/313813937/)
-* 2026-06-16 | Milano, IT | [Rust Language Milan](https://www.meetup.com/rust-language-milano)
+* 2026-06-16 | Milano, IT | [Rust Language Milan](https://www.meetup.com/rust-language-milan)
     * [**Real-time planning in Rust: SolverForge & SERIO**](https://www.meetup.com/rust-language-milan/events/314766950/)
 * 2026-06-18 | Aarhus, DK | [Rust Aarhus](https://www.meetup.com/rust-aarhus)
     * [**Talk Night at Danske Commodities**](https://www.meetup.com/rust-aarhus/events/314965238/)

--- a/draft/2026-06-10-this-week-in-rust.md
+++ b/draft/2026-06-10-this-week-in-rust.md
@@ -260,7 +260,7 @@ Rusty Events between 2026-06-10 - 2026-07-08 🦀
     * [**Rustmeet**](https://rustmeet.eu/)
 * 2026-06-16 | Leipzig, DE | [Rust - Modern Systems Programming in Leipzig](https://www.meetup.com/rust-modern-systems-programming-in-leipzig)
     * [**Interactive: Everything is Open Source**](https://www.meetup.com/rust-modern-systems-programming-in-leipzig/events/313813937/)
-* 2026-06-16 | Milano, IT | [Rust Language Milan](https://www.meetup.com/rust-language-milan)
+* 2026-06-16 | Milano, IT | [Rust Language Milan](https://www.meetup.com/rust-language-milano)
     * [**Real-time planning in Rust: SolverForge & SERIO**](https://www.meetup.com/rust-language-milan/events/314766950/)
 * 2026-06-18 | Aarhus, DK | [Rust Aarhus](https://www.meetup.com/rust-aarhus)
     * [**Talk Night at Danske Commodities**](https://www.meetup.com/rust-aarhus/events/314965238/)


### PR DESCRIPTION
Adding a Rust walkthrough post to the June 10 draft.

* [Extend MySQL Using Rust](https://villagesql.com/blog/rust/) — walkthrough showing how to build MySQL extensions in Rust using VillageSQL's SDK, with code examples for a rot13 function and a custom rational number type.