### PR TITLE
Add mqtt-typed-client 0.2 to Project/Tooling Updates

### DIFF
--- a/draft/2026-07-01-this-week-in-rust.md
+++ b/draft/2026-07-01-this-week-in-rust.md
@@ -45,6 +45,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [mqtt-typed-client 0.2](https://github.com/holovskyi/mqtt-typed-client) - a type-safe async MQTT client on top of rumqttc: declare topics as structs with `#[mqtt_topic("...")]` and get typed publish/subscribe, parameter parsing via FromStr, and tree-based routing instead of hand-written `format!()` and `split('/')`. [Write-up](https://holovskyi.github.io/blog/typed-mqtt-topics-for-rust/).
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs

--- a/draft/2026-07-01-this-week-in-rust.md
+++ b/draft/2026-07-01-this-week-in-rust.md
@@ -45,7 +45,7 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
-* [mqtt-typed-client 0.2](https://github.com/holovskyi/mqtt-typed-client) - a type-safe async MQTT client on top of rumqttc: declare topics as structs with `#[mqtt_topic("...")]` and get typed publish/subscribe, parameter parsing via FromStr, and tree-based routing instead of hand-written `format!()` and `split('/')`. [Write-up](https://holovskyi.github.io/blog/typed-mqtt-topics-for-rust/).
+* [mqtt-typed-client 0.2](https://holovskyi.github.io/blog/typed-mqtt-topics-for-rust/) - a type-safe async MQTT client on top of rumqttc: declare topics as structs with `#[mqtt_topic("...")]` and get typed publish/subscribe, parameter parsing via FromStr, and tree-based routing instead of hand-written `format!()` and `split('/')`.
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
Adds a Project/Tooling Updates entry for mqtt-typed-client 0.2, a type-safe async MQTT client built on rumqttc. You declare topics as structs with `#[mqtt_topic("...")]` and get typed publish/subscribe, topic-parameter parsing via FromStr, and tree-based routing instead of hand-written `format!()` and `split('/')`. The linked write-up covers the before/after and the trade-offs.

Crate: https://crates.io/crates/mqtt-typed-client
Repo: https://github.com/holovskyi/mqtt-typed-client
