### PR TITLE
Title: Add statsvg_rs to Project/Tooling Updates (#656)

### DIFF
--- a/draft/2026-06-17-this-week-in-rust.md
+++ b/draft/2026-06-17-this-week-in-rust.md
@@ -45,6 +45,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [statsvg_rs: GitHub stats SVG cards rendered in Rust -- re-generated every 6 hours via GitHub Actions, published to GitHub Pages, no servers, no API rate limits](https://github.com/akshay2211/statsvg_rs)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
Adds statsvg_rs (https://github.com/akshay2211/statsvg_rs) to the Project/Tooling Updates section of issue #656.

  About the project

  `statsvg_rs` is a Rust tool that generates styled SVG cards displaying GitHub user statistics, rendered entirely in Rust and published via GitHub Pages — no servers
  required, no API rate limits.

  Highlights:
  - Two card variants: profile.svg (for any repo README) and stats.svg (for profile READMEs)
  - Lifetime contribution tracking and contribution heatmaps 
  - Language breakdowns, pinned repositories, and top contributed-to repos
  - Multiple theme options
  - Auto-regenerated every 6 hours via GitHub Actions
  - Static hosting on GitHub Pages