### PR TITLE
Some small CI improvements

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -56,18 +56,12 @@ jobs:
             status="$?"
             cat "$CHECK_OUTPUT_FILE"
 
-            if [[ "$status" -eq 0 ]]; then
-                echo "failed=false" >> "$GITHUB_OUTPUT"
-            else
-                echo "failed=true" >> "$GITHUB_OUTPUT"
-            fi
-
-            exit 0
+            exit "$status"
       - name: inspect_markdown for main
         if: ${{ github.event_name == 'push' }}
         run: python3 tools/inspect_markdown.py --num-recent 5
       - name: inspect_markdown for pull request
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ !cancelled() && github.event_name == 'pull_request' }}
         id: inspect_markdown_pr
         shell: bash
         env:
@@ -78,22 +72,16 @@ jobs:
             status="$?"
             cat "$CHECK_OUTPUT_FILE"
 
-            if [[ "$status" -eq 0 ]]; then
-                echo "failed=false" >> "$GITHUB_OUTPUT"
-            else
-                echo "failed=true" >> "$GITHUB_OUTPUT"
-            fi
-
-            exit 0
+            exit "$status"
       # Upload the check output so the workflow_run workflow can fetch it later.
       # That follow-up workflow has permission to write PR comments, unlike this
       # pull_request workflow which runs on possibly-untrusted forks.
       - name: Prepare PR check output metadata
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ !cancelled() && github.event_name == 'pull_request' }}
         shell: bash
         run: echo "${{ github.event.pull_request.number }}" > "${{ runner.temp }}/pr-number.txt"
       - name: Upload PR check output
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ !cancelled() && github.event_name == 'pull_request' }}
         uses: actions/upload-artifact@v4
         with:
           name: pr-check-output
@@ -102,6 +90,3 @@ jobs:
             ${{ runner.temp }}/inspect-links-pr.txt
             ${{ runner.temp }}/inspect-markdown-pr.txt
           if-no-files-found: ignore
-      - name: Fail PR check on errors
-        if: ${{ github.event_name == 'pull_request' && (steps.inspect_links_pr.outputs.failed == 'true' || steps.inspect_markdown_pr.outputs.failed == 'true') }}
-        run: exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ cache
 .sass-cache
 **/.idea
 .DS_Store
+/.*
+!/.github/
 
 # Publishing creations...
 publishing/email

--- a/tools/inspect_links.py
+++ b/tools/inspect_links.py
@@ -276,8 +276,11 @@ def inspect_files(file_list: list[str], *, tree: Union[pygit2.Tree, None] = None
         for link in links:
             collision = linkset.get(link)
             if collision:
-                diagnostics.error(
-                    f"possible duplicate link {link} in file {file} (also found in {collision}")
+                if file == collision:
+                    diagnostics.error(f"possible duplicate link {link} found twice in {file}")
+                else:
+                    diagnostics.error(
+                        f"possible duplicate link {link} in file {file} (also found in {collision})")
             else:
                 linkset[link] = file
 

--- a/tools/inspect_markdown.py
+++ b/tools/inspect_markdown.py
@@ -55,7 +55,7 @@ def check_tags(html, file):
         if tag.name not in VALID_TAGS:
             tag_str = str(tag)[:50]
             diagnostics.error(
-                f'{file}: unrecognized tag {tag.name} in "{tag_str}"')
+                f'{file}: unrecognized tag "{tag.name}" in `{tag_str}`')
         if tag.name == 'li':
             if tag.get_text() == '':
                 diagnostics.error(f'{file}: empty <{tag.name}> tag after {prev_tag}')


### PR DESCRIPTION
* Ignore top-level dot files except for `.github` so that we don't need to manually ignore .vscode, .zed, .venv, etc
* Improve some wording for duplicate links and unknown tags (see example in [this demo](https://github.com/jder/this-week-in-rust/pull/21))
* Rework the CI checks so looking at the action failure page shows what actually failed (compare [this earlier failure](https://github.com/rust-lang/this-week-in-rust/actions/runs/28563416436/job/84685705591) with [this one](https://github.com/jder/this-week-in-rust/actions/runs/28602951542/job/84815680515?pr=21)). 

Individual commits are self-contained for review!