### PR TITLE
Add Rust Walkthrough: writing a native Polars plugin in Rust

### DIFF
--- a/draft/2026-07-29-this-week-in-rust.md
+++ b/draft/2026-07-29-this-week-in-rust.md
@@ -49,6 +49,8 @@ and just ask the editors to select the category.
 
 ### Rust Walkthroughs
 
+* [Writing a native Polars plugin in Rust: PII masking with no per-row Python](https://dev.to/fcarvajalbrown/writing-a-native-polars-plugin-in-rust-pii-masking-with-no-per-row-python-2co8)
+
 ### Research
 
 ### Miscellaneous


### PR DESCRIPTION
For the community section, under Rust Walkthroughs.

The post writes a Polars expression as a compiled Rust function instead of a per-row Python callback. It covers the pyo3-polars #[polars_expr] kernel over Arrow-backed Series, a byte pre-check that rejects most rows before any regex runs, and the reason is_elementwise is a promise the query optimizer relies on rather than a hint. MaskOps, an MPL-2.0 PII masking plugin, is the worked example. The article is free to read, with no paywall and no signup.

Link: https://dev.to/fcarvajalbrown/writing-a-native-polars-plugin-in-rust-pii-masking-with-no-per-row-python-2co8

If another category fits better, I will move it.