### PR TITLE
Add Rustacean (compile-checked Rust knowledge brain) to Project/Tooling Updates

### DIFF
--- a/draft/2026-07-01-this-week-in-rust.md
+++ b/draft/2026-07-01-this-week-in-rust.md
@@ -45,6 +45,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [Rustacean: a cross-linked Rust knowledge brain where every example is compile-checked in CI (edition 2024)](https://agricidaniel.github.io/rustacean/)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
Proposing **Rustacean** for the Project/Tooling Updates section.

It's an open-source (MIT) cross-linked knowledge base for writing idiomatic, current Rust (edition 2024 / stable 1.85+): hundreds of atomic notes — concepts, patterns, and the anti-patterns to avoid — distilled from the official books and `std`, each with a minimal example and dense cross-links.

Rust-specific angle: **every `rust` example is compile-checked in CI** (a `rustc` gate over ~1,000 snippets on edition 2024). Building that gate surfaced and fixed three real bugs — for example an unstable `async FnMut(..)` bound that should be `AsyncFnMut` on stable 1.85+, and a missing lifetime on a `&str`-returning helper.

- Site: https://agricidaniel.github.io/rustacean/
- Repo: https://github.com/AgriciDaniel/rustacean

Disclosure per the contributing guidelines: the notes were assembled with heavy LLM assistance and then human-reviewed; this is noted in the repo (the `ai-generated` topic and the README's "How it was built"). Happy to reword the entry or move it to a more fitting section.
