### PR TITLE
Add wickra (streaming technical indicators) to Project/Tooling Updates

### DIFF
--- a/draft/2026-07-08-this-week-in-rust.md
+++ b/draft/2026-07-08-this-week-in-rust.md
@@ -45,7 +45,7 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
-* [wickra](https://github.com/wickra-lib/wickra) — streaming-first technical indicators with a Rust core, native Python/Node/WASM bindings and a C ABI for C, C++, C#, Go, Java and R. 514 indicators, O(1) per tick, zero dependencies.
+* [wickra — Rust quickstart](https://docs.wickra.org/Quickstart-Rust) — streaming-first technical indicators: one Rust core (an `Indicator` trait with O(1) `update()`, `batch()` and composable `Chain`s) plus native Python/Node/WASM bindings and a C ABI for C, C++, C#, Go, Java and R. 514 indicators across 24 families, zero dependencies.
 
 ### Observations/Thoughts
 

--- a/draft/2026-07-08-this-week-in-rust.md
+++ b/draft/2026-07-08-this-week-in-rust.md
@@ -45,6 +45,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [wickra](https://github.com/wickra-lib/wickra) — streaming-first technical indicators with a Rust core, native Python/Node/WASM bindings and a C ABI for C, C++, C#, Go, Java and R. 514 indicators, O(1) per tick, zero dependencies.
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
Adds wickra to Project/Tooling Updates.

wickra is a streaming-first technical-analysis library: one Rust core with native Python/Node/WASM bindings and a C ABI for C, C++, C#, Go, Java and R. 514 indicators across 24 families, O(1) per tick, zero dependencies. Docs: https://docs.wickra.org — live demo: https://live.wickra.org