### PR TITLE
Add AimDB: Bring Your Own Connector to Project/Tooling Updates

### DIFF
--- a/draft/2026-07-01-this-week-in-rust.md
+++ b/draft/2026-07-01-this-week-in-rust.md
@@ -45,6 +45,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [AimDB: Bring Your Own Connector](https://aimdb.dev/blog/aimdb-bring-your-own-connector)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
Adds a link to the **Project/Tooling Updates** section of the 2026-07-01 draft.

* [AimDB: Bring Your Own Connector](https://aimdb.dev/blog/aimdb-bring-your-own-connector)

The post covers AimDB's unified connector registration: how a custom transport is added by implementing three trait methods (`recv`, `send`, and peer metadata) while inheriting protocol handling, security policies, and session management from the core framework. It contrasts data-plane connectors (MQTT, WebSocket) with remote-access session connectors (Unix socket, serial), showing that swapping the underlying transport requires no changes to application code.