### PR TITLE
Add kache 0.6.0 to Project/Tooling Updates

### DIFF
--- a/draft/2026-06-17-this-week-in-rust.md
+++ b/draft/2026-06-17-this-week-in-rust.md
@@ -44,7 +44,7 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
-* [kache 0.6.0: cross-clone build-cache convergence on Firefox (8.45×), now with clang-cl/Windows C/C++ caching](https://github.com/kunobi-ninja/kache/releases/tag/v0.6.0)
+* [kache 0.6.0: a shareable Rust + C/C++ build cache](https://github.com/kunobi-ninja/kache/releases/tag/v0.6.0)
 
 ### Observations/Thoughts
 

--- a/draft/2026-06-17-this-week-in-rust.md
+++ b/draft/2026-06-17-this-week-in-rust.md
@@ -44,6 +44,7 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
+* [kache 0.6.0: cross-clone build-cache convergence on Firefox (8.45×), now with clang-cl/Windows C/C++ caching](https://github.com/kunobi-ninja/kache/releases/tag/v0.6.0)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
Adds a Project/Tooling Updates entry for the kache 0.6.0 release.

* [kache 0.6.0: cross-clone build-cache convergence on Firefox (8.45×), now with clang-cl/Windows C/C++ caching](https://github.com/kunobi-ninja/kache/releases/tag/v0.6.0)

kache is an open-source, content-addressed Rust build cache (RUSTC_WRAPPER). This release adds C/C++ caching via clang-cl on Windows/MSVC and hardens the shared store.