### PR TITLE
Add Scope to Project/Tooling Updates (2026-07-15 draft)

### DIFF
--- a/draft/2026-07-15-this-week-in-rust.md
+++ b/draft/2026-07-15-this-week-in-rust.md
@@ -45,6 +45,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [Scope 0.5.0: a cross-platform serial-monitor TUI with RTT and Lua plugins](https://github.com/matheuswhite/scope-rs/releases/tag/v0.5.0)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
Adds an entry to **Project/Tooling Updates** in the 2026-07-15 draft.

[Scope](https://github.com/matheuswhite/scope-rs) is a cross-platform serial-monitor TUI built with `ratatui`. Beyond serial ports, it talks to embedded targets over **RTT via `probe-rs`**, and offers colored/timestamped send-receive, hex and `@tag` input macros, search, session recording, auto-reconnect, and **Lua plugins** for scripting custom hooks and commands. The 0.5.0 release rounds out the RTT interface and ships a rewritten guide. Published on crates.io as `scope-monitor`; runs on Linux, Windows and macOS.

The linked repo README includes a demo GIF and the full feature list.