### PR TITLE
add Building a provider-agnostic LLM layer in Rust with Rig

### DIFF
--- a/draft/2026-06-17-this-week-in-rust.md
+++ b/draft/2026-06-17-this-week-in-rust.md
@@ -49,6 +49,8 @@ and just ask the editors to select the category.
 
 ### Rust Walkthroughs
 
+* [Building a provider-agnostic LLM layer in Rust with Rig](https://smista.ai/blog/how-we-built-a-provider-agnostic-llm-layer-in-rust-with-rig)
+
 ### Research
 
 ### Miscellaneous


### PR DESCRIPTION
Add article <https://smista.ai/blog/how-we-built-a-provider-agnostic-llm-layer-in-rust-with-rig> to Rust walkthroughs.