### PR TITLE
Add kache 0.5.0 to Project/Tooling Updates

### DIFF
--- a/draft/2026-06-10-this-week-in-rust.md
+++ b/draft/2026-06-10-this-week-in-rust.md
@@ -50,6 +50,7 @@ and just ask the editors to select the category.
 * [Announcing Asterinas 0.18.0](https://asterinas.github.io/2026/06/04/announcing-asterinas-0.18.0.html)
 * [Oryxis SSH 0.8: split panes](https://github.com/wilsonglasser/oryxis/releases/tag/v0.8.0)
 * [Ratatui 0.30.1 is released - a Rust library for cooking up terminal user interfaces](https://ratatui.rs/highlights/v0301/)
+* [kache 0.5.0: designing a correct compile-cache key](https://kunobi.ninja/blog/kache-v0-5-0)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
Adds the kache 0.5.0 write-up to Project/Tooling Updates for the 2026-06-10 issue.

[Designing a correct compile-cache key](https://kunobi.ninja/blog/kache-v0-5-0) is the long-form design write-up behind the 0.5.0 release: how the cache key handles RUSTFLAGS, proc macros, and inputs the compiler invocation can't observe (e.g. sqlx's `query!`), and why a too-loose key is worse than a too-specific one.

As my teammates previously have done, I want to share that I'm part of the team maintaining kache too!