### PR TITLE
Add Rayfish blog post to Project/Tooling Updates

### DIFF
--- a/draft/2026-07-01-this-week-in-rust.md
+++ b/draft/2026-07-01-this-week-in-rust.md
@@ -45,6 +45,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [Rayfish: Your own private network. No servers, no setup.](https://rayfish.xyz/blog/01-introducing-rayfish)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
Adds a link to the Rayfish introduction blog post under Project/Tooling Updates.

Rayfish is a P2P mesh VPN built on iroh that connects peers by cryptographic identity instead of IP address.