### PR TITLE
Add samkhya to Project/Tooling Updates

### DIFF
--- a/draft/2026-07-29-this-week-in-rust.md
+++ b/draft/2026-07-29-this-week-in-rust.md
@@ -53,6 +53,7 @@ and just ask the editors to select the category.
 * [kobe 0.37.0: easier to deploy and install](https://github.com/kunobi-ninja/kobe/releases/tag/v0.37.0) <!-- url=https://github.com/rust-lang/this-week-in-rust/pull/8482 submerge-pr=8482 sha=2c20ea05be7070d96e800743e4220e31ffa2166a author=emmanuelm41 title=Add kobe 0.37.0 to Project/Tooling Updates -->
 * [kache 0.12.0: pluggable remotes, smarter GC, sharper diagnostics](https://github.com/kunobi-ninja/kache/releases/tag/v0.12.0) <!-- url=https://github.com/rust-lang/this-week-in-rust/pull/8483 submerge-pr=8483 sha=1e093f8b34b76e663c5ea069b90a81bc4f0efc01 author=emmanuelm41 title=Add kache 0.12.0 to Project/Tooling Updates -->
 * [Progress toward compiling Linux with gccrs](https://lwn.net/SubscriberLink/1083202/f1ba926cd57ac5c5/) <!-- url=https://github.com/rust-lang/this-week-in-rust/pull/8489 submerge-pr=8489 sha=a17d21ae028fa949bba3cb2c829085eea8c050e7 author=ojeda title=Rust LWN articles -->
+* [samkhya 1.2 — a join-cardinality ceiling you can prove](https://singhpratech.github.io/samkhya/)
 
 ### Observations/Thoughts
 

--- a/draft/2026-07-29-this-week-in-rust.md
+++ b/draft/2026-07-29-this-week-in-rust.md
@@ -53,7 +53,7 @@ and just ask the editors to select the category.
 * [kobe 0.37.0: easier to deploy and install](https://github.com/kunobi-ninja/kobe/releases/tag/v0.37.0) <!-- url=https://github.com/rust-lang/this-week-in-rust/pull/8482 submerge-pr=8482 sha=2c20ea05be7070d96e800743e4220e31ffa2166a author=emmanuelm41 title=Add kobe 0.37.0 to Project/Tooling Updates -->
 * [kache 0.12.0: pluggable remotes, smarter GC, sharper diagnostics](https://github.com/kunobi-ninja/kache/releases/tag/v0.12.0) <!-- url=https://github.com/rust-lang/this-week-in-rust/pull/8483 submerge-pr=8483 sha=1e093f8b34b76e663c5ea069b90a81bc4f0efc01 author=emmanuelm41 title=Add kache 0.12.0 to Project/Tooling Updates -->
 * [Progress toward compiling Linux with gccrs](https://lwn.net/SubscriberLink/1083202/f1ba926cd57ac5c5/) <!-- url=https://github.com/rust-lang/this-week-in-rust/pull/8489 submerge-pr=8489 sha=a17d21ae028fa949bba3cb2c829085eea8c050e7 author=ojeda title=Rust LWN articles -->
-* [samkhya 1.2 — a join-cardinality ceiling you can prove](https://singhpratech.github.io/samkhya/)
+* [samkhya 1.2.1 — the join-cardinality ceiling becomes provable](https://github.com/singhpratech/samkhya/releases/tag/v1.2.1)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
Submitting one project for the upcoming issue's **Project/Tooling Updates** section.

[samkhya](https://github.com/singhpratech/samkhya) is a 15-crate Rust workspace for join-cardinality estimation in embedded analytical engines. It clamps a corrected row-count estimate under a pessimistic ceiling the join provably cannot exceed, so a miscalibrated model cannot push a query optimizer past a number that has been proved. The sketch statistics (HLL, Bloom, Count-Min, equi-depth and 2D histograms) are serialized into Iceberg Puffin sidecars, so one file written with `samkhya-core` is read back unchanged through Iceberg, DataFusion and DuckDB.

The link goes to the [1.2.1 release notes](https://github.com/singhpratech/samkhya/releases/tag/v1.2.1) rather than the repo root, because the release is mostly a retraction and the notes are where the reasoning is.

**What 1.2.1 is about.** An audit on 2026-07-24 found that three of the four bounds shipped through v1.1 returned ceilings *below* the true join cardinality — 2,179 violations in 3,704 measured bound-evaluations. This release repairs them: 0 violations across the same 3,704, and on a foreign-key join the ceiling is exactly the true output. Two published headline numbers were withdrawn, including the 40.95× bound-tightness figure the project had led with for two releases. Both retractions are reproduced against raw data committed in the repo.

Three things the repair taught me that were about writing Rust, not about databases:

* The property tests asserted a **relative** invariant (bound vs. a reference estimator) where the property that mattered was **absolute** (bound ≥ true count). A family of bounds that is wrong together still agrees with itself, so the suite passed for two releases while the thing it was named after was false.
* The tightness harness computed `(bound / truth).max(1.0)`, turning every violation into a perfect-tightness reading. It averaged 2,179 violations into its headline and could not have reported one. A clamp inside a metric can make a test structurally unable to fail.
* Sketch estimators are two-sided, so a *bound* built on one needs a one-sided constructor. `AttributeDegree::from_hll_floor(rows, &hll)` counts non-zero registers and can therefore only under-count; the older constructor took the HLL point estimate, which sits above the truth about half the time. Every constructor on that type now either derives its guarantee or documents the obligation it puts on the caller.

Disclosure, per the LLM section of the README: the project's prose, including these release notes, was written with LLM assistance. I am the sole human author of the project, and I have checked every number in them against the committed data they cite.

Happy to shorten the link text, and equally happy for the editors to recategorize — the audit write-up may sit better in Observations/Thoughts than in Project/Tooling Updates. Thanks!
