### PR TITLE
Add 'We compiled our TypeScript parser to WASM' to Observations/Thoughts

### DIFF
--- a/draft/2026-07-15-this-week-in-rust.md
+++ b/draft/2026-07-15-this-week-in-rust.md
@@ -47,6 +47,8 @@ and just ask the editors to select the category.
 
 ### Observations/Thoughts
 
+* [We compiled our TypeScript parser to WASM](https://encore.dev/blog/typescript-parser-wasm)
+
 ### Rust Walkthroughs
 
 ### Research


### PR DESCRIPTION
We compiled our Rust TypeScript parser to WebAssembly with wasm-pack so it runs in the browser (rather than just in the CLI). The post covers gating OS-dependent code behind a native Cargo feature so it drops out of the WASM build, swapping disk reads for an in-memory file resolver, and embedding the SDK at compile time.