### PR TITLE
Add kache 0.9.0 to Project/Tooling Updates

### DIFF
--- a/draft/2026-07-08-this-week-in-rust.md
+++ b/draft/2026-07-08-this-week-in-rust.md
@@ -44,6 +44,7 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
+* [kache 0.9.0: supply-chain hardening + read-only CI cache](https://github.com/kunobi-ninja/kache/releases/tag/v0.9.0)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
Adds a Project/Tooling Updates entry for the kache 0.9.0 release.

* [kache 0.9.0: supply-chain hardening + read-only CI cache](https://github.com/kunobi-ninja/kache/releases/tag/v0.9.0)

kache is an open-source, content-addressed build cache (RUSTC_WRAPPER, and a C/C++ compiler wrapper). 0.9.0 adds a read-only remote consumer mode for GET-only environments like fork/PR CI, makes remapped debug-info paths resolve for profilers, and hardens the supply chain — SHA-pinned GitHub Actions, cargo-deny audits, a RUSTSEC advisory fix, and the first release published as an immutable GitHub release. The linked release notes cover why the changes were made and how to use them. Previous kache releases (0.2.0, 0.3.0, 0.5.0–0.8.0) have appeared in earlier issues.