### PR TITLE
Add plaza 1.0 to Project/Tooling Updates

### DIFF
--- a/draft/2026-07-15-this-week-in-rust.md
+++ b/draft/2026-07-15-this-week-in-rust.md
@@ -45,6 +45,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [plaza 1.0: a ratatui package-manager TUI that searches pacman, the AUR, apt, dnf, and Flatpak at once](https://github.com/StaszeKrk/plaza/releases/tag/v1.0.0)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
plaza 1.0: a cross-distro package-manager TUI built with ratatui. Searches pacman, the AUR, apt, dnf, and Flatpak concurrently, merges results by name, and runs installs in a background PTY pane. The linked release notes cover what changed for 1.0, including the in-memory dnf catalog that makes dnf search instant.