### PR TITLE
Add blog categorising the Rust week talks

### DIFF
--- a/draft/2026-07-08-this-week-in-rust.md
+++ b/draft/2026-07-08-this-week-in-rust.md
@@ -53,6 +53,8 @@ and just ask the editors to select the category.
 
 ### Miscellaneous
 
+* [Clickable euler diagram of all the Rust week talks](https://seanborg.tech/tiny-blog/rust-week-ven-diagram/)
+
 ## Crate of the Week
 
 <!-- COTW goes here -->


### PR DESCRIPTION
I categorized all the Rust week talks to present at Rust Manchester.

hopefully helps some people pick what they want to watch 