### PR TITLE
Adds FlareDB to this week's draft 2026-07-08

### DIFF
--- a/draft/2026-07-08-this-week-in-rust.md
+++ b/draft/2026-07-08-this-week-in-rust.md
@@ -59,6 +59,7 @@ and just ask the editors to select the category.
 * [RSSH v0.2.11 — terminal workflows, safer SSH key import, and observable AI ops](https://github.com/shihuili1218/rssh/releases/tag/v0.2.11)
 * [k8s-scale-app-rs: Scale or Restart a Kubernetes Deployment from a CronJob](https://blog.none.at/blog/2026/2026-07-06-k8s-scale-app-rs/)
 * [M-vis v0.5.0-rc1 update](https://dev.to/sicklefire/m-vis-v050-rc1-update-11cp)
+* [FlareDB: An Apache Beam Native Streaming Database built in Rust](https://ganeshsivakumar.substack.com/p/flaredb)
 
 ### Observations/Thoughts
 * [video] [Rust Berlin Meetup 25/06/2026 Livestream](https://www.youtube.com/watch?v=SGR5qBdwk30)


### PR DESCRIPTION
This PR adds FlareDB's architecture blog post under Project/Tooling Updates section of the draft. 

The blog post explains, motivation and how FlareDB runs data pipelines written in Java on its rust based execution engine. 

Blog post  - https://ganeshsivakumar.substack.com/p/flaredb

FlareDB repo - https://github.com/flare-db/flare-db

