### PR TITLE
Add kache 0.7.0 to Project/Tooling Updates

### DIFF
--- a/draft/2026-06-24-this-week-in-rust.md
+++ b/draft/2026-06-24-this-week-in-rust.md
@@ -44,6 +44,7 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
+* [kache 0.7.0: caching real-world C/C++ trees](https://github.com/kunobi-ninja/kache/releases/tag/v0.7.0)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
Adds a Project/Tooling Updates entry for the kache 0.7.0 release.

* [kache 0.7.0: caching real-world C/C++ trees](https://github.com/kunobi-ninja/kache/releases/tag/v0.7.0)

kache is an open-source, content-addressed build cache (RUSTC_WRAPPER, and a C/C++ compiler wrapper). 0.7.0 models the codegen flags that were forcing passthrough on large real-world C/C++ trees (Firefox, LLVM) so those translation units cache, and ships signed binaries via Homebrew, apt, and winget. The linked release notes cover why the changes were made and how to use them. 