### PR TITLE
Add kobe 0.33.0 to Project/Tooling Updates

### DIFF
--- a/draft/2026-07-15-this-week-in-rust.md
+++ b/draft/2026-07-15-this-week-in-rust.md
@@ -44,6 +44,7 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
+* [kobe 0.33.0: a Rust operator for instant CI Kubernetes clusters](https://github.com/kunobi-ninja/kobe/releases/tag/v0.33.0)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
Adds a Project/Tooling Updates entry for the first public release of kobe.

* [kobe 0.33.0: a Rust operator for instant CI Kubernetes clusters](https://github.com/kunobi-ninja/kobe/releases/tag/v0.33.0)

kobe is an open-source (Apache-2.0) Kubernetes operator written in Rust that manages fleets of ephemeral clusters. It keeps pools pre-warmed across pluggable backends (k3s, k0s, vcluster, CAPI) so CI jobs and developers can lease a fully configured, isolated cluster in under 5 seconds over an HTTP API — instead of spending 30–360s spinning up Kind/vcluster per job, with Docker-in-Docker hacks and static secrets to rotate.

It is built on kube-rs 3.0 + k8s-openapi for the control loops and CRDs, axum for the lease API, and sqlx/tokio/rustls/tracing; Rust edition 2024, MSRV 1.94.1. The CLI is published as the `kobectl` crate. The linked release notes cover why it exists, what it does, and how to use it.