### PR TITLE
Add BOG-A-THON 2 event

### DIFF
--- a/draft/2026-07-01-this-week-in-rust.md
+++ b/draft/2026-07-01-this-week-in-rust.md
@@ -292,6 +292,8 @@ Rusty Events between 2026-07-01 - 2026-07-29 🦀
     * [**Rust Lunch - Fareground**](https://www.meetup.com/rust-atx/events/xvkdgtyjckbdc/)
 * 2026-07-22 | Los Angeles, CA, US | [Rust Los Angeles](https://www.meetup.com/rust-los-angeles)
     * [**Rust LA: Rust in Distributed Systems with Flight Science!**](https://www.meetup.com/rust-los-angeles/events/315376271/)
+* 2026-07-25 | Brooklyn, NY, US | [Flower](https://flowercomputer.com/)
+    * [**BOG-A-THON 2**](https://partiful.com/e/Vq9fyDNCMSO7ia4ulK5b)
 
 ### Oceania
 * 2026-06-25 | Melbourne, AU | [Rust Melbourne](https://www.meetup.com/rust-melbourne)


### PR DESCRIPTION
Adds BOG-A-THON 2 to the upcoming events list. 

For additional context, we'll be hosting a meetup revolving around an incremental computing crate we're releasing soon, as well as rust-related tooling for working with databases in general!