### PR TITLE
Add Comhad to Project/Tooling Updates

### DIFF
--- a/draft/2026-07-22-this-week-in-rust.md
+++ b/draft/2026-07-22-this-week-in-rust.md
@@ -46,6 +46,7 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 * [kobe 0.35.0: readiness gates and cert recycling](https://github.com/kunobi-ninja/kobe/releases/tag/v0.35.0)
+* [comhad: a ranger-style terminal file browser for S3](https://github.com/Eoin-McMahon/comhad)
 
 * [Guardian Compute: Decentralized Edge Computing in GuardianDB](https://www.willsearch.com.br/blog/guardian-compute-decentralized-edge-computing-in-guardiandb)
 * [`tracing-reload` - reload layer without panics](https://mladedav.github.io/blog/blog/tracing-reload/)

--- a/draft/2026-07-22-this-week-in-rust.md
+++ b/draft/2026-07-22-this-week-in-rust.md
@@ -46,7 +46,7 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 * [kobe 0.35.0: readiness gates and cert recycling](https://github.com/kunobi-ninja/kobe/releases/tag/v0.35.0)
-* [comhad: a ranger-style terminal file browser for S3](https://github.com/Eoin-McMahon/comhad)
+* [Comhad: A ranger-style tui cyberduck replacement for browsing S3](https://github.com/Eoin-McMahon/comhad)
 
 * [Guardian Compute: Decentralized Edge Computing in GuardianDB](https://www.willsearch.com.br/blog/guardian-compute-decentralized-edge-computing-in-guardiandb)
 * [`tracing-reload` - reload layer without panics](https://mladedav.github.io/blog/blog/tracing-reload/)

--- a/draft/2026-07-22-this-week-in-rust.md
+++ b/draft/2026-07-22-this-week-in-rust.md
@@ -46,7 +46,7 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 * [kobe 0.35.0: readiness gates and cert recycling](https://github.com/kunobi-ninja/kobe/releases/tag/v0.35.0)
-* [Comhad: A ranger-style tui cyberduck replacement for browsing S3](https://github.com/Eoin-McMahon/comhad)
+* [Comhad v0.1.0: a ranger-style tui cyberduck replacement for browsing S3](https://github.com/Eoin-McMahon/comhad/releases/tag/v0.1.0)
 
 * [Guardian Compute: Decentralized Edge Computing in GuardianDB](https://www.willsearch.com.br/blog/guardian-compute-decentralized-edge-computing-in-guardiandb)
 * [`tracing-reload` - reload layer without panics](https://mladedav.github.io/blog/blog/tracing-reload/)


### PR DESCRIPTION
Hi! I'd like to submit **comhad**, a ranger-style terminal file browser for S3 (and S3-compatible endpoints), for this week's Project/Tooling Updates section. Think Cyberduck, but in the terminal.

![comhad demo](https://raw.githubusercontent.com/Eoin-McMahon/Comhad/master/assets/demo.gif)

> Storage backends sit behind a single `StorageProvider` async trait, so adding another service (SFTP, GCS, ...) is a matter of implementing that trait, the goal is for comhad to grow into a Cyberduck-style multi-backend tool rather than staying S3-only.

The linked v0.1.0 release write-up goes into a couple of the trickier Rust bits (the async trait backend abstraction, and a tmux/iTerm2/Sixel terminal-graphics-detection quirk I had to work around with `ratatui-image`).

Thanks for considering it!