### PR TITLE
Post PR comments from separate workflow with write permissions

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -11,7 +11,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   Run-Markdown-Checks:
@@ -86,59 +85,23 @@ jobs:
             fi
 
             exit 0
-      - name: Comment on PR check output
+      # Upload the check output so the workflow_run workflow can fetch it later.
+      # That follow-up workflow has permission to write PR comments, unlike this
+      # pull_request workflow which runs on possibly-untrusted forks.
+      - name: Prepare PR check output metadata
         if: ${{ github.event_name == 'pull_request' }}
         shell: bash
-        env:
-          LINK_OUTPUT_FILE: ${{ runner.temp }}/inspect-links-pr.txt
-          LINK_FAILED: ${{ steps.inspect_links_pr.outputs.failed }}
-          MARKDOWN_OUTPUT_FILE: ${{ runner.temp }}/inspect-markdown-pr.txt
-          MARKDOWN_FAILED: ${{ steps.inspect_markdown_pr.outputs.failed }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-            python3 - <<'PY'
-            import json
-            import os
-            from pathlib import Path
-
-            def section(title, path):
-                output = Path(path).read_text().strip()
-                if not output:
-                    return None
-                return (
-                    f"### {title}\n\n"
-                    f"{output}\n"
-                )
-
-            sections = [
-                section("Link check", os.environ["LINK_OUTPUT_FILE"]),
-                section("Markdown check", os.environ["MARKDOWN_OUTPUT_FILE"]),
-            ]
-            sections = [s for s in sections if s]
-            if sections:
-                check_output = "\n\n".join(sections)
-
-                body = (
-                    f"Thank you for your contribution to This Week in Rust! Our automated checks found some possible issues with these changes:\n\n"
-                    f"{check_output}\n\n"
-                    f"You can see more details here: {os.environ['RUN_URL']}"
-                )
-
-                if len(body) > 60000:
-                    body = body[:59900] + "\n\n... truncated"
-
-                Path("comment.json").write_text(json.dumps({"body": body}))
-            PY
-
-            if [[ -s comment.json ]]; then
-                gh api \
-                    --method POST \
-                    "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
-                    --input comment.json
-            fi
+        run: echo "${{ github.event.pull_request.number }}" > "${{ runner.temp }}/pr-number.txt"
+      - name: Upload PR check output
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-check-output
+          path: |
+            ${{ runner.temp }}/pr-number.txt
+            ${{ runner.temp }}/inspect-links-pr.txt
+            ${{ runner.temp }}/inspect-markdown-pr.txt
+          if-no-files-found: ignore
       - name: Fail PR check on errors
         if: ${{ github.event_name == 'pull_request' && (steps.inspect_links_pr.outputs.failed == 'true' || steps.inspect_markdown_pr.outputs.failed == 'true') }}
         run: exit 1

--- a/.github/workflows/comment-on-check-output.yml
+++ b/.github/workflows/comment-on-check-output.yml
@@ -1,0 +1,154 @@
+name: Comment on PR Check Output
+
+# This workflow runs using the definition from main and can write to pull
+# requests. It only reads the untrusted artifact produced by Correctness Checks
+# and posts a comment if that artifact contains check output.
+on:
+  workflow_run:
+    workflows: ["Correctness Checks"]
+    types: [completed]
+
+permissions:
+  actions: read
+  pull-requests: write
+
+jobs:
+  comment:
+    name: Comment on PR check output
+    # Correctness Checks also runs on pushes to main. Only PR runs upload the
+    # artifact that contains a PR number and check output.
+    if: ${{ github.event.workflow_run.event == 'pull_request' }}
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Download PR check output
+        id: download
+        uses: actions/download-artifact@v5
+        with:
+          name: pr-check-output
+          path: ${{ runner.temp }}/pr-check-output
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Comment on PR check output
+        shell: bash
+        env:
+          CHECK_OUTPUT_DIR: ${{ runner.temp }}/pr-check-output
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+          RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import re
+          import subprocess
+          import sys
+          import tempfile
+          from pathlib import Path
+          from typing import Optional
+
+          MAX_COMMENT_LENGTH = 60000
+
+          output_dir = Path(os.environ["CHECK_OUTPUT_DIR"])
+          repository = os.environ["GITHUB_REPOSITORY"]
+          run_head_sha = os.environ["RUN_HEAD_SHA"]
+          run_url = os.environ["RUN_URL"]
+
+          def read_pr_number() -> Optional[str]:
+              path = output_dir / "pr-number.txt"
+              if not path.exists():
+                  print("No pull request number artifact found for workflow run; skipping comment.")
+                  return None
+
+              value = path.read_text().strip()
+              if not value:
+                  print("No pull request number artifact found for workflow run; skipping comment.")
+                  return None
+
+              if not re.fullmatch(r"[0-9]+", value):
+                  raise ValueError(f"invalid pull request number artifact: {value!r}")
+              return value
+
+          def section(title: str, filename: str) -> Optional[str]:
+              path = output_dir / filename
+              if not path.exists():
+                  return None
+
+              output = path.read_text().strip()
+              if not output:
+                  return None
+
+              return f"### {title}\n\n{output}\n"
+
+          def build_comment() -> Optional[str]:
+              sections = [
+                  section("Link check", "inspect-links-pr.txt"),
+                  section("Markdown check", "inspect-markdown-pr.txt"),
+              ]
+              sections = [item for item in sections if item]
+              if not sections:
+                  print("No check output found; skipping comment.")
+                  return None
+
+              details = f"\n\nYou can see more details here: {run_url}"
+              check_output = "\n\n".join(sections)
+              body = (
+                  "Thank you for your contribution to This Week in Rust! "
+                  "Our automated checks found some possible issues with these changes:\n\n"
+                  f"{check_output}"
+              )
+
+              if len(body) + len(details) > MAX_COMMENT_LENGTH:
+                  body = body[:MAX_COMMENT_LENGTH - len(details)]
+
+              return body + details
+
+          def run_gh(args: list[str]) -> subprocess.CompletedProcess[str]:
+              return subprocess.run(
+                  ["gh", *args],
+                  check=True,
+                  text=True,
+                  capture_output=True,
+              )
+
+          def validate_pr_head(pr_number: str) -> bool:
+              result = run_gh(["api", f"repos/{repository}/pulls/{pr_number}", "--jq", ".head.sha"])
+              pr_head_sha = result.stdout.strip()
+              if pr_head_sha != run_head_sha:
+                  print("Pull request head SHA no longer matches workflow run; skipping stale comment.")
+                  return False
+              return True
+
+          def post_comment(pr_number: str, body: str) -> None:
+              with tempfile.NamedTemporaryFile("w", encoding="utf-8", suffix=".json") as input_file:
+                  json.dump({"body": body}, input_file)
+                  input_file.flush()
+                  run_gh(
+                      [
+                          "api",
+                          "--method",
+                          "POST",
+                          f"repos/{repository}/issues/{pr_number}/comments",
+                          "--input",
+                          input_file.name,
+                      ]
+                  )
+
+          try:
+              pr_number = read_pr_number()
+              if not pr_number:
+                  raise SystemExit(0)
+
+              if not validate_pr_head(pr_number):
+                  raise SystemExit(0)
+
+              body = build_comment()
+              if not body:
+                  raise SystemExit(0)
+
+              post_comment(pr_number, body)
+          except subprocess.CalledProcessError as exc:
+              sys.stderr.write(exc.stderr)
+              raise
+          PY


### PR DESCRIPTION
The [previous code](https://github.com/rust-lang/this-week-in-rust/pull/8248) to post a comment back to contribution PRs when the checks failed worked only when the PR was opened from the same fork, because GitHub (very reasonably) prevents write access when running code from public forks. 

This code now uses a second workflow triggered by a [`workflow_run` event](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflow_run) which reads the output from the test workflow and posts the comment. `workflow_run` workflows always use the default branch's content (not the PR branch) and so are trusted and get write tokens. (This case is one of the [examples given in the announcement of `workflow_run`](https://github.blog/news-insights/product-news/github-actions-improvements-for-fork-and-pull-request-workflows/)).

Here's [an example](https://github.com/jder/this-week-in-rust/pull/18) of this new code working in a cross-fork manner. 