### PR TITLE
CfP: solana-infra-doctor good-first issues

### DIFF
--- a/draft/2026-06-17-this-week-in-rust.md
+++ b/draft/2026-06-17-this-week-in-rust.md
@@ -120,6 +120,9 @@ Some of these tasks may also have mentors available, visit the task page for mor
 
 <!-- CFPs go here, use this format: * [project name - title of issue](URL to issue) -->
 <!-- * [ - ]() -->
+* [solana-infra-doctor - List exit codes in `sol-doctor --help`](https://github.com/satyakwok/solana-infra-doctor/issues/77)
+* [solana-infra-doctor - Make the invalid-URL error suggest the expected scheme](https://github.com/satyakwok/solana-infra-doctor/issues/78)
+* [solana-infra-doctor - Add a glossary of RPC readiness terms](https://github.com/satyakwok/solana-infra-doctor/issues/79)
 <!-- or if none - *No Calls for participation were submitted this week.* -->
 
 If you are a Rust project owner and are looking for contributors, please submit tasks [here][guidelines] or through a [PR to TWiR](https://github.com/rust-lang/this-week-in-rust) or by reaching out on [Bluesky](https://bsky.app/profile/thisweekinrust.bsky.social) or [Mastodon](https://mastodon.social/@thisweekinrust)!


### PR DESCRIPTION
Adding three good-first (easy) issues under **Call for Participation → Projects** for [solana-infra-doctor](https://github.com/satyakwok/solana-infra-doctor) — an independent, open-source (MIT OR Apache-2.0) Rust CLI for Solana RPC production-readiness diagnostics.

Per the guidelines: OSI-approved license ✓, public issue tracker ✓, each task has a difficulty level (easy) noted in the issue.

- [#77 — List exit codes in `sol-doctor --help`](https://github.com/satyakwok/solana-infra-doctor/issues/77)
- [#78 — Make the invalid-URL error suggest the expected scheme](https://github.com/satyakwok/solana-infra-doctor/issues/78)
- [#79 — Add a glossary of RPC readiness terms](https://github.com/satyakwok/solana-infra-doctor/issues/79)

Thanks for running TWiR!