### PR TITLE
Add CleitonForge to issue 660 (Project/Tooling Updates + Observations/Thoughts)

### DIFF
--- a/draft/2026-07-15-this-week-in-rust.md
+++ b/draft/2026-07-15-this-week-in-rust.md
@@ -45,7 +45,11 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [CleitonForge: neutral Rust quantum circuit benchmarking found a silent Rz sign convention bug (fidelity=0) in a Rust simulator](https://github.com/cleitonaugusto/CleitonForge)
+
 ### Observations/Thoughts
+
+* [Why do some Rust quantum simulators use the opposite Rz gate sign convention from OpenQASM 3?](https://quantumcomputing.stackexchange.com/questions/46362/)
 
 ### Rust Walkthroughs
 

--- a/draft/2026-07-15-this-week-in-rust.md
+++ b/draft/2026-07-15-this-week-in-rust.md
@@ -47,7 +47,11 @@ and just ask the editors to select the category.
 
 * [CleitonForge: neutral Rust quantum circuit benchmarking found a silent Rz sign convention bug (fidelity=0) in a Rust simulator](https://github.com/cleitonaugusto/CleitonForge)
 
+* [CleitonForge: neutral Rust quantum circuit benchmarking found a silent Rz sign convention bug (fidelity=0) in a Rust simulator](https://github.com/cleitonaugusto/CleitonForge)
+
 ### Observations/Thoughts
+
+* [Why do some Rust quantum simulators use the opposite Rz gate sign convention from OpenQASM 3?](https://quantumcomputing.stackexchange.com/questions/46362/)
 
 * [Why do some Rust quantum simulators use the opposite Rz gate sign convention from OpenQASM 3?](https://quantumcomputing.stackexchange.com/questions/46362/)
 

--- a/draft/2026-07-15-this-week-in-rust.md
+++ b/draft/2026-07-15-this-week-in-rust.md
@@ -45,13 +45,9 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
-* [CleitonForge: neutral Rust quantum circuit benchmarking found a silent Rz sign convention bug (fidelity=0) in a Rust simulator](https://github.com/cleitonaugusto/CleitonForge)
-
-* [CleitonForge: neutral Rust quantum circuit benchmarking found a silent Rz sign convention bug (fidelity=0) in a Rust simulator](https://github.com/cleitonaugusto/CleitonForge)
+* [We benchmarked 4 Rust quantum simulators — three agreed, one didn't (and we found why)](https://dev.to/cleiton_augusto_/we-benchmarked-4-rust-quantum-simulators-three-agreed-one-didnt-4dd2)
 
 ### Observations/Thoughts
-
-* [Why do some Rust quantum simulators use the opposite Rz gate sign convention from OpenQASM 3?](https://quantumcomputing.stackexchange.com/questions/46362/)
 
 * [Why do some Rust quantum simulators use the opposite Rz gate sign convention from OpenQASM 3?](https://quantumcomputing.stackexchange.com/questions/46362/)
 


### PR DESCRIPTION
## Links added to issue 660

**Project/Tooling Updates:**
* [CleitonForge: neutral Rust quantum circuit benchmarking found a silent Rz sign convention bug (fidelity=0) in a Rust simulator](https://github.com/cleitonaugusto/CleitonForge)

CleitonForge is a Rust workspace (cforge-core, cforge-parser, cforge-backends, cforge-metrics, cforge-cli) that runs the same OpenQASM 2/3 circuit through multiple backends and compares statevector fidelity. While building it, we found that `quantrs2` implements `Rz(λ)` with the opposite sign from the OpenQASM 3 standard — causing QAOA circuits to silently return fidelity = 0.0 with no error. Python bindings via PyO3: `pip install cleitonforge`.

**Observations/Thoughts:**
* [Why do some Rust quantum simulators use the opposite Rz gate sign convention from OpenQASM 3?](https://quantumcomputing.stackexchange.com/questions/46362/)

The QSE question documenting the sign convention discrepancy and its impact on circuit fidelity.