### PR TITLE
Add article: a post-quantum hybrid handshake in a Rust VPN

### DIFF
--- a/draft/2026-06-24-this-week-in-rust.md
+++ b/draft/2026-06-24-this-week-in-rust.md
@@ -45,6 +45,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [Adding a post-quantum hybrid handshake to a Rust VPN](https://dev.to/alexandr_litvinov/adding-a-post-quantum-hybrid-handshake-to-a-rust-vpn-pk8)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
Adds one entry to **Project/Tooling Updates** in the 2026-06-24 draft:

* [Adding a post-quantum hybrid handshake to a Rust VPN](https://dev.to/alexandr_litvinov/adding-a-post-quantum-hybrid-handshake-to-a-rust-vpn-pk8)

A long-form, Rust-specific write-up on adding a hybrid X25519 + ML-KEM-768 key exchange to [Qeli](https://github.com/litvinovtd/qeli), a self-hosted VPN written in Rust.

Disclosure: I am the author of both the project and the article.