### PR TITLE
Add kache 0.11.0 to Project/Tooling Updates

### DIFF
--- a/draft/2026-07-22-this-week-in-rust.md
+++ b/draft/2026-07-22-this-week-in-rust.md
@@ -46,6 +46,7 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 * [kobe 0.35.0: readiness gates and cert recycling](https://github.com/kunobi-ninja/kobe/releases/tag/v0.35.0)
+* [kache 0.11.0: broader compiler coverage and libc-aware keys](https://github.com/kunobi-ninja/kache/releases/tag/v0.11.0)
 
 * [Guardian Compute: Decentralized Edge Computing in GuardianDB](https://www.willsearch.com.br/blog/guardian-compute-decentralized-edge-computing-in-guardiandb)
 * [`tracing-reload` - reload layer without panics](https://mladedav.github.io/blog/blog/tracing-reload/)


### PR DESCRIPTION
Adds a Project/Tooling Updates entry for the kache 0.11.0 release.

* [kache 0.11.0: broader compiler coverage and libc-aware keys](https://github.com/kunobi-ninja/kache/releases/tag/v0.11.0)

kache is an open-source, content-addressed build cache (RUSTC_WRAPPER, and a C/C++ compiler wrapper). 0.11.0 widens toolchain coverage — target-prefixed cross-compilers and cargo-zigbuild's zigcc are recognized as their real compiler family, and native Linux outputs are now keyed by host libc so glibc and musl builds don't collide. It also refuses to mis-cache CUDA compiles, hardlinks immutable blobs on non-reflink filesystems (ext4/tmpfs) to extend near-zero-copy restore, and fixes several cross-compilation cache keys. The linked release notes cover the why and how, and the release includes contributions from several first-time contributors.