### PR TITLE
Add red-team writeup to Observations/Thoughts

### DIFF
--- a/draft/2026-07-15-this-week-in-rust.md
+++ b/draft/2026-07-15-this-week-in-rust.md
@@ -47,6 +47,8 @@ and just ask the editors to select the category.
 
 ### Observations/Thoughts
 
+* [I red-teamed my own LLM security gateway (Rust) in four passes — every detection gap and how I closed it](https://dev.to/akavlabs_69/i-red-teamed-my-own-llm-security-gateway-in-four-passes-heres-every-gap-i-found-5cl9)
+
 ### Rust Walkthroughs
 
 ### Research


### PR DESCRIPTION
Adding a write-up under Observations/Thoughts: a four-pass red-team of an open-source Rust LLM-security proxy — the detection-engineering angle (evasion gaps, egress/streaming DLP, and keeping false positives at zero with a benign-corpus discipline). Not a crate release; it's an article with code.