### PR TITLE
Add ferrovec to Project/Tooling Updates

### DIFF
--- a/draft/2026-07-22-this-week-in-rust.md
+++ b/draft/2026-07-22-this-week-in-rust.md
@@ -45,7 +45,7 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
-* [ferrovec: a dependency-light HNSW vector index in Rust that compiles to WebAssembly for in-browser semantic search](https://github.com/singhpratech/ferrovec)
+* [ferrovec: dependency-light HNSW vector search in Rust, compiled to WebAssembly for private in-browser semantic search](https://singhpratech.github.io/ferrovec/)
 
 ### Observations/Thoughts
 

--- a/draft/2026-07-22-this-week-in-rust.md
+++ b/draft/2026-07-22-this-week-in-rust.md
@@ -45,6 +45,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [ferrovec: a dependency-light HNSW vector index in Rust that compiles to WebAssembly for in-browser semantic search](https://github.com/singhpratech/ferrovec)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
Submitting a new project for the upcoming issue's **Project/Tooling Updates** section.

**[ferrovec](https://github.com/singhpratech/ferrovec)** is a dependency-light HNSW vector index written in Rust that compiles cleanly to `wasm32-unknown-unknown` for in-browser semantic search. `serde` + `postcard` are the only deps (~33 KB gzipped wasm), it uses a deterministic seeded PRNG (no `getrandom`) and SIMD128 distance kernels, and it also runs natively as a plain crate. Published on [crates.io](https://crates.io/crates/ferrovec).

Live demo (runs offline): https://singhpratech.github.io/ferrovec/demo.html

Happy to have the editors recategorize if another section fits better. Thanks!