### PR TITLE
Add @utoo/pack to Project/Tooling Updates

### DIFF
--- a/draft/2026-06-10-this-week-in-rust.md
+++ b/draft/2026-06-10-this-week-in-rust.md
@@ -50,6 +50,7 @@ and just ask the editors to select the category.
 * [Announcing Asterinas 0.18.0](https://asterinas.github.io/2026/06/04/announcing-asterinas-0.18.0.html)
 * [Oryxis SSH 0.8: split panes](https://github.com/wilsonglasser/oryxis/releases/tag/v0.8.0)
 * [Ratatui 0.30.1 is released - a Rust library for cooking up terminal user interfaces](https://ratatui.rs/highlights/v0301/)
+* [@utoo/pack: A Next-Generation Build Tool Based on Turbopack](https://utoo.land/en/docs/blog/utoopack-intro)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
Adds the @utoo/pack introduction blog post to the Project/Tooling Updates section of the next TWiR draft.