### PR TITLE
Add Axiom OS to Project/Tooling Updates

### DIFF
--- a/draft/2026-07-01-this-week-in-rust.md
+++ b/draft/2026-07-01-this-week-in-rust.md
@@ -45,6 +45,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [Axiom OS: per-read file integrity in a no_std kernel via block-level BLAKE3](https://github.com/abhiprd2000/axiom-os-kernel)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
Adding Axiom OS to Project/Tooling Updates. Independent no_std Rust kernel that does per-read file integrity by storing a per-4 KiB-block BLAKE3 leaf hash and verifying only the blocks a read touches. Per-read cost is proportional to bytes read instead of re-hashing the whole file. The repo includes the kernel and a benchmark harness. Happy to recategorize if the editors prefer a different section.