### PR TITLE
Fixing incorrect Australian state/territory codes in meetup automation script

### DIFF
--- a/tools/events/meetup-automation/city_to_state_map.py
+++ b/tools/events/meetup-automation/city_to_state_map.py
@@ -1,0 +1,57 @@
+# Mapping of known cities to their state codes
+CITY_STATE_MAP = {
+    # New South Wales
+    "Sydney": "NSW",
+    "Newcastle": "NSW",
+    "Wollongong": "NSW",
+    "Central Coast": "NSW",
+
+    # Victoria
+    "Melbourne": "VIC",
+    "Geelong": "VIC",
+    "Ballarat": "VIC",
+    "Bendigo": "VIC",
+
+    # Queensland
+    "Brisbane": "QLD",
+    "Gold Coast": "QLD",
+    "Sunshine Coast": "QLD",
+    "Townsville": "QLD",
+    "Cairns": "QLD",
+
+    # Western Australia
+    "Perth": "WA",
+    "Fremantle": "WA",
+    "Bunbury": "WA",
+
+    # South Australia
+    "Adelaide": "SA",
+    "Mount Gambier": "SA",
+
+    # Tasmania
+    "Hobart": "TAS",
+    "Launceston": "TAS",
+
+    # Northern Territory
+    "Darwin": "NT",
+    "Alice Springs": "NT",
+
+    # Australian Capital Territory
+    "Canberra": "ACT",
+}
+
+def update_state_from_city(events, city_state_map=CITY_STATE_MAP):
+    """
+    Iterate over all events and set event.location.state
+    based on event.location.city using the provided mapping.
+    """
+    for key, value in events.items():
+        for event in value:
+            city = event.location.city
+            state = city_state_map.get(city)
+            if state:
+                event.location.state = state
+            else:
+                print(f"No state mapping found for city: {city}")
+
+    return events

--- a/tools/events/meetup-automation/main.py
+++ b/tools/events/meetup-automation/main.py
@@ -13,6 +13,7 @@ from country_code_to_continent import country_code_to_continent
 from generate_events_meetup import TwirMeetupClient
 from event import Event
 from utils import read_meetup_group_urls
+from city_to_state_map import update_state_from_city
 
 
 logger = logging.getLogger(__name__)
@@ -49,6 +50,10 @@ def main():
     # Group by virtual or by continent.
     events = group_virtual_continent(events)
 
+    # update state letter code for events based on city name using our mapping
+    events = update_state_from_city(events)
+
+    # return;
     # if json is specified, output as json. Otherwise print in a nice TWIR-formatted way
     if args.json:
         # convert our events to a json-friendly format
@@ -124,7 +129,7 @@ def remove_duplicate_events(events: List[Event]) -> List[Event]:
             checked.append(event)
 
     return checked
-            
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
### Description
Australia's state abbreviations aren't a fixed length — they're a mix of 2 and 3 letters depending on the state.  
Good examples of each:
Two-letter codes: WA (Western Australia), SA (South Australia), NT (Northern Territory)
Three-letter codes: NSW (New South Wales), VIC (Victoria), QLD (Queensland), TAS (Tasmania), ACT (Australian Capital Territory)

This PR fixes the issue by using a fixed city/state lookup map, where each city is mapped explicitly to its correct official abbreviation

Closes #8208 