### PR TITLE
CFP: contribute randomness to the tidex6 trusted setup ceremony

### DIFF
--- a/draft/2026-07-22-this-week-in-rust.md
+++ b/draft/2026-07-22-this-week-in-rust.md
@@ -121,6 +121,7 @@ Some of these tasks may also have mentors available, visit the task page for mor
 
 <!-- CFPs go here, use this format: * [project name - title of issue](URL to issue) -->
 <!-- * [ - ]() -->
+* [tidex6 - Contribute randomness to the trusted setup ceremony (easy, ~1 minute, in-browser)](https://github.com/koshak01/tidex6/issues/1)
 <!-- or if none - *No Calls for participation were submitted this week.* -->
 
 If you are a Rust project owner and are looking for contributors, please submit tasks [here][guidelines] or through a [PR to TWiR](https://github.com/rust-lang/this-week-in-rust) or by reaching out on [Bluesky](https://bsky.app/profile/thisweekinrust.bsky.social) or [Mastodon](https://mastodon.social/@thisweekinrust)!


### PR DESCRIPTION
Submitting one task for the Call for Participation section of the 2026-07-22 draft.

* [tidex6 - Contribute randomness to the trusted setup ceremony (easy, ~1 minute, in-browser)](https://github.com/koshak01/tidex6/issues/1)

tidex6 is a Rust-native privacy framework for Solana — Groth16 on arkworks 0.5, with the Phase-2 MPC engine and the browser contribution written in Rust and compiled to `wasm32-unknown-unknown` (no snarkjs anywhere in production).

We're running a public multi-party trusted setup ceremony to replace the current single-contributor parameters. Contributing takes about a minute and happens entirely in the browser, so it's approachable regardless of Rust experience — and the whole contribution chain is publicly downloadable and independently verifiable with a tool in the repo.

Guidelines checklist:
- OSI-approved license: dual MIT / Apache-2.0
- Publicly accessible issue tracker: yes
- Task issue with a clear description and difficulty level (easy): [#1](https://github.com/koshak01/tidex6/issues/1)
- Contribution guidelines linked from the task: [CONTRIBUTING.md](https://github.com/koshak01/tidex6/blob/master/CONTRIBUTING.md); no CLA or copyright assignment required