### PR TITLE
Add Tree Ring Memory Rust tooling article

### DIFF
--- a/draft/2026-07-08-this-week-in-rust.md
+++ b/draft/2026-07-08-this-week-in-rust.md
@@ -45,6 +45,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [Building A Rust-Native Memory Lifecycle CLI For AI Agents](https://terminallylazy.github.io/Tree-Ring-Memory/launch/rust-native-agent-memory-cli.md)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
Adds a Rust-specific launch article about Tree Ring Memory under Project/Tooling Updates for issue 659.

The article covers the workspace split, SQLite/FTS storage choice, explicit writes instead of transcript capture, explainable recall, audit/forgetting, and the Ratatui operator console.

Disclosure: the linked article itself notes that it was prepared with AI-assisted drafting from checked-in repository, release, and marketing materials.