### PR TITLE
Add napwatch to Project/Tooling Updates

### DIFF
--- a/draft/2026-07-29-this-week-in-rust.md
+++ b/draft/2026-07-29-this-week-in-rust.md
@@ -45,6 +45,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [napwatch: a ratatui TUI for diagnosing macOS "dark wakes" and background battery drain](https://github.com/Tuguberk/napwatch)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
Adding napwatch — a terminal UI built with ratatui + crossterm for diagnosing and controlling macOS power/battery behavior.

It surfaces things macOS doesn't show anywhere else in one screen: instant-Watt battery draw (computed from ioreg's InstantAmperage/Voltage/AppleRawMaxCapacity, correct from the first poll instead of needing a 3-minute delta window), a live sleep/wake event feed sourced from `pmset -g log` to catch Power Nap-driven "dark wakes" that silently drain the battery overnight, a power-ranked process table (via `top -l 2`, since a single sample always reads 0.0 for power), and toggles for Power Nap / Wake-for-network / Low Power Mode / Standby / TCP Keepalive.

macOS only, MIT licensed, distributed via Homebrew tap and `cargo install`.