### PR TITLE
Add Burin to Project/Tooling Updates

### DIFF
--- a/draft/2026-07-29-this-week-in-rust.md
+++ b/draft/2026-07-29-this-week-in-rust.md
@@ -44,8 +44,8 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
-* [Burin — a retained-mode GUI framework where `Signal<T>` replaces the dependency graph](https://github.com/chh-itt/burin)
-  — 60 widgets, dual GPU/CPU backend, Taffy incremental layout, Material 3 theme, headless test harness. Built on the [Auralis](https://github.com/chh-itt/auralis) reactive kernel.
+* [ZH] [Burin — a retained-mode GUI framework where `Signal<T>` replaces the dependency graph](https://rustcc.cn/article?id=c7b9bc5e-2fad-42fc-983e-5302127be8ca)
+  — 60 widgets, dual GPU/CPU backend, Taffy incremental layout, Material 3 theme, headless test harness. Built on the Auralis reactive kernel.
 
 ### Observations/Thoughts
 

--- a/draft/2026-07-29-this-week-in-rust.md
+++ b/draft/2026-07-29-this-week-in-rust.md
@@ -44,6 +44,8 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
+* [Burin — a retained-mode GUI framework where Signal<T> replaces the dependency graph](https://github.com/chh-itt/burin)
+  — 60 widgets, dual GPU/CPU backend, Taffy incremental layout, Material 3 theme, headless test harness. Built on the [Auralis](https://github.com/chh-itt/auralis) reactive kernel.
 
 ### Observations/Thoughts
 

--- a/draft/2026-07-29-this-week-in-rust.md
+++ b/draft/2026-07-29-this-week-in-rust.md
@@ -44,7 +44,7 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
-* [Burin — a retained-mode GUI framework where Signal<T> replaces the dependency graph](https://github.com/chh-itt/burin)
+* [Burin — a retained-mode GUI framework where `Signal<T>` replaces the dependency graph](https://github.com/chh-itt/burin)
   — 60 widgets, dual GPU/CPU backend, Taffy incremental layout, Material 3 theme, headless test harness. Built on the [Auralis](https://github.com/chh-itt/auralis) reactive kernel.
 
 ### Observations/Thoughts


### PR DESCRIPTION
Burin is a newly released Rust GUI framework that connects Signal<T>
directly to the rendering pipeline — 60 widgets, dual GPU/CPU backend,
Taffy incremental layout, Material 3 theme.