### PR TITLE
Add kache storage blog post to Miscellaneous

### DIFF
--- a/draft/2026-07-01-this-week-in-rust.md
+++ b/draft/2026-07-01-this-week-in-rust.md
@@ -52,6 +52,7 @@ and just ask the editors to select the category.
 ### Research
 
 ### Miscellaneous
+* [AI and worktrees are filling our disks: kache storage, measured](https://kunobi.ninja/blog/kache-storage-worktrees)
 
 ## Crate of the Week
 


### PR DESCRIPTION
Adds a Miscellaneous entry linking a kache blog post (placed in Miscellaneous to match the earlier "Content-addressed Rust builds (or, what kache actually caches)" deep-dive in the 2026-05-27 issue).

* [AI and worktrees are filling our disks: kache storage, measured](https://kunobi.ninja/blog/kache-storage-worktrees)

A technical deep-dive, with real measurements from a Firefox build (which mixes Rust and C/C++), on how kache — a content-addressed build cache — shares compiled artifacts across multiple git worktrees zero-copy via reflinks/copy-on-write: restoring 13.5 GB without copying a byte and saving 27.4 GB of duplicate data across a run. Covers methodology, an sccache comparison, implementation boundaries, and reproduction steps.