### PR TITLE
`event`: Add SciPy India x Rust Delhi Meetup

### DIFF
--- a/draft/2026-07-29-this-week-in-rust.md
+++ b/draft/2026-07-29-this-week-in-rust.md
@@ -245,6 +245,8 @@ Rusty Events between 2026-07-29 - 2026-08-26 🦀
     * [**​Rust Mumbai — July Meetup 🦀**](https://luma.com/7ksabwbm/)
 * 2026-07-26 | Pune, IN | [Rust Pune](https://www.meetup.com/rust-pune)
     * [**Rust Pune: July 2026**](https://www.meetup.com/rust-pune/events/315651505/)
+* 2026-08-22 | Noida, IN | [SciPy India](https://scipy.in/) X [Rust Delhi](https://rustdelhi.in/)
+    * [**Scientific Computing in Rust and Python**](https://scipy.in/sci-py-rs/)
 
 ### Europe
 * 2026-07-23 | Berlin, DE | [Rust Berlin](https://www.meetup.com/rust-berlin)


### PR DESCRIPTION
Adds the `SciPy India x Rust Delhi Meetup` to the Asia events section. It's a scientific computing in Rust and Python meetup co-organized by [SciPy India](https://scipy.in/) and [Rust Delhi](https://rustdelhi.in/), with RSVPs and the CFP currently [open](https://scipy.in/sci-py-rs/).

Opening this back up from [#8157](https://github.com/rust-lang/this-week-in-rust/pull/8157) now that the event fits this draft's date range.

CC: @agriyakhetarpal, @gswebspace