### PR TITLE
Add rssh to Project/Tooling Updates

### DIFF
--- a/draft/2026-07-01-this-week-in-rust.md
+++ b/draft/2026-07-01-this-week-in-rust.md
@@ -45,6 +45,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [Inside RSSH: one Rust crate, three binaries, and the Tauri lessons along the way](https://github.com/shihuili1218/rssh/blob/main/docs/article_arch_en.md)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
Adds rssh under Project/Tooling Updates. The link is a build/architecture writeup — one Rust crate compiled into three feature-gated binaries, crate selection (incl. the russh RustCrypto prerelease-pinning saga), and Tauri lessons across five targets. rssh is my own MIT-licensed project.