### PR TITLE
Add Java–Rust microservice article to Observations/Thoughts

### DIFF
--- a/draft/2026-07-29-this-week-in-rust.md
+++ b/draft/2026-07-29-this-week-in-rust.md
@@ -46,7 +46,7 @@ and just ask the editors to select the category.
 ### Project/Tooling Updates
 
 ### Observations/Thoughts
-
+* [Building Java–Rust Microservices with TeaQL: Models, Events, and Audit Intent](https://teaql.io/blog/java-rust-microservice-integration-with-teaql/) — Lessons from introducing an Axum payment service alongside Java: ownership, async state, decimal money, typed domain APIs, idempotency, and the limits of “no GC” performance claims.
 ### Rust Walkthroughs
 
 ### Research


### PR DESCRIPTION
This adds an evidence-backed article about the engineering boundaries between Java and Rust microservices.

It focuses on the concerns Java teams encounter when adopting Rust: Axum state management, Arc and ownership, Tokio async execution, Result-based error boundaries, decimal money, durable idempotency, generated typed APIs, and realistic performance claims.

The article includes an AI-assisted editing disclosure.