### PR TITLE
Add Rayfish intro to Project/Tooling Updates (issue 659)

### DIFF
--- a/draft/2026-07-08-this-week-in-rust.md
+++ b/draft/2026-07-08-this-week-in-rust.md
@@ -1,0 +1,241 @@
+Title: This Week in Rust 659
+Number: 659
+Date: 2026-07-08
+Category: This Week in Rust
+
+Hello and welcome to another issue of *This Week in Rust*!
+[Rust](https://www.rust-lang.org/) is a programming language empowering everyone to build reliable and efficient software.
+This is a weekly summary of its progress and community.
+Want something mentioned? Tag us at
+[@thisweekinrust.bsky.social](https://bsky.app/profile/thisweekinrust.bsky.social) on Bluesky or
+[@ThisWeekinRust](https://mastodon.social/@thisweekinrust) on mastodon.social, or
+[send us a pull request](https://github.com/rust-lang/this-week-in-rust).
+Want to get involved? [We love contributions](https://github.com/rust-lang/rust/blob/main/CONTRIBUTING.md).
+
+*This Week in Rust* is openly developed [on GitHub](https://github.com/rust-lang/this-week-in-rust) and archives can be viewed at [this-week-in-rust.org](https://this-week-in-rust.org/).
+If you find any errors in this week's issue, [please submit a PR](https://github.com/rust-lang/this-week-in-rust/pulls).
+
+Want TWIR in your inbox? [Subscribe here](https://this-week-in-rust.us11.list-manage.com/subscribe?u=fd84c1c757e02889a9b08d289&id=0ed8b72485).
+
+## Updates from Rust Community
+
+<!--
+
+Dear community contributors:
+Please read README.md for guidance on submissions.
+Each submitted link should be of the form:
+
+* [Title of the linked Page](https://example.com/my_article)
+
+If you add a link to a non-text content please prefix it with `[video]` or `[audio]`:
+
+* [video] [Title of the linked video](https://example.com/my_video_article)
+* [audio] [Title of the linked audio file](https://example.com/my_podcast)
+
+If you don't know which category to use, feel free to submit a PR anyway
+and just ask the editors to select the category.
+
+-->
+
+### Official
+
+### Foundation
+
+### Newsletters
+
+### Project/Tooling Updates
+
+* [Rayfish: Your own private network. No servers, no setup.](https://rayfish.xyz/blog/01-introducing-rayfish) (This article was written by a human and edited with the assistance of an LLM.)
+
+### Observations/Thoughts
+
+### Rust Walkthroughs
+
+### Research
+
+### Miscellaneous
+
+## Crate of the Week
+
+<!-- COTW goes here -->
+
+[Please submit your suggestions and votes for next week][submit_crate]!
+
+[submit_crate]: https://users.rust-lang.org/t/crate-of-the-week/2704
+
+## Calls for Testing
+An important step for RFC implementation is for people to experiment with the
+implementation and give feedback, especially before stabilization.
+
+If you are a feature implementer and would like your RFC to appear in this list, add a
+`call-for-testing` label to your RFC along with a comment providing testing instructions and/or
+guidance on which aspect(s) of the feature need testing.
+
+<!-- If there are new CfT items this week, include:
+
+  [Repo Name](Repo URL)
+    * [<Feature name>](<Feature URL>)
+        * [Testing steps](<Testing Steps URL>)
+
+  - and make note in the item so the authors know to remove the `call-for-testing` label:
+This RFC will appear in the **Call for Testing** section of the next issue (#) of This Week in Rust (TWiR).
+You may remove the `call-for-testing` label.  Please feel free to leave the `call-for-testing` label in place if you would like this RFC to appear again in another issue of TWiR.
+
+  - where `Repo Name` and `Repo URL` are one of:
+[Rust](https://github.com/rust-lang/rust/labels/call-for-testing),
+[Rust language RFCs](https://github.com/rust-lang/rfcs/issues?q=label%3Acall-for-testing),
+[Cargo](https://github.com/rust-lang/cargo/labels/call-for-testing) or
+[Rustup](https://github.com/rust-lang/rustup/labels/call-for-testing)
+
+  - and `Testing steps` points directly to the procedures the item wants users to exercise.
+
+  - For all `Repo Names` with no new CfT items this week: use (removing the repos for which new
+     CfT items did appear, of course)
+
+* *No calls for testing were issued this week by
+  [Rust](https://github.com/rust-lang/rust/labels/call-for-testing),
+  [Rust language RFCs](https://github.com/rust-lang/rfcs/issues?q=label%3Acall-for-testing),
+  [Cargo](https://github.com/rust-lang/cargo/labels/call-for-testing) or
+  [Rustup](https://github.com/rust-lang/rustup/labels/call-for-testing).*
+-->
+
+[Let us know](https://github.com/rust-lang/this-week-in-rust/issues) if you would like your feature to be tracked as a part of this list.
+
+### [RFCs](https://github.com/rust-lang/rfcs/issues?q=label%3Acall-for-testing)
+
+### [Rust](https://github.com/rust-lang/rust/labels/call-for-testing)
+
+### [Rustup](https://github.com/rust-lang/rustup/labels/call-for-testing)
+
+If you are a feature implementer and would like your RFC to appear on the above list, add the new `call-for-testing`
+label to your RFC along with a comment providing testing instructions and/or guidance on which aspect(s) of the feature
+need testing.
+
+## Call for Participation; projects and speakers
+
+### CFP - Projects
+
+Always wanted to contribute to open-source projects but did not know where to start?
+Every week we highlight some tasks from the Rust community for you to pick and get started!
+
+Some of these tasks may also have mentors available, visit the task page for more information.
+
+<!-- CFPs go here, use this format: * [project name - title of issue](URL to issue) -->
+<!-- * [ - ]() -->
+<!-- or if none - *No Calls for participation were submitted this week.* -->
+
+If you are a Rust project owner and are looking for contributors, please submit tasks [here][guidelines] or through a [PR to TWiR](https://github.com/rust-lang/this-week-in-rust) or by reaching out on [Bluesky](https://bsky.app/profile/thisweekinrust.bsky.social) or [Mastodon](https://mastodon.social/@thisweekinrust)!
+
+[guidelines]:https://github.com/rust-lang/this-week-in-rust?tab=readme-ov-file#call-for-participation-guidelines
+
+### CFP - Events
+
+Are you a new or experienced speaker looking for a place to share something cool? This section highlights events that are being planned and are accepting submissions to join their event as a speaker.
+
+<!-- CFPs go here, use this format: * [**event name**](URL to CFP)| Date CFP closes in YYYY-MM-DD | city,state,country | Date of event in YYYY-MM-DD -->
+<!-- or if none - *No Calls for papers or presentations were submitted this week.* -->
+
+If you are an event organizer hoping to expand the reach of your event, please submit a link to the website through a [PR to TWiR](https://github.com/rust-lang/this-week-in-rust) or by reaching out on [Bluesky](https://bsky.app/profile/thisweekinrust.bsky.social) or [Mastodon](https://mastodon.social/@thisweekinrust)!
+
+## Updates from the Rust Project
+
+<!-- Rust updates go here -->
+
+### Rust Compiler Performance Triage
+
+<!-- Perf results go here -->
+
+### [Approved RFCs](https://github.com/rust-lang/rfcs/commits/master)
+
+Changes to Rust follow the Rust [RFC (request for comments) process](https://github.com/rust-lang/rfcs#rust-rfcs). These
+are the RFCs that were approved for implementation this week:
+
+<!-- Use either
+* [Item title](Item URL)
+  - or
+* *No RFCs were approved this week.*
+-->
+
+### Final Comment Period
+
+Every week, [the team](https://www.rust-lang.org/team.html) announces the 'final comment period' for RFCs and key PRs
+which are reaching a decision. Express your opinions now.
+
+#### Tracking Issues & PRs
+<!-- Either remove the group from the "No Items Entered Final Comment Period this week for" section
+     and add the item(s) which entered Final comment period:
+##### [Group](Group URL)
+* [Item title](Item URL)
+  - for `disposition-merge` `final-comment-period` items, or
+* [disposition: postpone]
+  - for `disposition-postpone` `final-comment-period` items, or
+* [disposition: close]
+  - for `disposition-close` `final-comment-period` items,
+* [disposition: unspecified]
+  - when `disposition` is unspecified or ensure the group is a part of the
+     "No Items Entered Final Comment Period this week for" section
+*No Items entered Final Comment Period this week for
+  [Rust RFCs](https://github.com/rust-lang/rfcs/labels/final-comment-period),
+  [Cargo](https://github.com/rust-lang/cargo/issues?q=is%3Aopen+label%3Afinal-comment-period+sort%3Aupdated-desc),
+  [Compiler Team](https://github.com/rust-lang/compiler-team/issues?q=label%3Amajor-change%20%20label%3Afinal-comment-period) [(MCPs only)](https://forge.rust-lang.org/compiler/mcp.html),
+  [Language Team](https://github.com/rust-lang/lang-team/issues?q=is%3Aopen+label%3Afinal-comment-period+sort%3Aupdated-desc+),
+  [Language Reference](https://github.com/rust-lang/reference/issues?q=is%3Aopen+label%3Afinal-comment-period+sort%3Aupdated-desc),
+  [Leadership Council](https://github.com/rust-lang/leadership-council/issues?q=state%3Aopen%20label%3Afinal-comment-period) or
+  [Unsafe Code Guidelines](https://github.com/rust-lang/unsafe-code-guidelines/issues?q=is%3Aopen+label%3Afinal-comment-period+sort%3Aupdated-desc).*
+
+Let us know if you would like your PRs, Tracking Issues or RFCs to be tracked as a part of this list.
+-->
+
+#### [New and Updated RFCs](https://github.com/rust-lang/rfcs/pulls)
+<!-- Use either
+* [Item title](Item URL)
+  - for new items, or
+* [updated] [Item title](Item URL)
+  - for updated items, or
+* *No New or Updated RFCs were created this week.*
+-->
+
+<!-- Sample commit message
+Update CFT, FCP, MCP and RFC sections for TWiR-xxx
+-->
+
+## Upcoming Events
+
+Rusty Events between $twir_issue_date - $twir_events_end_date 🦀
+
+$twir_events_list
+
+If you are running a Rust event please add it to the [calendar] to get
+it mentioned here. Please remember to add a link to the event too.
+Email the [Rust Community Team][community] for access.
+
+[calendar]: https://www.google.com/calendar/embed?src=apd9vmbc22egenmtu5l6c5jbfc%40group.calendar.google.com
+[community]: mailto:community-team@rust-lang.org
+
+## Jobs
+
+Please see the latest [Who's Hiring thread on r/rust](INSERT_LINK_HERE)
+
+# Quote of the Week
+
+<!-- QOTW goes here -->
+
+[Please submit quotes and vote for next week!](https://users.rust-lang.org/t/twir-quote-of-the-week/328)
+
+This Week in Rust is edited by:
+
+* [nellshamrell](https://github.com/nellshamrell)
+* [llogiq](https://github.com/llogiq)
+* [ericseppanen](https://github.com/ericseppanen)
+* [extrawurst](https://github.com/extrawurst)
+* [U007D](https://github.com/U007D)
+* [mariannegoldin](https://github.com/mariannegoldin)
+* [bdillo](https://github.com/bdillo)
+* [opeolluwa](https://github.com/opeolluwa)
+* [bnchi](https://github.com/bnchi)
+* [KannanPalani57](https://github.com/KannanPalani57)
+* [tzilist](https://github.com/tzilist)
+
+*Email list hosting is sponsored by [The Rust Foundation](https://foundation.rust-lang.org/)*
+
+<small>[Discuss on r/rust](REDDIT_LINK_HERE)</small>


### PR DESCRIPTION
Resubmitting the Rayfish introduction blog post for next week's issue (659), following up on #8276.

Per the [LLM guidelines](https://github.com/rust-lang/this-week-in-rust/#llm-written-articles), the entry now discloses that the linked article was written by a human and edited with the assistance of an LLM.

Rayfish is a P2P mesh VPN built on iroh that connects peers by cryptographic identity instead of IP address.

Next week's draft did not exist yet, so this PR creates `draft/2026-07-08-this-week-in-rust.md` from the template. If the editors generate their own draft for 659, feel free to just pick up the single entry under Project/Tooling Updates.