### PR TITLE
Add Rust Walkthrough: porting MediaInfoLib to pure Rust (revelo)

### DIFF
--- a/draft/2026-06-24-this-week-in-rust.md
+++ b/draft/2026-06-24-this-week-in-rust.md
@@ -49,6 +49,8 @@ and just ask the editors to select the category.
 
 ### Rust Walkthroughs
 
+* [Porting 300,000 Lines of C++ and Perl to Rust: A Dual-Oracle Media Metadata Engine](https://medium.com/@vbasky/porting-200-000-lines-of-c-to-rust-building-a-byte-identical-mediainfo-replacement-8e9b587d469a)
+
 ### Research
 
 ### Miscellaneous


### PR DESCRIPTION
Submitting a deep-dive article for the **Rust Walkthroughs** section.

**[Porting 300,000 Lines of C++ and Perl to Rust: A Dual-Oracle Media Metadata Engine](https://medium.com/@vbasky/porting-200-000-lines-of-c-to-rust-building-a-byte-identical-mediainfo-replacement-8e9b587d469a)**

A walkthrough of building [revelo](https://github.com/vbasky/revelo) — a clean-room, pure-Rust port of MediaInfoLib that reads metadata from 177+ media formats, differential-tested byte-for-byte against the C++ `mediainfo` oracle (plus an ExifTool-grade maker-note layer validated against the `exiftool` binary). The article covers the dual-oracle differential-testing harness, format-coverage strategy, and the C-ABI `libmediainfo` drop-in replacement.

- Free to read (not members-only / no paywall).
- Written by me (a person), not LLM-generated.
- Happy to recategorise (e.g. Project/Tooling Updates) if the editors prefer.