### PR TITLE
Add muskitty-html5-parser to issue 661 (Project/Tooling Updates)

### DIFF
--- a/draft/2026-07-22-this-week-in-rust.md
+++ b/draft/2026-07-22-this-week-in-rust.md
@@ -44,6 +44,7 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
+* [muskitty-html5-parser: an LLM-agent-built HTML5 parser, 100% WPT tree construction, 0 unsafe](https://crates.io/crates/muskitty-html5-parser) -- An experiment in specification-guided LLM codegen: the agent was given the WHATWG HTML spec and a three-rule constitution (spec > WPT > Chromium, safe-first, spec-first), then left to iterate against WPT. Tokenizer: 99.8%. Tree builder: 100% including adoption agency & template. Human wrote the test-feedback loop; LLM wrote the Rust. [LLM authorship disclosed](https://github.com/muskitty-dev/muskitty-html5-parser/blob/main/LLM_GENERATION.md). [Source](https://github.com/muskitty-dev/muskitty-html5-parser)
 
 ### Observations/Thoughts
 

--- a/draft/2026-07-22-this-week-in-rust.md
+++ b/draft/2026-07-22-this-week-in-rust.md
@@ -44,7 +44,7 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
-* [muskitty-html5-parser: an LLM-agent-built HTML5 parser, 100% WPT tree construction, 0 unsafe](https://crates.io/crates/muskitty-html5-parser) -- An experiment in specification-guided LLM codegen: the agent was given the WHATWG HTML spec and a three-rule constitution (spec > WPT > Chromium, safe-first, spec-first), then left to iterate against WPT. Tokenizer: 99.8%. Tree builder: 100% including adoption agency & template. Human wrote the test-feedback loop; LLM wrote the Rust. [LLM authorship disclosed](https://github.com/muskitty-dev/muskitty-html5-parser/blob/main/LLM_GENERATION.md). [Source](https://github.com/muskitty-dev/muskitty-html5-parser)
+* [muskitty-html5-parser: an LLM-agent-built HTML5 parser, 100% WPT tree construction, 0 unsafe](https://github.com/muskitty-dev/muskitty-html5-parser#readme) -- An experiment in specification-guided LLM codegen: the agent was given the WHATWG HTML spec and a three-rule constitution (spec > WPT > Chromium, safe-first, spec-first), then left to iterate against WPT. Tokenizer: 99.8%. Tree builder: 100% including adoption agency & template. Human wrote the test-feedback loop; LLM wrote the Rust. [LLM authorship disclosed](https://github.com/muskitty-dev/muskitty-html5-parser/blob/main/LLM_GENERATION.md).
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
Adding muskitty-html5-parser to the Project/Tooling Updates section of issue 661 (2026-07-22).

## What

muskitty-html5-parser is an LLM-agent-built HTML5 parser written in pure Safe Rust:

- **Tokenizer** (WHATWG §13.2.5): 99.8% pass on html5lib tokenizer suite (7022/7036; the 14 failures are XML processing instructions, which the spec defines as parse errors)
- **Tree construction** (WHATWG §13.2.6): 100% pass on html5lib tree construction suite (1716/1716, including adoption agency algorithm, foster parenting, foreign content, and template insertion mode)
- Zero `unsafe` code, zero C/C++ dependencies

## LLM Authorship Disclosure

Per TWIR's LLM policy, the core parser logic in this crate is LLM-generated. The human author wrote the project constitution (three rules: spec > WPT > Chromium, safe-first, spec-first) and the Python test-feedback loop; the LLM wrote the Rust implementation. Full disclosure with Rust-specific observations is in [LLM_GENERATION.md](https://github.com/muskitty-dev/muskitty-html5-parser/blob/main/LLM_GENERATION.md).

## Links

- crates.io: https://crates.io/crates/muskitty-html5-parser
- Source: https://github.com/muskitty-dev/muskitty-html5-parser
- LLM disclosure: https://github.com/muskitty-dev/muskitty-html5-parser/blob/main/LLM_GENERATION.md