### PR TITLE
Add Rust and Allocator behaviour to Observations/Thoughts

### DIFF
--- a/draft/2026-07-01-this-week-in-rust.md
+++ b/draft/2026-07-01-this-week-in-rust.md
@@ -47,6 +47,8 @@ and just ask the editors to select the category.
 
 ### Observations/Thoughts
 
+[Your Rust Service Isn't Leaking — It Could Be the Allocator](https://pranitha.dev/posts/rust-and-memory-allocators)
+
 ### Rust Walkthroughs
 
 ### Research


### PR DESCRIPTION
How we diagnosed unexplained memory staying pinned near the top of our container limit in a Rust event stream processor — not a leak or fragmentation, and why the allocator matters.