### PR TITLE
Add hwatu to Project/Tooling Updates

### DIFF
--- a/draft/2026-07-22-this-week-in-rust.md
+++ b/draft/2026-07-22-this-week-in-rust.md
@@ -46,7 +46,7 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 * [kobe 0.35.0: readiness gates and cert recycling](https://github.com/kunobi-ninja/kobe/releases/tag/v0.35.0)
-* [hwatu: a daemon-based WebKitGTK browser for tiling WMs with ~13ms window spawn](https://github.com/hongnoul/hwatu)
+* [hwatu: a daemon-based WebKitGTK browser for tiling WMs with ~13ms window spawn](https://hongnoul.github.io/hwatu/)
 
 * [Guardian Compute: Decentralized Edge Computing in GuardianDB](https://www.willsearch.com.br/blog/guardian-compute-decentralized-edge-computing-in-guardiandb)
 * [`tracing-reload` - reload layer without panics](https://mladedav.github.io/blog/blog/tracing-reload/)

--- a/draft/2026-07-22-this-week-in-rust.md
+++ b/draft/2026-07-22-this-week-in-rust.md
@@ -46,6 +46,7 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 * [kobe 0.35.0: readiness gates and cert recycling](https://github.com/kunobi-ninja/kobe/releases/tag/v0.35.0)
+* [hwatu: a daemon-based WebKitGTK browser for tiling WMs with ~13ms window spawn](https://github.com/hongnoul/hwatu)
 
 * [Guardian Compute: Decentralized Edge Computing in GuardianDB](https://www.willsearch.com.br/blog/guardian-compute-decentralized-edge-computing-in-guardiandb)
 * [`tracing-reload` - reload layer without panics](https://mladedav.github.io/blog/blog/tracing-reload/)


### PR DESCRIPTION
Adds hwatu, a daemon-based WebKitGTK 6 browser for tiling window managers written in Rust. It splits the browser into a daemon owning the engine/prewarmed WebViews and a thin socket client, giving ~13ms median window spawn on a warm daemon. Benchmark methodology is documented in the repo.