### PR TITLE
Add blog post: A data race that doesn't compile

### DIFF
--- a/draft/2026-06-24-this-week-in-rust.md
+++ b/draft/2026-06-24-this-week-in-rust.md
@@ -49,6 +49,8 @@ and just ask the editors to select the category.
 
 ### Rust Walkthroughs
 
+* [A data race that doesn't compile](https://corentin-core.github.io/posts/ruxe-type-level-disjointness/)
+
 ### Research
 
 ### Miscellaneous


### PR DESCRIPTION
Submitting a blog post about building a compile-time disjointness check for parallel reducers in stable Rust. The technique is the Sculptor pattern from frunk. Includes a false start (an AllDistinct attempt that was structurally a Contains check) before reformulating the problem as a bijection.

Going under Rust Walkthroughs since it has significant Rust source and steps through the construction.

Article: https://corentin-core.github.io/posts/ruxe-type-level-disjointness/

I drafted the prose with Claude and rewrote it across multiple passes. Disclosure is in the article footer per the LLM policy.