### PR TITLE
Add mqtt-typed-client 0.2 to Project/Tooling Updates

### DIFF
--- a/draft/2026-07-08-this-week-in-rust.md
+++ b/draft/2026-07-08-this-week-in-rust.md
@@ -59,6 +59,7 @@ and just ask the editors to select the category.
 * [RSSH v0.2.11 — terminal workflows, safer SSH key import, and observable AI ops](https://github.com/shihuili1218/rssh/releases/tag/v0.2.11)
 * [k8s-scale-app-rs: Scale or Restart a Kubernetes Deployment from a CronJob](https://blog.none.at/blog/2026/2026-07-06-k8s-scale-app-rs/)
 * [M-vis v0.5.0-rc1 update](https://dev.to/sicklefire/m-vis-v050-rc1-update-11cp)
+* [mqtt-typed-client 0.2: a type-safe async MQTT client on rumqttc](https://holovskyi.github.io/blog/typed-mqtt-topics-for-rust/)
 
 ### Observations/Thoughts
 * [video] [Rust Berlin Meetup 25/06/2026 Livestream](https://www.youtube.com/watch?v=SGR5qBdwk30)


### PR DESCRIPTION
Adds a Project/Tooling Updates entry for mqtt-typed-client 0.2, a type-safe async MQTT client built on rumqttc.

This is a resubmission of #8300 with the link description shortened per @nellshamrell's request (it was closed as the issue was about to publish). The descriptive text is now inside the link and kept short.

Link goes to the write-up: https://holovskyi.github.io/blog/typed-mqtt-topics-for-rust/