### PR TITLE
Add Schobio to Project/Tooling Updates

### DIFF
--- a/draft/2026-07-29-this-week-in-rust.md
+++ b/draft/2026-07-29-this-week-in-rust.md
@@ -45,6 +45,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [Schobio: The loom was wrung](https://codeberg.org/Schobi/Schobio) – a thin Rust layer over the [Schobi](https://codeberg.org/Schobi/Schobi) C work-stealing scheduler, where closures borrow (`&data`, no `Arc`), panics are contained at the FFI boundary, and a `!Send` barrier makes a cross-group wait a compile error. It plays in the high-throughput fork/join class — 455 Mtasks/s at 0.33 µs p50 on an M4 Max (~10× oneTBB), a 16-task fork/join 0.8 µs hot vs rayon's 3 µs+ — stays debuggable (frame-pointer-clean fiber unwinds, a `.natvis` that names which task parked where, Superluminal/uProf/ftrace markers), and is verified top to bottom: a C core proven under CBMC, GenMC and Relacy, plus Kani and loom over the Rust glue.
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
Adds Schobio to Project/Tooling Updates.

Schobio is a thin Rust frontend over the Schobi C work-stealing scheduler,
written as a proof of concept for what Rust's type system can enforce on top of
a C runtime: borrowed closures instead of `Arc`, a `catch_unwind` firewall at
every FFI entry point, and a `GroupBarrier` that is `!Send + !Sync` so a wait
from outside its fiber group fails to compile rather than segfaulting in C.

The C core is the real engine — an eager lenient fork/join scheduler that clears 455 Mtasks/s
at 0.33 µs p50 on an M4 Max (~10× oneTBB), exhaustively verified under CBMC,
GenMC and Relacy — with Kani and loom proving the Rust glue on top. The README
is a walkthrough rather than a changelog: the four C contracts the `unsafe`
blocks depend on, the proof ladder, the debuggability story (frame-pointer-clean
fiber unwinds, a `.natvis` view of parked tasks, profiler markers), and
benchmark methodology against rayon, chili, fork_union and bevy_tasks including
the events where Schobio loses and why.