### PR TITLE
Add kache storage/worktrees post to Project/Tooling Updates

### DIFF
--- a/draft/2026-07-01-this-week-in-rust.md
+++ b/draft/2026-07-01-this-week-in-rust.md
@@ -45,9 +45,9 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
-* [AI and worktrees are filling our disks: kache storage, measured](https://kunobi.ninja/blog/kache-storage-worktrees)
-
 ### Observations/Thoughts
+
+* [AI and worktrees are filling our disks: kache storage, measured](https://kunobi.ninja/blog/kache-storage-worktrees)
 
 ### Rust Walkthroughs
 

--- a/draft/2026-07-01-this-week-in-rust.md
+++ b/draft/2026-07-01-this-week-in-rust.md
@@ -45,6 +45,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [AI and worktrees are filling our disks: kache storage, measured](https://kunobi.ninja/blog/kache-storage-worktrees)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
Adds an Observations/Thoughts entry for our latest kache post:

* [AI and worktrees are filling our disks: kache storage, measured](https://kunobi.ninja/blog/kache-storage-worktrees)

The post measures how kache's reflink-based, content-addressed cache cuts duplicate storage across multiple Firefox worktrees (47.2 GB → 19.9 GB, 27.4 GB shared). This is placed in Observations/Thoughts rather than Project/Tooling Updates since it's a data/analysis writeup rather than a release update.

Disclaimer: the charts in the linked post were generated with AI assistance.