### PR TITLE
Silicon Sundays Meetup

### DIFF
--- a/draft/2026-07-15-this-week-in-rust.md
+++ b/draft/2026-07-15-this-week-in-rust.md
@@ -245,6 +245,8 @@ Rusty Events between 2026-07-15 - 2026-08-12 🦀
 ### Asia
 * 2026-07-18 | Bangalore, IN | [Rust Bangalore](https://hasgeek.com/rustbangalore)
   * [**July 2026 Rustacean Meetup**](https://hasgeek.com/rustbangalore/july-2026-rustacean-meetup/)
+* 2026-07-19 | Virtual (Bangalore, IN) | [Embedded Rust Discord](https://discord.gg/VJyv3NfVdw)
+  * [**Silicon Sundays**](https://discord.gg/6gwCNpFP?event=1526087936234225814)
 
 ### Africa:
 * 2026-07-14 | Johannesburg, ZA | [Johannesburg Rust Meetup](https://www.meetup.com/johannesburg-rust-meetup/events/)


### PR DESCRIPTION
The [Embedded Rust Discord](https://discord.gg/VJyv3NfVdw), is hosting it's first meetup titled **Silicon Sundays** on 19th July 2026.

I would love to have it featured in This Week in Rust.
