### PR TITLE
CFP: add two AimDB tasks for 2026-07-01

### DIFF
--- a/draft/2026-07-01-this-week-in-rust.md
+++ b/draft/2026-07-01-this-week-in-rust.md
@@ -122,6 +122,9 @@ Some of these tasks may also have mentors available, visit the task page for mor
 <!-- * [ - ]() -->
 <!-- or if none - *No Calls for participation were submitted this week.* -->
 
+* [AimDB - Add minimal example: hello-single-latest](https://github.com/aimdb-dev/aimdb/issues/93)
+* [AimDB - Wire `.transform()` and `.transform_join()` into stage profiling](https://github.com/aimdb-dev/aimdb/issues/109)
+
 If you are a Rust project owner and are looking for contributors, please submit tasks [here][guidelines] or through a [PR to TWiR](https://github.com/rust-lang/this-week-in-rust) or by reaching out on [Bluesky](https://bsky.app/profile/thisweekinrust.bsky.social) or [Mastodon](https://mastodon.social/@thisweekinrust)!
 
 [guidelines]:https://github.com/rust-lang/this-week-in-rust?tab=readme-ov-file#call-for-participation-guidelines


### PR DESCRIPTION
Adds two Call for Participation (Projects) entries for [AimDB](https://github.com/aimdb-dev/aimdb) to the 2026-07-01 draft:

* [Add minimal example: hello-single-latest](https://github.com/aimdb-dev/aimdb/issues/93) — `good first issue` + `help wanted` (~2–3 h)
* [Wire `.transform()` and `.transform_join()` into stage profiling](https://github.com/aimdb-dev/aimdb/issues/109) — `help wanted` (intermediate, fully specced)

