### PR TITLE
Add 'We put a Redis server inside our runtime' to Observations/Thoughts

### DIFF
--- a/draft/2026-07-01-this-week-in-rust.md
+++ b/draft/2026-07-01-this-week-in-rust.md
@@ -47,6 +47,8 @@ and just ask the editors to select the category.
 
 ### Observations/Thoughts
 
+* [We put a Redis server inside our runtime](https://encore.dev/blog/redis-runtime)
+
 ### Rust Walkthroughs
 
 ### Research


### PR DESCRIPTION
We ported [miniredis](https://github.com/alicebob/miniredis) from Go to Rust so our runtime (also written in Rust) can run an in-process Redis for local dev and tests, and validated the port by running miniredis’s own Go integration suite against the Rust server, comparing the raw RESP responses byte-for-byte. The post covers the port (~25k lines of Rust), the mock-clock and TLS-cert fidelity bugs that surfaced from diffing against the reference, and how the runtime chooses the embedded server versus a real Redis.