### PR TITLE
Add CuNi 0.1.6 (exact multi-target py/go/js + link tutorial)

### DIFF
--- a/draft/2026-07-29-this-week-in-rust.md
+++ b/draft/2026-07-29-this-week-in-rust.md
@@ -45,6 +45,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [CuNi 0.1.6: exact multi-target compile to Python, Go, and JavaScript (or refuse) — link interop tutorial](https://github.com/ceedot-rock/cuni/blob/v0.1.6/docs/LINK_TUTORIAL.md)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
## Project/Tooling Updates

Adds one link under **Project/Tooling Updates** for this week's draft:

* [CuNi 0.1.6: exact multi-target compile to Python, Go, and JavaScript (or refuse) — link interop tutorial](https://github.com/ceedot-rock/cuni/blob/v0.1.6/docs/LINK_TUTORIAL.md)

### Why not a bare repo link

Per TWiR guidelines, this points at a **tutorial + release narrative** (interop demo, exactness gate, install), not only the GitHub root.

### About CuNi

Rust-built open-source language (MIT). Compiles one source to Python, Go, and JavaScript with an exactness contract (`cuni check`). Early v0.1.

Happy to adjust wording or category if editors prefer.