### PR TITLE
Add cochlea to Project/Tooling Updates

### DIFF
--- a/draft/2026-07-15-this-week-in-rust.md
+++ b/draft/2026-07-15-this-week-in-rust.md
@@ -45,6 +45,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [cochlea 0.1.0: a headless, deterministic audio engine for AI agents](https://richer-richard.github.io/cochlea/)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
Adds [cochlea](https://github.com/richer-richard/cochlea) to Project/Tooling Updates in the 2026-07-15 draft.

cochlea is a headless, deterministic audio engine written for AI agents rather than human ears: it renders declarative scores to byte-identical PCM offline, then exposes the result as loudness/pitch/tempo/key/structure reports and spectrograms so an agent can inspect audio without reading raw samples. Pure Rust, no unsafe, all 9 crates published to crates.io this week (v0.1.0), plus an MCP server for agent tool use.

Linked to the project's docs site (https://richer-richard.github.io/cochlea/) rather than the bare repo, per the contributing guide.