### PR TITLE
Add cargo-reapi tooling update

### DIFF
--- a/draft/2026-07-29-this-week-in-rust.md
+++ b/draft/2026-07-29-this-week-in-rust.md
@@ -45,6 +45,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [Sharing Rust build work across Cargo worktrees with cargo-reapi](https://github.com/TamedTornado/cargo-reapi/blob/main/docs/introducing-cargo-reapi.md)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
Adds an introduction to cargo-reapi to the Project/Tooling Updates section for the July 29 issue. The article explains how it shares Rust compiler and linker work across independent Cargo worktrees while keeping Cargo authoritative, along with measured Bevy results, correctness boundaries, and current limitations.