### PR TITLE
Add kache 0.10.0 to Project/Tooling Updates

### DIFF
--- a/draft/2026-07-15-this-week-in-rust.md
+++ b/draft/2026-07-15-this-week-in-rust.md
@@ -44,6 +44,7 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
+* [kache 0.10.0: instant download dedup, no more polling](https://github.com/kunobi-ninja/kache/releases/tag/v0.10.0)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
Adds a Project/Tooling Updates entry for the kache 0.10.0 release.

* [kache 0.10.0: instant download dedup, no more polling](https://github.com/kunobi-ninja/kache/releases/tag/v0.10.0)

kache is an open-source, content-addressed build cache (RUSTC_WRAPPER, and a C/C++ compiler wrapper). In 0.10.0, waiters on an in-flight cache download now wake through a per-key tokio `Notify` the instant the leader's claim guard drops, instead of polling every 100ms for up to 30s — which also closed a latent double-claim race where two waiters could each re-claim the key and download the same artifact twice. It also fixes a Windows ReFS warning that wrongly blamed the filesystem for lacking copy-on-write (block-cloning can only clone cluster-aligned ranges, so sub-cluster files must fall back to a copy on a perfectly healthy Dev Drive).

The linked release notes cover why the changes were made, how to use them, and what we learned. Previous kache releases (0.2.0, 0.3.0, 0.5.0–0.9.0) have appeared in earlier issues.