### PR TITLE
submerge error handling, display improvements, and a bug fix

### DIFF
--- a/tools/submerge/Cargo.lock
+++ b/tools/submerge/Cargo.lock
@@ -2292,6 +2292,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "maybe-async"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2339,6 +2348,15 @@ name = "nonempty"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9737e026353e5cd0736f98eddae28665118eb6f6600902a7f50db585621fecb6"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "num-bigint"
@@ -3244,6 +3262,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shell-words"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3395,6 +3422,7 @@ dependencies = [
  "serde_json",
  "similar",
  "tempfile",
+ "test-log",
  "tokio",
  "url",
 ]
@@ -3450,6 +3478,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "test-log"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b9c218384242b5c89b68303ab6f6fc53a312d923f0c14dc6bb860c6aeee40f1"
+dependencies = [
+ "env_logger",
+ "test-log-macros",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "test-log-core"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c26ef8b00e4d382e59f6a8ddb3cd790b3a5bb29f21a358a9a69ea2f29f13f27b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "test-log-macros"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "944ad38adcbb71eaa682c56bceeb079e4ca82b4b3edc2a0fde5cb297b77dac8d"
+dependencies = [
+ "syn",
+ "test-log-core",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3467,6 +3527,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -3651,6 +3720,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -3728,6 +3826,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"

--- a/tools/submerge/Cargo.toml
+++ b/tools/submerge/Cargo.toml
@@ -29,6 +29,7 @@ regex = "1.12.2"
 serde = { version = "1.0.228", features = ["derive"] }
 similar = "3.1.1"
 tempfile = "3.23.0"
+test-log = "0.2.21"
 tokio = { version = "1.48.0", features = ["macros", "rt-multi-thread"] }
 url = "2.5.7"
 

--- a/tools/submerge/README.md
+++ b/tools/submerge/README.md
@@ -34,6 +34,8 @@ submerge fetch
 
 This will print a list of PRs which are being placed into your local draft copy, as well as the PRs which are not (and a reason for each of the latter).
 
+Note this only fetches PRs which add a single community link and are passing CI. If other cases become common we could extend this!
+
 ### Edit the draft to reorder, remove, or adjust submissions
 Keep the comment metadata attached to each link as you move/edit. The metadata itself shouldn't be edited.
 

--- a/tools/submerge/src/lib.rs
+++ b/tools/submerge/src/lib.rs
@@ -98,6 +98,18 @@ pub struct SkippedPr {
     pub url: Url,
 }
 
+#[derive(Debug)]
+enum ClassifiedSubmission {
+    Ignore(anyhow::Error),
+    Success(Submission),
+}
+
+impl ClassifiedSubmission {
+    fn new_ignore(reason: anyhow::Error) -> Self {
+        Self::Ignore(reason)
+    }
+}
+
 #[derive(Debug, Clone)]
 struct PullSummary {
     number: u64,
@@ -159,9 +171,10 @@ async fn run_fetch(args: FetchArgs) -> Result<()> {
             &pull,
         )
         .await
+        .with_context(|| format!("could not fetch PR #{}", pull.number))?
         {
-            Ok(submission) => submissions.push(submission),
-            Err(reason) => skipped.push(SkippedPr {
+            ClassifiedSubmission::Success(submission) => submissions.push(submission),
+            ClassifiedSubmission::Ignore(reason) => skipped.push(SkippedPr {
                 pr: pull.number,
                 title: pull.title,
                 reason,
@@ -201,44 +214,56 @@ async fn fetch_submission(
     draft_rel: &Path,
     current_text: &str,
     pull: &PullSummary,
-) -> Result<Submission> {
+) -> Result<ClassifiedSubmission> {
     if pull.draft {
-        bail!("draft PR");
+        return Ok(ClassifiedSubmission::new_ignore(anyhow!("draft PR")));
     }
 
-    let files = fetch_pr_files(client, owner, name, pull.number).await?;
+    let files = fetch_pr_files(client, owner, name, pull.number)
+        .await
+        .with_context(|| format!("could not fetch changed files for PR #{}", pull.number))?;
     // Use the PR's base to determine what it adds even if main has moved since it was opened.
     let base_text = fetch_file_text(client, owner, name, draft_rel, pull.base_sha)
         .await
-        .context("could not read base draft")?;
+        .with_context(|| format!("could not fetch base draft for PR #{}", pull.number))?;
     let head_text = fetch_file_text(client, owner, name, draft_rel, pull.head_sha)
         .await
-        .context("could not read head draft")?;
-    let submission = classify_submission(
+        .with_context(|| format!("could not fetch head draft for PR #{}", pull.number))?;
+    let submission = match classify_submission(
         pull,
         &files,
         draft_rel,
         current_text,
         &base_text,
         &head_text,
-    )?;
+    )
+    .context("submission failed validation")
+    {
+        Ok(submission) => submission,
+        Err(reason) => return Ok(ClassifiedSubmission::new_ignore(reason)),
+    };
 
     info!("checking CI state for PR #{}", submission.pr);
-    match fetch_ci_state(client, owner, name, submission.head_sha).await? {
+    match fetch_ci_state(client, owner, name, submission.head_sha)
+        .await
+        .with_context(|| format!("could not fetch CI status for PR #{}", submission.pr))?
+    {
         CiState::Success => {}
         CiState::Failure => {
             warn!("skipping PR #{}: CI is failing", submission.pr);
-            bail!("CI is failing");
+            return Ok(ClassifiedSubmission::new_ignore(anyhow!("CI is failing")));
         }
         CiState::Unknown => {
             warn!(
                 "skipping PR #{}: CI status is unknown or pending",
                 submission.pr
             );
-            bail!("CI status is unknown or pending");
+            return Ok(ClassifiedSubmission::new_ignore(anyhow!(
+                "CI status is unknown or pending"
+            )));
         }
     }
-    Ok(submission)
+    Ok(ClassifiedSubmission::Success(submission))
 }
 
 fn run_merge(args: MergeArgs) -> Result<()> {
@@ -852,11 +877,11 @@ fn submission_item_summary(submission: &Submission) -> &str {
 
 fn format_skipped_pr_summary(skipped: &SkippedPr) -> String {
     format!(
-        "#{} {} ({}) {}/files",
+        "#{} {} {}/files:\n{:?}",
         skipped.pr,
         skipped.title,
+        skipped.url.as_str().trim_end_matches('/'),
         skipped.reason,
-        skipped.url.as_str().trim_end_matches('/')
     )
 }
 
@@ -1120,6 +1145,14 @@ mod tests {
         }));
 
         assert_eq!(classify_check_runs(&check_runs), CiState::Success);
+    }
+
+    #[test]
+    fn classified_submission_ignore_keeps_reason() {
+        match ClassifiedSubmission::new_ignore(anyhow!("draft PR")) {
+            ClassifiedSubmission::Ignore(reason) => assert_eq!(reason.to_string(), "draft PR"),
+            ClassifiedSubmission::Success(_) => panic!("expected ignored submission"),
+        }
     }
 
     #[test]
@@ -1583,7 +1616,22 @@ mod tests {
 
         assert_eq!(
             format_skipped_pr_summary(&skipped),
-            "#1234 Not a submission (changes 2 files) https://github.com/rust-lang/this-week-in-rust/pull/1234/files"
+            "#1234 Not a submission https://github.com/rust-lang/this-week-in-rust/pull/1234/files:\nchanges 2 files"
+        );
+    }
+
+    #[test]
+    fn formats_skipped_pr_summary_with_error_context() {
+        let skipped = SkippedPr {
+            pr: 1234,
+            title: "Not a submission".to_string(),
+            reason: anyhow!("changes 2 files").context("submission failed validation"),
+            url: Url::parse("https://github.com/rust-lang/this-week-in-rust/pull/1234").unwrap(),
+        };
+
+        assert_eq!(
+            format_skipped_pr_summary(&skipped),
+            "#1234 Not a submission https://github.com/rust-lang/this-week-in-rust/pull/1234/files:\nsubmission failed validation\n\nCaused by:\n    changes 2 files"
         );
     }
 

--- a/tools/submerge/src/lib.rs
+++ b/tools/submerge/src/lib.rs
@@ -970,6 +970,7 @@ fn print_summary(submissions: &[Submission], skipped: &[SkippedPr]) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use test_log::test;
 
     fn test_signature() -> gix::actor::Signature {
         gix::actor::Signature {
@@ -1304,7 +1305,7 @@ mod tests {
             head,
         )
         .unwrap();
-        assert_eq!(submission.item, "  - [New item](https://example.com/new)");
+        assert_eq!(submission.item, "- [New item](https://example.com/new)");
 
         let buffer = build_edit_buffer(base, &[submission]).unwrap();
         assert!(buffer.contains("\n* [New item](https://example.com/new) <!--"));
@@ -1478,7 +1479,7 @@ mod tests {
             head,
         )
         .unwrap_err();
-        assert!(err.to_string().contains("multiple blocks"));
+        assert!(err.to_string().contains("multiple items"));
     }
 
     #[test]
@@ -1494,7 +1495,7 @@ mod tests {
             head,
         )
         .unwrap_err();
-        assert!(err.to_string().contains("multiple blocks"));
+        assert!(err.to_string().contains("unexpected"));
     }
 
     #[test]

--- a/tools/submerge/src/lib.rs
+++ b/tools/submerge/src/lib.rs
@@ -1193,6 +1193,22 @@ mod tests {
     }
 
     #[test]
+    fn accepts_item_added_before_existing_item() {
+        let base = "## Updates from Rust Community\n\n### Project/Tooling Updates\n* [Existing](https://example.com/existing)\n\n### Observations/Thoughts\n";
+        let head = "## Updates from Rust Community\n\n### Project/Tooling Updates\n* [New](https://example.com/new)\n* [Existing](https://example.com/existing)\n\n### Observations/Thoughts\n";
+        let submission = classify_pr(
+            &pull(21),
+            &[file("", 1, 0)],
+            Path::new("draft/2026-06-24-this-week-in-rust.md"),
+            base,
+            head,
+        )
+        .unwrap();
+
+        assert_eq!(submission.item, "* [New](https://example.com/new)");
+    }
+
+    #[test]
     fn accepts_pr_based_before_locally_merged_submissions() {
         let pr_base = "## Updates from Rust Community\n\n### Project/Tooling Updates\n\n### Observations/Thoughts\n";
         let current = "## Updates from Rust Community\n\n### Project/Tooling Updates\n* [Already merged](https://example.com/existing)\n\n### Observations/Thoughts\n";

--- a/tools/submerge/src/lib.rs
+++ b/tools/submerge/src/lib.rs
@@ -878,7 +878,7 @@ fn submission_item_summary(submission: &Submission) -> &str {
 
 fn format_skipped_pr_summary(skipped: &SkippedPr) -> String {
     format!(
-        "#{} {} {}/files:\n{:?}",
+        "#{} {} {}/files:\n{:?}\n\n",
         skipped.pr,
         skipped.title,
         skipped.url.as_str().trim_end_matches('/'),
@@ -955,16 +955,18 @@ fn normalize_repo_relative_path(workdir: &Path, path: &Path) -> Result<PathBuf> 
 }
 
 fn print_summary(submissions: &[Submission], skipped: &[SkippedPr]) {
+    println!("---");
     println!("eligible submissions: {}", submissions.len());
     for submission in submissions {
         println!(
-            "  #{} [{}] {}",
+            "#{} [{}] {}",
             submission.pr, submission.section, submission.item
         );
     }
+    println!("---");
     println!("non-eligible PRs: {}", skipped.len());
     for skipped in skipped {
-        println!("  {}", format_skipped_pr_summary(skipped));
+        println!("{}", format_skipped_pr_summary(skipped));
     }
 }
 
@@ -1634,7 +1636,7 @@ mod tests {
 
         assert_eq!(
             format_skipped_pr_summary(&skipped),
-            "#1234 Not a submission https://github.com/rust-lang/this-week-in-rust/pull/1234/files:\nchanges 2 files"
+            "#1234 Not a submission https://github.com/rust-lang/this-week-in-rust/pull/1234/files:\nchanges 2 files\n\n"
         );
     }
 
@@ -1649,7 +1651,7 @@ mod tests {
 
         assert_eq!(
             format_skipped_pr_summary(&skipped),
-            "#1234 Not a submission https://github.com/rust-lang/this-week-in-rust/pull/1234/files:\nsubmission failed validation\n\nCaused by:\n    changes 2 files"
+            "#1234 Not a submission https://github.com/rust-lang/this-week-in-rust/pull/1234/files:\nsubmission failed validation\n\nCaused by:\n    changes 2 files\n\n"
         );
     }
 

--- a/tools/submerge/src/lib.rs
+++ b/tools/submerge/src/lib.rs
@@ -99,6 +99,7 @@ pub struct SkippedPr {
 }
 
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 enum ClassifiedSubmission {
     Ignore(anyhow::Error),
     Success(Submission),

--- a/tools/submerge/src/md.rs
+++ b/tools/submerge/src/md.rs
@@ -122,7 +122,7 @@ fn single_inserted_item(
     inserted.ok_or(anyhow!("no list item inserted"))
 }
 
-/// Produce a list of events, noramlized to chunks of non-list-item content
+/// Produce a list of events, normalized to chunks of non-list-item content
 /// (with whitespace changes ignored)
 /// and top-level list items, so we can then easily find added list items.
 fn comparable_events(text: &str) -> Vec<ComparableEvent> {

--- a/tools/submerge/src/md.rs
+++ b/tools/submerge/src/md.rs
@@ -1,20 +1,42 @@
 use anyhow::{Result, anyhow, bail};
+use log::debug;
 use pulldown_cmark::{Event, HeadingLevel, Parser as MarkdownParser, Tag, TagEnd};
+use similar::{Algorithm, DiffOp, capture_diff_slices};
+use std::hash::Hash;
 use std::ops::Range;
 
 const COMMUNITY_HEADING: &str = "Updates from Rust Community";
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) struct ListItem {
     pub(crate) section: Option<String>,
     pub(crate) item: String,
 }
 
 #[derive(Debug, Clone)]
-struct ComparableEvent {
-    event: Event<'static>,
+struct EventWithLocation {
+    event: ComparableEvent,
     range: Range<usize>,
-    section: Option<String>,
+}
+
+impl PartialEq for EventWithLocation {
+    fn eq(&self, other: &Self) -> bool {
+        self.event == other.event
+    }
+}
+
+impl Eq for EventWithLocation {}
+
+impl Hash for EventWithLocation {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.event.hash(state);
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum ComparableEvent {
+    ListItem(ListItem),
+    Raw(String),
 }
 
 #[derive(Default)]
@@ -79,128 +101,59 @@ pub(crate) fn find_single_added_community_list_item(
 ) -> Result<ListItem> {
     let base_events = comparable_events(base_text);
     let head_events = comparable_events(head_text);
-    let inserted_range = changed_event_range(&base_events, &head_events)?;
-    let item = single_inserted_item(head_text, &head_events[inserted_range])?;
+
+    debug!("base_events: {base_events:?}");
+    debug!("head_events: {head_events:?}");
+
+    let item = single_inserted_item(&base_events, &head_events)?;
     if item.section.is_none() {
         bail!("does not add a valid community list item");
     }
     Ok(item)
 }
 
-fn changed_event_range(old: &[ComparableEvent], new: &[ComparableEvent]) -> Result<Range<usize>> {
-    let prefix_len = old
-        .iter()
-        .zip(new)
-        .take_while(|(old, new)| old.event == new.event)
-        .count();
-
-    let suffix_len = old[prefix_len..]
-        .iter()
-        .rev()
-        .zip(new[prefix_len..].iter().rev())
-        .take_while(|(old, new)| old.event == new.event)
-        .count();
-
-    let old_changed = prefix_len..old.len() - suffix_len;
-    let new_changed = prefix_len..new.len() - suffix_len;
-    if old_changed.is_empty() {
-        Ok(new_changed)
-    } else if event_range_contains_item(&new[new_changed]) {
-        let base_has_item = event_range_contains_item(&old[old_changed]);
-        if base_has_item {
-            bail!("adds to an existing markdown list item");
-        }
-        bail!("adds multiple blocks");
-    } else {
-        bail!("changes existing markdown content");
-    }
-}
-
-fn event_range_contains_item(events: &[ComparableEvent]) -> bool {
-    events
-        .iter()
-        .any(|event| event.event == Event::Start(Tag::Item))
-}
-
-fn single_inserted_item(text: &str, events: &[ComparableEvent]) -> Result<ListItem> {
-    let mut start_list_seen = false;
-    let mut end_list_seen = false;
-    let mut item_depth = 0;
-    let mut item_start = None;
-    let mut item_end = None;
-    let mut item_section = None;
-
-    for event in events {
-        match &event.event {
-            Event::Start(Tag::List(_)) if item_start.is_none() => {
-                if start_list_seen {
-                    bail!("adds multiple blocks");
+fn single_inserted_item(
+    base_events: &[EventWithLocation],
+    head_events: &[EventWithLocation],
+) -> Result<ListItem> {
+    let mut inserted = None;
+    for op in capture_diff_slices(Algorithm::Myers, base_events, head_events) {
+        match op {
+            DiffOp::Equal { .. } => {}
+            DiffOp::Delete { .. } => bail!("submission deletes existing content"),
+            DiffOp::Insert {
+                new_index,
+                new_len: 1,
+                ..
+            } => {
+                // inserts exactly one thing
+                if inserted.is_some() {
+                    bail!("submission inserts multiple items");
                 }
-                start_list_seen = true;
-            }
-            Event::End(TagEnd::List(_)) if item_end.is_some() => {
-                if end_list_seen {
-                    bail!("adds multiple blocks");
-                }
-                end_list_seen = true;
-            }
-            Event::Start(Tag::Item) => {
-                if item_start.is_none() && item_is_indented(text, event.range.start) {
-                    bail!("adds to an existing markdown list item");
-                }
-                item_depth += 1;
-                if item_depth == 1 {
-                    if item_start.replace(event.range.start).is_some() {
-                        bail!("adds multiple blocks");
-                    }
-                    item_section = event.section.clone();
+
+                if let EventWithLocation {
+                    event: ComparableEvent::ListItem(item),
+                    ..
+                } = &head_events[new_index]
+                {
+                    inserted = Some(item.clone());
                 }
             }
-            Event::End(TagEnd::Item) => {
-                if item_depth == 0 {
-                    bail!("changes existing markdown content");
-                }
-                if item_depth == 1 {
-                    item_end = Some(event.range.end);
-                }
-                item_depth -= 1;
-            }
-            _ if item_start.is_some() && item_end.is_none() => {}
-            _ => bail!("adds multiple blocks"),
+            DiffOp::Insert { .. } => bail!("submission inserts unexpected content"),
+            DiffOp::Replace { .. } => bail!("submission edits existing content"),
         }
     }
 
-    if item_depth != 0 {
-        bail!("changes existing markdown content");
-    }
-    let start = item_start.ok_or_else(|| anyhow!("does not add a valid community list item"))?;
-    let end = item_end.ok_or_else(|| anyhow!("does not add a valid community list item"))?;
-    let item_text = text
-        .get(start..end)
-        .map(str::trim_end)
-        .ok_or_else(|| anyhow!("could not locate added item in head draft"))?;
-    Ok(ListItem {
-        section: item_section,
-        item: item_text.to_string(),
-    })
+    inserted.ok_or(anyhow!("no list item inserted"))
 }
 
-fn item_is_indented(text: &str, item_start: usize) -> bool {
-    let line_start = text[..item_start]
-        .rfind('\n')
-        .map(|index| index + 1)
-        .unwrap_or(0);
-    text[line_start..item_start]
-        .chars()
-        .any(|ch| !matches!(ch, ' ' | '\t'))
-        || item_start > line_start
-}
-
-fn comparable_events(text: &str) -> Vec<ComparableEvent> {
+fn comparable_events(text: &str) -> Vec<EventWithLocation> {
     let mut events = Vec::new();
     let mut sections = SectionTracker::default();
 
-    for (event, range) in MarkdownParser::new(text).into_offset_iter() {
+    let mut md_events = MarkdownParser::new(text).into_offset_iter();
+    while let Some((event, range)) = md_events.next() {
+        debug!("Processing {event:?}");
         match &event {
             Event::Start(Tag::Heading { level, .. }) => {
                 sections.start_heading(*level);
@@ -223,61 +176,59 @@ fn comparable_events(text: &str) -> Vec<ComparableEvent> {
             _ => {}
         }
 
-        if !sections.in_heading()
-            && let Some(event) = meaningful_event(&event)
-        {
-            events.push(ComparableEvent {
-                event,
-                range,
-                section: sections.current_section(),
-            });
+        if !sections.in_heading() {
+            match event {
+                Event::Start(Tag::List(_)) | Event::End(TagEnd::List(_)) => {} // ignore added/removed lists (the items are what matter)
+                Event::SoftBreak | Event::HardBreak => {}                      // skip newlines
+                Event::Start(Tag::Item) => {
+                    let start_range = range.clone();
+                    fn end_of_item<'a, I: Iterator<Item = (Event<'a>, Range<usize>)>>(
+                        iter: &mut I,
+                    ) -> Option<Range<usize>> {
+                        // find the end:
+                        let mut nesting = 1;
+                        while let Some((e, range)) = iter.next() {
+                            match e {
+                                Event::Start(Tag::Item) => nesting += 1,
+                                Event::End(TagEnd::Item) => nesting -= 1,
+                                _ => {}
+                            }
+                            if nesting == 0 {
+                                return Some(range);
+                            }
+                        }
+                        None
+                    }
+
+                    let end_range = end_of_item(&mut md_events).expect("list item has an end");
+                    let text = &text[start_range.start..end_range.end];
+                    events.push(EventWithLocation {
+                        event: ComparableEvent::ListItem(ListItem {
+                            section: sections.current_section(),
+                            item: text.trim().into(),
+                        }),
+                        range: start_range.start..range.end,
+                    });
+                }
+                _ => events.push(EventWithLocation {
+                    event: ComparableEvent::Raw(text[range.clone()].into()),
+                    range,
+                }),
+            }
         }
     }
 
     events
 }
 
-fn meaningful_event(event: &Event<'_>) -> Option<Event<'static>> {
-    match event {
-        Event::SoftBreak | Event::HardBreak => None,
-        _ => Some(event.clone().into_static()),
-    }
-}
-
 fn markdown_list_items(text: &str) -> Vec<ListItem> {
-    let events = comparable_events(text);
-    let mut items = Vec::new();
-    let mut item_depth = 0;
-    let mut item_start = None;
-    let mut item_section = None;
-
-    for event in events {
-        match event.event {
-            Event::Start(Tag::Item) => {
-                item_depth += 1;
-                if item_depth == 1 {
-                    item_start = Some(event.range.start);
-                    item_section = event.section;
-                }
-            }
-            Event::End(TagEnd::Item) => {
-                if item_depth == 1
-                    && let Some(start) = item_start.take()
-                    && let Some(item_text) = text.get(start..event.range.end).map(str::trim_end)
-                    && !item_text.is_empty()
-                {
-                    items.push(ListItem {
-                        section: item_section.take(),
-                        item: item_text.to_string(),
-                    });
-                }
-                item_depth -= 1;
-            }
-            _ => {}
-        }
-    }
-
-    items
+    comparable_events(text)
+        .into_iter()
+        .filter_map(|e| match e.event {
+            ComparableEvent::ListItem(i) => Some(i),
+            _ => None,
+        })
+        .collect()
 }
 
 pub(crate) fn is_single_list_item(item: &str) -> bool {

--- a/tools/submerge/src/md.rs
+++ b/tools/submerge/src/md.rs
@@ -168,7 +168,7 @@ fn comparable_events(text: &str) -> Vec<ComparableEvent> {
                     ) -> Option<Range<usize>> {
                         // find the end:
                         let mut nesting = 1;
-                        while let Some((e, range)) = iter.next() {
+                        for (e, range) in iter.by_ref() {
                             match e {
                                 Event::Start(Tag::Item) => nesting += 1,
                                 Event::End(TagEnd::Item) => nesting -= 1,

--- a/tools/submerge/src/md.rs
+++ b/tools/submerge/src/md.rs
@@ -2,7 +2,6 @@ use anyhow::{Result, anyhow, bail};
 use log::debug;
 use pulldown_cmark::{Event, HeadingLevel, Parser as MarkdownParser, Tag, TagEnd};
 use similar::{Algorithm, DiffOp, capture_diff_slices};
-use std::hash::Hash;
 use std::ops::Range;
 
 const COMMUNITY_HEADING: &str = "Updates from Rust Community";
@@ -11,26 +10,6 @@ const COMMUNITY_HEADING: &str = "Updates from Rust Community";
 pub(crate) struct ListItem {
     pub(crate) section: Option<String>,
     pub(crate) item: String,
-}
-
-#[derive(Debug, Clone)]
-struct EventWithLocation {
-    event: ComparableEvent,
-    range: Range<usize>,
-}
-
-impl PartialEq for EventWithLocation {
-    fn eq(&self, other: &Self) -> bool {
-        self.event == other.event
-    }
-}
-
-impl Eq for EventWithLocation {}
-
-impl Hash for EventWithLocation {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.event.hash(state);
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -113,8 +92,8 @@ pub(crate) fn find_single_added_community_list_item(
 }
 
 fn single_inserted_item(
-    base_events: &[EventWithLocation],
-    head_events: &[EventWithLocation],
+    base_events: &[ComparableEvent],
+    head_events: &[ComparableEvent],
 ) -> Result<ListItem> {
     let mut inserted = None;
     for op in capture_diff_slices(Algorithm::Myers, base_events, head_events) {
@@ -131,11 +110,7 @@ fn single_inserted_item(
                     bail!("submission inserts multiple items");
                 }
 
-                if let EventWithLocation {
-                    event: ComparableEvent::ListItem(item),
-                    ..
-                } = &head_events[new_index]
-                {
+                if let ComparableEvent::ListItem(item) = &head_events[new_index] {
                     inserted = Some(item.clone());
                 }
             }
@@ -147,7 +122,10 @@ fn single_inserted_item(
     inserted.ok_or(anyhow!("no list item inserted"))
 }
 
-fn comparable_events(text: &str) -> Vec<EventWithLocation> {
+/// Produce a list of events, noramlized to chunks of non-list-item content
+/// (with whitespace changes ignored)
+/// and top-level list items, so we can then easily find added list items.
+fn comparable_events(text: &str) -> Vec<ComparableEvent> {
     let mut events = Vec::new();
     let mut sections = SectionTracker::default();
 
@@ -178,9 +156,12 @@ fn comparable_events(text: &str) -> Vec<EventWithLocation> {
 
         if !sections.in_heading() {
             match event {
-                Event::Start(Tag::List(_)) | Event::End(TagEnd::List(_)) => {} // ignore added/removed lists (the items are what matter)
-                Event::SoftBreak | Event::HardBreak => {}                      // skip newlines
+                // ignore added/removed lists (the items are what matter)
+                Event::Start(Tag::List(_)) | Event::End(TagEnd::List(_)) => {}
+                // skip newlines
+                Event::SoftBreak | Event::HardBreak => {}
                 Event::Start(Tag::Item) => {
+                    // Collect the (possibly-nested) list item into a single thing to compare
                     let start_range = range.clone();
                     fn end_of_item<'a, I: Iterator<Item = (Event<'a>, Range<usize>)>>(
                         iter: &mut I,
@@ -202,18 +183,12 @@ fn comparable_events(text: &str) -> Vec<EventWithLocation> {
 
                     let end_range = end_of_item(&mut md_events).expect("list item has an end");
                     let text = &text[start_range.start..end_range.end];
-                    events.push(EventWithLocation {
-                        event: ComparableEvent::ListItem(ListItem {
-                            section: sections.current_section(),
-                            item: text.trim().into(),
-                        }),
-                        range: start_range.start..range.end,
-                    });
+                    events.push(ComparableEvent::ListItem(ListItem {
+                        section: sections.current_section(),
+                        item: text.trim().into(),
+                    }));
                 }
-                _ => events.push(EventWithLocation {
-                    event: ComparableEvent::Raw(text[range.clone()].into()),
-                    range,
-                }),
+                _ => events.push(ComparableEvent::Raw(text[range].into())),
             }
         }
     }
@@ -224,7 +199,7 @@ fn comparable_events(text: &str) -> Vec<EventWithLocation> {
 fn markdown_list_items(text: &str) -> Vec<ListItem> {
     comparable_events(text)
         .into_iter()
-        .filter_map(|e| match e.event {
+        .filter_map(|e| match e {
             ComparableEvent::ListItem(i) => Some(i),
             _ => None,
         })


### PR DESCRIPTION
* Causes GitHub API errors (e.g. out of quota) to abort fetching new PRs rather than ignoring them.
* Update the docs to clarify intended behavior of multi-link PRs (i.e. we currently do not handle them)
* Dramatically simplify how we detect added links, also fixing a bug where adding a link to the *start* of a section instead of to the end would not show up as a PR to get merged in.
* Also print errors (somewhat) more clearly when actively/intentionally ignoring a PR (it is currently easy to miss the reason) as well as adding more logging (in RUST_LOG=debug)

cc @nellshamrell 🙇 