### PR TITLE
Add buildline to Project/Tooling Updates

### DIFF
--- a/draft/2026-07-22-this-week-in-rust.md
+++ b/draft/2026-07-22-this-week-in-rust.md
@@ -49,6 +49,7 @@ and just ask the editors to select the category.
 * [`tracing-reload` - reload layer without panics](https://mladedav.github.io/blog/blog/tracing-reload/)
 * [Introducing OpenTypeless: Voice Input That Actually Works](https://www.opentypeless.com/en/blog/introducing-talkmore)
 * [Reading a Rust crate's capabilities out of its compiled symbols](https://dev.to/booyaka101/reading-a-rust-crates-capabilities-out-of-its-compiled-symbols-58pb)
+* [buildline: merging cargo and ninja's build profiling into one timeline](https://dev.to/nabsei/buildline-merging-cargo-and-ninjas-build-profiling-into-one-timeline-2373)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
Adding a link to a writeup about buildline, a project I recently built and published: https://dev.to/nabsei/buildline-merging-cargo-and-ninjas-build-profiling-into-one-timeline-2373

buildline merges the profiling output of multiple build tools (cargo, ninja) into a single Chrome Trace Event timeline, viewable in Perfetto — aimed at the "where did my build time actually go" problem when a build mixes several tools and no single tool's own profiler covers the gaps between them.

Per the guidelines, note that Claude Code assisted with the implementation of the underlying project (disclosed in the writeup itself); this PR/entry and the writeup were written by me.