### PR TITLE
Add kache 0.8.0 to Project/Tooling Updates

### DIFF
--- a/draft/2026-07-01-this-week-in-rust.md
+++ b/draft/2026-07-01-this-week-in-rust.md
@@ -44,6 +44,7 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
+* [kache 0.8.0: zero-copy restores on Windows (ReFS)](https://github.com/kunobi-ninja/kache/releases/tag/v0.8.0)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
Adds a Project/Tooling Updates entry for the kache 0.8.0 release.

* [kache 0.8.0: zero-copy restores on Windows (ReFS)](https://github.com/kunobi-ninja/kache/releases/tag/v0.8.0)

kache is an open-source, content-addressed build cache (RUSTC_WRAPPER, and a C/C++ compiler wrapper). 0.8.0 brings zero-copy restores on Windows via ReFS block-cloning (the Windows analog of reflink/CoW), a self-healing cache index that recovers from corruption instead of failing every command, and steadier cross-clone cache keys. The linked release notes cover why the changes were made and how to use them. Previous kache releases (0.2.0, 0.3.0, 0.5.0, 0.6.0, 0.7.0) have appeared in earlier issues.