### PR TITLE
Add gmacFTP to Project/Tooling Updates

### DIFF
--- a/draft/2026-07-01-this-week-in-rust.md
+++ b/draft/2026-07-01-this-week-in-rust.md
@@ -45,6 +45,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+[I built a macOS FTP client entirely in Rust - no Electron, no webview](https://dev.to/gregorymc86/i-built-a-macos-ftp-client-entirely-in-rust-no-electron-no-webview-2a8i)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
Adding [gmacFTP](https://github.com/GMAC-pl/gmacFTP) - a dual-pane FTP/FTPS/SFTP client for macOS built entirely in Rust with a Slint GPU-accelerated UI.

Article: https://dev.to/gregorymc86/i-built-a-macos-ftp-client-entirely-in-rust-no-electron-no-webview-2a8i

The article includes architecture details (Rust + Slint + Tokio), code-level insights, and a call for testers. No paywall, no signup required.