### PR TITLE
Add Numax v0.1.0 to Project/Tooling Updates

### DIFF
--- a/draft/2026-06-17-this-week-in-rust.md
+++ b/draft/2026-06-17-this-week-in-rust.md
@@ -44,6 +44,7 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
+* [numax v0.1.0 – first stable release of the numax distributed WASM runtime](https://github.com/GianIac/numax/)
 
 ### Observations/Thoughts
 

--- a/draft/2026-06-17-this-week-in-rust.md
+++ b/draft/2026-06-17-this-week-in-rust.md
@@ -44,7 +44,7 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
-* [numax v0.1.0 – first stable release of the numax distributed WASM runtime](https://github.com/GianIac/numax/)
+* [numax v0.1.0 – first stable release of the numax distributed WASM runtime](https://github.com/GianIac/numax/releases/tag/v0.1.0)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
Adding numax v0.1.0 to Project/Tooling Updates.

numax is a local-first distributed WASM runtime written in Rust.
It runs untrusted WebAssembly modules in a sandboxed environment,
persists state locally without a central server, and synchronizes
that state across peers using a built-in CRDT suite.

What's in v0.1.0:

- Wasmtime execution engine with strict sandboxing and WASI preview1
- Embedded key/value store (sled) — no external database, no orchestrator
- Full CRDT suite: GCounter, PNCounter, LWW-Register, ORSet, LWW-Map, RGA
- TCP networking with mTLS (TLS 1.3), NodeID derived from hash(cert.public_key)
- Automatic reconnect, peer health tracking, periodic anti-entropy
- bincode wire format (~50% smaller, ~10x faster than JSON)
- Host API (nx_sdk): db, crdt, time, crypto, net, sys
- Prometheus-compatible /metrics, /health, /ready endpoints
- Pre-built binaries for Linux (x86_64/aarch64 musl), macOS, Windows
- Multi-OS CI with load gates: throughput, full-mesh sync, chaos restarts

This is the first stable release. Five alphas and one RC built the
foundation. The roadmap is public and the door is open for contributions.

Repo: https://github.com/GianIac/numax
Release: https://github.com/GianIac/numax/releases/tag/v0.1.0
Site: https://gianiac.github.io/numax/

TY!!