### PR TITLE
Project/Tooling Updates: ds4-rs-metal (Rust + Metal DeepSeek-V4-Flash on Apple Silicon)

### DIFF
--- a/draft/2026-07-01-this-week-in-rust.md
+++ b/draft/2026-07-01-this-week-in-rust.md
@@ -45,6 +45,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [ds4-rs-metal: DeepSeek-V4-Flash inference in Rust + Metal on Apple Silicon, at or ahead of the antirez C reference](https://github.com/yijunyu/ds4-rs-metal)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
Adds **ds4-rs-metal** under *Project/Tooling Updates*.

An open-source Rust + Metal inference engine for DeepSeek-V4-Flash on Apple Silicon that sustains ~300 tok/s prefill on an M1 Ultra 128GB Mac Studio — about +19% over the antirez/ds4 C reference, with a byte-identical +13.6% coming purely from MTLEvent-ordered command-buffer scheduling. Fully buildable with `cargo build`; a derivative of antirez/ds4 (MIT, vendored in-tree with attribution).

Repo: https://github.com/yijunyu/ds4-rs-metal

(Written by a human; honest framing — not fewer FLOPs, decode is a tie.)