### PR TITLE
Add tenferro-rs launch post to Project/Tooling Updates

### DIFF
--- a/draft/2026-06-24-this-week-in-rust.md
+++ b/draft/2026-06-24-this-week-in-rust.md
@@ -45,6 +45,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [From Julia to Rust: a differentiable tensor stack for scientific computing in the agentic AI era](https://tensor4all.org/blog/introducing-tenferro-rs/)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
Adds a **Project/Tooling Updates** entry for the launch post of `tenferro-rs`, a Rust-native differentiable tensor stack for scientific computing (dense tensors, eager + traced autodiff, NumPy/JAX-style einsum, linear algebra, FFT, explicit CPU/CUDA backends). The first crates were published to crates.io as v0.1 this week.

The link is a write-up (a blog post with a runnable Rust example and design discussion), not a bare repo or crates.io link. Per the contributing guidelines, the article discloses that it was written collaboratively with AI coding agents and edited by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)