### PR TITLE
Add link to post about Basin in Project/Tooling Updates

### DIFF
--- a/draft/2026-06-17-this-week-in-rust.md
+++ b/draft/2026-06-17-this-week-in-rust.md
@@ -45,6 +45,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+- [Basin: Numerical Optimization in Rust](https://jolars.co/blog/2026-06-10-basin/)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
This PR adds a link to my blog post about Basin at <https://jolars.co/blog/2026-06-10-basin/>, an optimization library.