### PR TITLE
Add kobe 0.35.0 to Project/Tooling Updates

### DIFF
--- a/draft/2026-07-22-this-week-in-rust.md
+++ b/draft/2026-07-22-this-week-in-rust.md
@@ -45,6 +45,7 @@ and just ask the editors to select the category.
 * [The Embedded Rustacean Issue #76](https://www.theembeddedrustacean.com/p/the-embedded-rustacean-issue-76)
 
 ### Project/Tooling Updates
+* [kobe 0.35.0: readiness gates and cert recycling](https://github.com/kunobi-ninja/kobe/releases/tag/v0.35.0)
 
 * [`tracing-reload` - reload layer without panics](https://mladedav.github.io/blog/blog/tracing-reload/)
 * [Introducing OpenTypeless: Voice Input That Actually Works](https://www.opentypeless.com/en/blog/introducing-talkmore)


### PR DESCRIPTION
Adds a Project/Tooling Updates entry for the kobe 0.35.0 release.

* [kobe 0.35.0: readiness gates and cert recycling](https://github.com/kunobi-ninja/kobe/releases/tag/v0.35.0)

kobe is an open-source (Apache-2.0) Kubernetes operator written in Rust that leases pre-warmed ephemeral clusters (k3s, k0s, vcluster, CAPI) to CI and developers. 0.35.0 hardens the guarantees around a lease: a cluster is only marked Ready once an in-cluster service-account token round-trips (the InClusterToken admission gate), so a lease binds only when the cluster can actually authenticate workloads; and cluster PKI now uses bounded cert lifetimes with recycle-before-expiry so a lease never inherits a soon-to-fail cert. The linked release notes cover the why and how. (kobe's public release was covered in a recent issue.)