### PR TITLE
Add litchee 0.1.0 to Project/Tooling Updates

### DIFF
--- a/draft/2026-06-17-this-week-in-rust.md
+++ b/draft/2026-06-17-this-week-in-rust.md
@@ -47,6 +47,7 @@ and just ask the editors to select the category.
 
 * [I built EVM from scratch. Again.](https://sergey-melnychuk.github.io/2026/05/23/yevm/)
 * [processkit 1.0: async process tree management](https://zelanton.github.io/processkit/)
+* [litchee 0.1.0: an async Rust client for the full Lichess API with OAuth2 PKCE](https://github.com/obazin/litchee/releases/tag/v0.1.0)
 * [Basin: Numerical Optimization in Rust](https://jolars.co/blog/2026-06-10-basin/)
 
 ### Observations/Thoughts

--- a/draft/2026-06-17-this-week-in-rust.md
+++ b/draft/2026-06-17-this-week-in-rust.md
@@ -47,7 +47,7 @@ and just ask the editors to select the category.
 
 * [I built EVM from scratch. Again.](https://sergey-melnychuk.github.io/2026/05/23/yevm/)
 * [processkit 1.0: async process tree management](https://zelanton.github.io/processkit/)
-* [litchee 0.1.0: an async Rust client for the full Lichess API with OAuth2 PKCE](https://github.com/obazin/litchee/releases/tag/v0.1.0)
+* [litchee: Rust Lichess API client](https://github.com/obazin/litchee/releases/tag/v0.1.0)
 * [Basin: Numerical Optimization in Rust](https://jolars.co/blog/2026-06-10-basin/)
 
 ### Observations/Thoughts


### PR DESCRIPTION
Adds [litchee](https://github.com/obazin/litchee) — an async, builder-pattern Rust client for the Lichess API — to the Project/Tooling Updates section.

litchee 0.1.0 covers all documented Lichess API operations, is streaming-native (NDJSON), strongly typed, and ships OAuth2 PKCE ("Log in with Lichess"). It's published on [crates.io](https://crates.io/crates/litchee) with docs on [docs.rs](https://docs.rs/litchee), and is listed as an official client at lichess.org/api.
