### PR TITLE
Add ANIMUS blog post to Observations/Thoughts

### DIFF
--- a/draft/2026-06-24-this-week-in-rust.md
+++ b/draft/2026-06-24-this-week-in-rust.md
@@ -45,6 +45,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [ANIMUS v4.0: an autonomous Rust system with a self-auditing knowledge graph, running a local LLM via llama.cpp on consumer GPU](https://github.com/shellhack/animus-ai)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
**Description:**
Following up on PR #8243 — per feedback that we don't link directly to GitHub repos, I wrote up the project as a blog post and I'm submitting it for the Observations/Thoughts section instead.

The post covers some Rust-specific debugging work (a recency bias bug in a custom semantic search function, a gap-filter fix in an autonomous loop, and migrating the inference engine to llama-server.exe) along with a broader lesson about metrics that climb without reflecting real progress.