### PR TITLE
Nominate rag-gate for Crate of the Week

### DIFF
--- a/draft/2026-07-22-this-week-in-rust.md
+++ b/draft/2026-07-22-this-week-in-rust.md
@@ -65,9 +65,11 @@ and just ask the editors to select the category.
 
 ## Crate of the Week
 
-<!-- COTW goes here -->
+This week's crate is [rag-gate](https://crates.io/crates/rag-gate), an inference-time confidence middleware for RAG pipelines.
 
-[Please submit your suggestions and votes for next week][submit_crate]!
+It sits as a wire-level proxy between your client and any OpenAI-compatible LLM API, intercepts the token stream in real time, and gates generation into **ANSWER**, **ABSTAIN**, or **ESCALATE** based on mean token logprob confidence — a signal already computed for free during inference, with no post-hoc LLM judge required.
+
+Thanks to [ajanm007](https://github.com/ajanm007) for the self-suggestion!
 
 [submit_crate]: https://users.rust-lang.org/t/crate-of-the-week/2704
 


### PR DESCRIPTION
Nominating `rag-gate` for Crate of the Week.

- Crates.io: https://crates.io/crates/rag-gate
- Repo: https://github.com/ajanm007/rag-gate

`rag-gate` is an inference-time confidence middleware that intercepts 
OpenAI-compatible LLM streams and gates generation into ANSWER, ABSTAIN, 
or ESCALATE using mean token logprob confidence — a signal already computed 
for free during inference. No post-hoc LLM judge, no retrieval-score 
threshold. Based on selective prediction research (IC3AI 2025).

Self-nomination.