### PR TITLE
Add bincode-next v3.1.1 release note

### DIFF
--- a/draft/2026-06-24-this-week-in-rust.md
+++ b/draft/2026-06-24-this-week-in-rust.md
@@ -44,6 +44,7 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
+* [Releasing bincode-next v3.1.1 (v3 stabilization release!)](https://users.rust-lang.org/t/releasing-bincode-next-v3-1-1-v3-stabilization-release/140842/)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
Hi TWiR Editors!
We are maintainers of the bincode-next project, and after several months of development after the original bincode gone dark, we are finally releasing v3 stable! And so are applying to get this important update into the sight of the community.
Thanks!