### PR TITLE
Add rust-symbol-audit write-up to Project/Tooling Updates (2026-07-22)

### DIFF
--- a/draft/2026-07-22-this-week-in-rust.md
+++ b/draft/2026-07-22-this-week-in-rust.md
@@ -45,6 +45,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [Reading a Rust crate's capabilities out of its compiled symbols](https://dev.to/booyaka101/reading-a-rust-crates-capabilities-out-of-its-compiled-symbols-58pb)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
Adds one entry to **Project/Tooling Updates** in the `2026-07-22` draft.

- **Reading a Rust crate's capabilities out of its compiled symbols** — https://dev.to/booyaka101/reading-a-rust-crates-capabilities-out-of-its-compiled-symbols-58pb

It's a technical write-up rather than a changelog: reading a dependency's capability surface out of its v0-demangled symbols, why `build.rs` is a blind spot for that approach, and where monomorphization limits it — with Rust snippets throughout. Link text matches the post title and the URL has no tracking parameters. One submission from me this week.

For editor transparency: the post discloses that the tool and a first draft of the write-up were AI-assisted; the final text and the technical claims are mine. Happy to adjust the link text or placement if you'd prefer.
