### PR TITLE
Add OrdoFP 0.1.0 to Project/Tooling Updates

### DIFF
--- a/draft/2026-07-22-this-week-in-rust.md
+++ b/draft/2026-07-22-this-week-in-rust.md
@@ -45,6 +45,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [OrdoFP 0.1.0 released — a functional-programming toolbelt for Rust (HList, GAT type classes, optics, effects, monad transformers)](https://github.com/ordokr/ordofp/releases/tag/v0.1.0)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
Adding a one-line entry for OrdoFP 0.1.0, a functional-programming toolbelt for Rust (HList, GAT type classes, optics, effects, monad transformers) that just published to crates.io.