### PR TITLE
Add exiftool-rs 0.7.0 to Project/Tooling Updates

### DIFF
--- a/draft/2026-07-29-this-week-in-rust.md
+++ b/draft/2026-07-29-this-week-in-rust.md
@@ -45,6 +45,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [exiftool-rs 0.7.0: a pure-Rust reimplementation of ExifTool, now with localized `-lang` values](https://github.com/Le-Syl21/exiftool-rs)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs

--- a/draft/2026-07-29-this-week-in-rust.md
+++ b/draft/2026-07-29-this-week-in-rust.md
@@ -45,7 +45,7 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
-* [exiftool-rs 0.7.0: a pure-Rust reimplementation of ExifTool, now with localized `-lang` values](https://github.com/Le-Syl21/exiftool-rs)
+* [exiftool-rs 0.7.0: localizing ExifTool's PrintConv values, not just its labels](https://github.com/Le-Syl21/exiftool-rs/releases/tag/v0.7.0)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
Adds a one-line entry under Project/Tooling Updates for the exiftool-rs 0.7.0 release — a pure-Rust reimplementation of ExifTool (no Perl, no system libraries) with byte-for-byte name/value parity on the test corpus. 0.7.0 adds localized PrintConv values under `-lang`.

Repo: https://github.com/Le-Syl21/exiftool-rs