### PR TITLE
Add Warbell to Project/Tooling Updates (2026-07-01 draft)

### DIFF
--- a/draft/2026-07-01-this-week-in-rust.md
+++ b/draft/2026-07-01-this-week-in-rust.md
@@ -45,6 +45,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [Warbell — a castle-defense action-RPG built with Bevy 0.19](https://miskibin.github.io/warbell/)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
Adds **Warbell** to the Project/Tooling Updates section of the current draft.

Warbell is an open-source castle-defense action-RPG built in Rust with Bevy 0.19: defend a central castle through nightly ork sieges, with combat, an economy, an upgrade tree, five biomes, villagers, and bloodline succession. The linked page is the game's showcase site (screenshots + downloads); source is at https://github.com/miskibin/warbell.

I wasn't sure this is the best-fitting category — happy for the editors to recategorize (e.g. Newsletters/Misc) or to point it at a different URL. Not LLM-authored copy; disclosing per the submission rules that this PR description was drafted with assistance.