### PR TITLE
CI: Separate errors from warnings, post comments on either

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -11,6 +11,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   Run-Markdown-Checks:
@@ -29,23 +30,115 @@ jobs:
           update-pip: "false"
           update-setuptools: "false"
           update-wheel: "false"
-      - name: Compute diff base
+      - name: Compute PR diff base
+        if: ${{ github.event_name == 'pull_request' }}
         id: base
         shell: bash
         run: |
-            if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-                BASE="$(git merge-base \
-                    "${{ github.event.pull_request.base.sha }}" \
-                    "${{ github.event.pull_request.head.sha }}")"
-            elif [[ "${{ github.event_name }}" == "push" ]]; then
-                BASE="${{ github.event.before }}"
-            else
-                echo "Unsupported event: ${{ github.event_name }}" >&2
-                exit 1
-            fi
+            BASE="$(git merge-base \
+                "${{ github.event.pull_request.base.sha }}" \
+                "${{ github.event.pull_request.head.sha }}")"
 
             echo "base=$BASE" >> "$GITHUB_OUTPUT"
-      - name: inspect_links
-        run: python3 tools/inspect_links.py --since "${{ steps.base.outputs.base }}"
-      - name: inspect_markdown
+      - name: inspect_links for main
+        if: ${{ github.event_name == 'push' }}
+        run: python3 tools/inspect_links.py
+      - name: inspect_links for pull request
+        if: ${{ github.event_name == 'pull_request' }}
+        id: inspect_links_pr
+        shell: bash
+        env:
+          CHECK_OUTPUT_FILE: ${{ runner.temp }}/inspect-links-pr.txt
+        run: |
+            set +e
+            python3 tools/inspect_links.py \
+                --since "${{ steps.base.outputs.base }}" \
+                --show-warnings > "$CHECK_OUTPUT_FILE"
+            status="$?"
+            cat "$CHECK_OUTPUT_FILE"
+
+            if [[ "$status" -eq 0 ]]; then
+                echo "failed=false" >> "$GITHUB_OUTPUT"
+            else
+                echo "failed=true" >> "$GITHUB_OUTPUT"
+            fi
+
+            exit 0
+      - name: inspect_markdown for main
+        if: ${{ github.event_name == 'push' }}
         run: python3 tools/inspect_markdown.py --num-recent 5
+      - name: inspect_markdown for pull request
+        if: ${{ github.event_name == 'pull_request' }}
+        id: inspect_markdown_pr
+        shell: bash
+        env:
+          CHECK_OUTPUT_FILE: ${{ runner.temp }}/inspect-markdown-pr.txt
+        run: |
+            set +e
+            python3 tools/inspect_markdown.py --num-recent 5 > "$CHECK_OUTPUT_FILE"
+            status="$?"
+            cat "$CHECK_OUTPUT_FILE"
+
+            if [[ "$status" -eq 0 ]]; then
+                echo "failed=false" >> "$GITHUB_OUTPUT"
+            else
+                echo "failed=true" >> "$GITHUB_OUTPUT"
+            fi
+
+            exit 0
+      - name: Comment on PR check output
+        if: ${{ github.event_name == 'pull_request' }}
+        shell: bash
+        env:
+          LINK_OUTPUT_FILE: ${{ runner.temp }}/inspect-links-pr.txt
+          LINK_FAILED: ${{ steps.inspect_links_pr.outputs.failed }}
+          MARKDOWN_OUTPUT_FILE: ${{ runner.temp }}/inspect-markdown-pr.txt
+          MARKDOWN_FAILED: ${{ steps.inspect_markdown_pr.outputs.failed }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+            python3 - <<'PY'
+            import json
+            import os
+            from pathlib import Path
+
+            def section(title, path):
+                output = Path(path).read_text().strip()
+                if not output:
+                    return None
+                return (
+                    f"### {title}\n\n"
+                    f"{output}\n"
+                )
+
+            sections = [
+                section("Link check", os.environ["LINK_OUTPUT_FILE"]),
+                section("Markdown check", os.environ["MARKDOWN_OUTPUT_FILE"]),
+            ]
+            sections = [s for s in sections if s]
+            if sections:
+                check_output = "\n\n".join(sections)
+
+                body = (
+                    f"Thank you for your contribution to This Week in Rust! Our automated checks found some possible issues with these changes:\n\n"
+                    f"{check_output}\n\n"
+                    f"You can see more details here: {os.environ['RUN_URL']}"
+                )
+
+                if len(body) > 60000:
+                    body = body[:59900] + "\n\n... truncated"
+
+                Path("comment.json").write_text(json.dumps({"body": body}))
+            PY
+
+            if [[ -s comment.json ]]; then
+                gh api \
+                    --method POST \
+                    "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
+                    --input comment.json
+            fi
+      - name: Fail PR check on errors
+        if: ${{ github.event_name == 'pull_request' && (steps.inspect_links_pr.outputs.failed == 'true' || steps.inspect_markdown_pr.outputs.failed == 'true') }}
+        run: exit 1

--- a/tools/inspect_links.py
+++ b/tools/inspect_links.py
@@ -19,7 +19,6 @@ import pygit2
 import urllib.parse
 
 LOG = logging.getLogger(__name__)
-LOG.setLevel(logging.INFO)
 
 
 class Diagnostics:
@@ -296,8 +295,11 @@ def main():
     parser.add_argument('--debug', action='store_true')
     args = parser.parse_args()
     if args.debug:
-        LOG.setLevel(logging.DEBUG)
+        logging.basicConfig(level=logging.DEBUG)
+    else:
+        logging.basicConfig(level=logging.INFO)
     LOG.debug(f'command-line arguments: {args}')
+
     file_list = get_recent_files(args.paths, args.num_recent)
     inspect_files(file_list)
 
@@ -319,23 +321,17 @@ def main():
         warnings = []
 
     if errors or warnings:
-        print("diagnostics exist:")
+        LOG.info("diagnostics exist:")
         for d in errors:
             print(f"* error: {d}")
         for d in warnings:
             print(f"* warning: {d}")
     else:
-        print("everything is ok!")
+        LOG.info("everything is ok!")
 
     if errors:
         sys.exit(1)
 
 
-def setup_logging():
-    log_stdout = logging.StreamHandler(sys.stdout)
-    logging.getLogger('').addHandler(log_stdout)
-
-
 if __name__ == "__main__":
-    setup_logging()
     main()

--- a/tools/inspect_links.py
+++ b/tools/inspect_links.py
@@ -47,6 +47,9 @@ warnings = Warnings()
 # A regex that matches filenames to inspect.
 RE_FILENAME = re.compile(r'\d\d\d\d-\d\d-\d\d-this-week-in-rust.md$')
 
+# A regex that matches bare GitHub repo URLs.
+RE_GITHUB_REPO = re.compile(r'https://github.com/[^/]+/[^/]+/?[^/]*$')
+
 # A block-list of tracking parameters
 TRACKING_PARAMETERS = set([
     'utm_source',
@@ -86,9 +89,9 @@ def check_truncated_title(tag):
     if title and title.endswith('...') and len(title) == 70:
         warnings.warn(f'truncated link title: {repr(title)}')
 
-def check_domain(domain, url):
-  if domain.lower() == "github.com":
-    warnings.warn(f"link {url} is to github.com -- we do not usually include links directly to GitHub repos; "
+def check_suspicious(domain, url):
+  if RE_GITHUB_REPO.match(url):
+    warnings.warn(f"link {url} is directly to a GitHub repo; "
       "please double check our guidelines here: https://github.com/rust-lang/this-week-in-rust#projectstooling-updates")
   elif domain.lower() == "crates.io":
     warnings.warn(f"link {url} is to crates.io -- we do not usually include links directly to crates on crates.io; "
@@ -217,8 +220,7 @@ def parse_url(link):
     # need to warn about
     reconstituted = urllib.parse.urlunsplit((scheme, loc, path, query, frag))
 
-    # Disabled since it's currently failing on the main branch: checks are too strict
-    # check_domain(loc, link)
+    check_suspicious(loc, link)
 
     return reconstituted
 

--- a/tools/inspect_links.py
+++ b/tools/inspect_links.py
@@ -1,9 +1,10 @@
 #!/usr/bin/python3
 
 """
-Inspect a set of markdown files, and warn if there are:
+Inspect a set of markdown files, and produce errors/warnings if there are:
 - duplicate links
 - malformed links
+- usually-rejected links
 """
 
 import argparse
@@ -21,28 +22,28 @@ LOG = logging.getLogger(__name__)
 LOG.setLevel(logging.INFO)
 
 
-class Warnings:
-    """ A singleton object for gathering warnings to be printed later. """
+class Diagnostics:
+    """ A singleton object for gathering diagnostics to be printed later. """
 
     def __init__(self):
-        self.warnings = []
-        self.silent = False
+        self._errors = []
+        self._warnings = []
 
     def warn(self, msg):
-        if not self.silent:
-            self.warnings.append(msg)
+        self._warnings.append(msg)
 
-    def get(self):
-        return self.warnings
+    def error(self, msg):
+        self._errors.append(msg)
 
-    def get_and_clear(self):
-        to_return = self.warnings
-        self.warnings = []
+    def drain_errors_and_warnings(self) -> tuple[list[str], list[str]]:
+        to_return = (self._errors, self._warnings)
+        self._errors = []
+        self._warnings = []
         return to_return
 
 
-# The singleton object that gathers warnings, for later reporting.
-warnings = Warnings()
+# The singleton object that gathers warnings & errors, for later reporting.
+diagnostics = Diagnostics()
 
 # A regex that matches filenames to inspect.
 RE_FILENAME = re.compile(r'\d\d\d\d-\d\d-\d\d-this-week-in-rust.md$')
@@ -78,23 +79,18 @@ def check_truncated_title(tag):
     Links collected from Discord may be truncated to a length of exactly
     70 characters, including a "..." suffix.
 
-    If we're unlucky enough to trigger this warning by mistake, here are
-    some workarounds:
-    - Make any change to the title so that it's not exactly 70 characters
-      (e.g. add an extra space between words)
-    - Replace the "..." with unicode "…"
     """
     title = tag.string
     LOG.debug(f'link title: {repr(title)}')
     if title and title.endswith('...') and len(title) == 70:
-        warnings.warn(f'truncated link title: {repr(title)}')
+        diagnostics.warn(f'this link title may be unintentionally truncated: {repr(title)}')
 
 def check_suspicious(domain, url):
   if RE_GITHUB_REPO.match(url):
-    warnings.warn(f"link {url} is directly to a GitHub repo; "
+    diagnostics.warn(f"link {url} is directly to a GitHub repo; "
       "please double check our guidelines here: https://github.com/rust-lang/this-week-in-rust#projectstooling-updates")
   elif domain.lower() == "crates.io":
-    warnings.warn(f"link {url} is to crates.io -- we do not usually include links directly to crates on crates.io; "
+    diagnostics.warn(f"link {url} is to crates.io -- we do not usually include links directly to crates on crates.io; "
       "please double check our guidelines here: https://github.com/rust-lang/this-week-in-rust#projectstooling-updates")
 
 def extract_links(html):
@@ -106,7 +102,7 @@ def extract_links(html):
     account, for example).
 
     Side-effects:
-    - If links are malformed, warnings may be recorded. See `parse_url`
+    - If links are malformed, diagnostics may be recorded. See `parse_url`
       for details.
 
     """
@@ -159,7 +155,7 @@ def scrub_parameters(url, query):
 
     # Store a warning if
     if found_tracking:
-        warnings.warn(f'found tracking parameters on {url}: {found_tracking}')
+        diagnostics.error(f'found tracking parameters on {url}: {found_tracking}')
 
     # If there are no query parameters left, return the empty string.
     if not filtered_dict:
@@ -177,14 +173,14 @@ def parse_url(link):
     - "http" and "https" URLs are considered the same.
     - consecutive slashes and trailing slashes are ignored.
 
-    Warnings may be issued if unnecessary tracking parameters are found,
+    Diagnostics may be issued if unnecessary tracking parameters are found,
     or if the URL contains consecutive slashes.
     """
     parsed_url = urllib.parse.urlsplit(link)
 
     scheme = parsed_url.scheme
     if scheme not in ('mailto', 'http', 'https'):
-        warnings.warn(f'possibly malformed link: {link}')
+        diagnostics.error(f'unexpected/malformed link scheme: {link}')
     if scheme == 'http':
         scheme = 'https'
 
@@ -211,7 +207,7 @@ def parse_url(link):
     reconstituted = urllib.parse.urlunsplit((sch, loc, path, query, frag))
     if reconstituted != link:
         LOG.debug(f'reconstituted: {reconstituted}')
-        warnings.warn(f'link can be simplified: {link} -> {reconstituted}')
+        diagnostics.error(f'link can be simplified: {link} -> {reconstituted}')
 
     # Strip any trailing slashes, again.
     path = path.rstrip('/')
@@ -272,7 +268,7 @@ def get_recent_files(dirs, count):
 
 
 def inspect_files(file_list: list[str], *, tree: Union[pygit2.Tree, None] = None):
-    """ Inspect a set of files, storing warnings about duplicate links. """
+    """ Inspect a set of files, storing errors about duplicate links. """
     linkset = {}
 
     for index, file in enumerate(file_list):
@@ -281,7 +277,7 @@ def inspect_files(file_list: list[str], *, tree: Union[pygit2.Tree, None] = None
         for link in links:
             collision = linkset.get(link)
             if collision:
-                warnings.warn(
+                diagnostics.error(
                     f"possible duplicate link {link} in file {file} (also found in {collision}")
             else:
                 linkset[link] = file
@@ -294,7 +290,9 @@ def main():
     parser.add_argument('--num-recent', default=25, type=int,
                         help="Number of recent files to inspect")
     parser.add_argument('--since', default=None, type=str,
-                        help="Show only warnings which appear after the given git commit")
+                        help="Show only diagnostics which appear after the given git commit")
+    parser.add_argument("--show-warnings", default=False, action='store_true',
+                        help="Show warnings as well as errors (warnings never affect exit code)")
     parser.add_argument('--debug', action='store_true')
     args = parser.parse_args()
     if args.debug:
@@ -303,7 +301,7 @@ def main():
     file_list = get_recent_files(args.paths, args.num_recent)
     inspect_files(file_list)
 
-    warns = warnings.get_and_clear()
+    (errors, warnings) = diagnostics.drain_errors_and_warnings()
 
     if args.since:
         try:
@@ -313,16 +311,24 @@ def main():
 
         LOG.info(f"inspecting files since commit {args.since}")
         inspect_files(file_list, tree=tree)
-        old_warns = set(warnings.get_and_clear())
-        warns = [w for w in warns if w not in old_warns]
+        (old_errors, old_warnings) = diagnostics.drain_errors_and_warnings()
+        errors = [e for e in errors if e not in old_errors]
+        warnings = [w for w in warnings if w not in old_warnings]
 
-    if warns:
-        print("warnings exist:")
-        for w in warns:
-            print(w)
-        sys.exit(1)
+    if not args.show_warnings:
+        warnings = []
+
+    if errors or warnings:
+        print("diagnostics exist:")
+        for d in errors:
+            print(f"* error: {d}")
+        for d in warnings:
+            print(f"* warning: {d}")
     else:
         print("everything is ok!")
+
+    if errors:
+        sys.exit(1)
 
 
 def setup_logging():

--- a/tools/inspect_markdown.py
+++ b/tools/inspect_markdown.py
@@ -12,7 +12,7 @@ import argparse
 import bs4
 import markdown
 import sys
-from inspect_links import get_recent_files, setup_logging, warnings
+from inspect_links import diagnostics, get_recent_files, setup_logging
 
 """
 This is a collection of html tags that have appeared in past issues.
@@ -34,11 +34,11 @@ def render_file(filename):
 
         # Empty backticks don't make much sense.
         if line.count('``') > 0:
-            warnings.warn(f'{filename}: found empty backticks: "{line}"')
+            diagnostics.error(f'{filename}: found empty backticks: "{line}"')
 
         c = line.count('`')
         if c % 2 != 0:
-            warnings.warn(f'{filename}: found odd backticks: "{line}"')
+            diagnostics.error(f'{filename}: found odd backticks: "{line}"')
 
     html = markdown.markdown(md_text)
     return html
@@ -50,11 +50,11 @@ def check_tags(html, file):
     for tag in bs4.BeautifulSoup(html, 'html.parser').find_all():
         if tag.name not in VALID_TAGS:
             tag_str = str(tag)[:50]
-            warnings.warn(
+            diagnostics.error(
                 f'{file}: unrecognized tag {tag.name} in "{tag_str}"')
         if tag.name == 'li':
             if tag.get_text() == '':
-                warnings.warn(f'{file}: empty <{tag.name}> tag after {prev_tag}')
+                diagnostics.error(f'{file}: empty <{tag.name}> tag after {prev_tag}')
         prev_tag = tag
 
 def main():
@@ -78,11 +78,15 @@ if __name__ == "__main__":
     setup_logging()
     main()
 
-    warns = warnings.get()
-    if warns:
-        print("warnings exist:")
-        for w in warns:
-            print(w)
-        sys.exit(1)
+    errors, warnings = diagnostics.drain_errors_and_warnings()
+    # TODO: if we want warnings here, add/reuse the --show-warnings and --since logic from inspect_links.py
+    assert not warnings, "we don't expect warnings in this script"
+    if errors:
+        print("errors exist:")
+        for d in errors:
+            print(f"* error: {d}")
     else:
         print("everything is ok!")
+
+    if errors:
+        sys.exit(1)

--- a/tools/inspect_markdown.py
+++ b/tools/inspect_markdown.py
@@ -12,7 +12,11 @@ import argparse
 import bs4
 import markdown
 import sys
-from inspect_links import diagnostics, get_recent_files, setup_logging
+from inspect_links import diagnostics, get_recent_files
+import logging
+
+
+LOG = logging.getLogger(__name__)
 
 """
 This is a collection of html tags that have appeared in past issues.
@@ -75,18 +79,18 @@ def main():
 
 
 if __name__ == "__main__":
-    setup_logging()
+    logging.basicConfig(level=logging.INFO)
     main()
 
     errors, warnings = diagnostics.drain_errors_and_warnings()
     # TODO: if we want warnings here, add/reuse the --show-warnings and --since logic from inspect_links.py
     assert not warnings, "we don't expect warnings in this script"
     if errors:
-        print("errors exist:")
+        LOG.info("errors exist:")
         for d in errors:
             print(f"* error: {d}")
     else:
-        print("everything is ok!")
+        LOG.info("everything is ok!")
 
     if errors:
         sys.exit(1)


### PR DESCRIPTION
This builds on #8153 to:
* Separate errors from warnings for the CI checks. The idea is that we can decide to merge things with warnings (i.e. it's an editorial decision) as opposed to errors which will fail CI.
* Everything that existed before #8153 are errors since they don't have false positives, except for the heuristic check on title truncation. The new checks for commonly-rejected links are warnings since they are sometimes ok.
* By default both scripts only show & fail on errors. (ie will pass on main)
* You can turn on warnings (and the related `--since` tag to filter down to recent ones) with `--show-warnings`. This still only fails for errors (arguably weird but this is because of next change).
* The CI check now posts a comment back to the PR if there are warnings or errors, and fails on errors. See examples of a [warnings only pr](https://github.com/jder/this-week-in-rust/pull/12) and [pr with errors](https://github.com/jder/this-week-in-rust/pull/13) for what this looks like.
* To make this easy, we make stdout be the content we'd post to the PR and use stderr for info/debug messages from the script (via normal python logging machinery) and move some existing prints to logging.
* Finally, we change the GitHub warning to look for root repo links, not any repo link.

Individual commits should be ~separately reviewable. 

Fixes #8154
Fixes #8168