### PR TITLE
Add submission to Rust Walkthroughs: reqwest + Paperless-ngx sync daemon bugs

### DIFF
--- a/draft/2026-07-22-this-week-in-rust.md
+++ b/draft/2026-07-22-this-week-in-rust.md
@@ -48,6 +48,7 @@ and just ask the editors to select the category.
 ### Observations/Thoughts
 
 ### Rust Walkthroughs
+* [Two bugs I only found by running my Rust sync daemon against real infrastructure](https://dev.to/scripthpp/two-bugs-i-only-found-by-running-my-rust-sync-daemon-against-real-infrastructure-4278)
 
 ### Research
 


### PR DESCRIPTION
Adding a submission to the Rust Walkthroughs section for the upcoming issue.

Article walks through two bugs found while building a Notion-to-Paperless-ngx sync daemon: reqwest dropping the Authorization header on a scheme-change redirect, and treating an async task-accepted response as success without polling the actual task result. Not sure if Rust Walkthroughs is the right category, happy to have editors move it if not.