### PR TITLE
Add Nova v0.2.1 to Project/Tooling Updates (issue 661)

### DIFF
--- a/draft/2026-07-22-this-week-in-rust.md
+++ b/draft/2026-07-22-this-week-in-rust.md
@@ -44,6 +44,7 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
+* [Nova v0.2.1: computer-use MCP server](https://github.com/bigduu/Nova/releases/tag/v0.2.1)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
Re-submitting for next week's edition per the feedback on #8401 — link text now kept to ~5 words.

Nova is a computer-use MCP server for macOS & Windows, shipped as a single self-contained Rust binary.

https://claude.ai/code/session_01UL4szV36SJjZbt2XnUCMdm