### PR TITLE
Added Tokio Scheduling Post to Observations/Thoughts

### DIFF
--- a/draft/2026-07-22-this-week-in-rust.md
+++ b/draft/2026-07-22-this-week-in-rust.md
@@ -47,6 +47,8 @@ and just ask the editors to select the category.
 
 ### Observations/Thoughts
 
+* [Tokio Gives Progress, Not Ordering: Scheduling 1M Tasks](https://pranitha.dev/posts/tokio-gives-progress-not-ordering)
+
 ### Rust Walkthroughs
 
 ### Research


### PR DESCRIPTION
How spawning 1M Tokio tasks preserved throughput while letting polling order drift from event submission order, and why task creation needs an application-level bound.