### PR TITLE
Add mirador 0.7.0 to Project/Tooling Updates

### DIFF
--- a/draft/2026-07-29-this-week-in-rust.md
+++ b/draft/2026-07-29-this-week-in-rust.md
@@ -44,6 +44,7 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
+* [mirador 0.7.0: a terminal dashboard in Rust and ratatui gains an offline `.ics` agenda, hand-parsed on jiff rather than adding 30 crates and 2.3 MB of dependencies](https://github.com/jchultarsky/mirador/releases/tag/v0.7.0)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
Adds one entry to `### Project/Tooling Updates` in the 2026-07-29 draft.

**Link:** https://github.com/jchultarsky/mirador/releases/tag/v0.7.0

[mirador](https://github.com/jchultarsky/mirador) is a personal dashboard for the terminal — Rust + ratatui, MIT, macOS/Linux/Windows. 0.7.0 adds an agenda panel that reads a local `.ics` file.

Per the guidelines on release notes ("they need to include useful information about why you made the changes, how to use the changes, the things you learned"), the linked notes are not just a changelog. The substantive Rust content is the dependency decision: `icalendar` + `rrule` would have added **30 transitive crates and 2.3 MB to a 3.4 MB binary** — measured against a hello-world on the same release profile — most of it `chrono-tz` carrying a timezone database that `jiff`, already in the tree, provides. So the iCalendar parsing is in-tree on `jiff`, and recurrence covers the common `RRULE` subset while deliberately emitting only the first occurrence for rules outside it, since those parts narrow the occurrence set and guessing would invent meetings that are not happening.

## LLM disclosure

Per the contributing guidelines: **mirador is built with heavy AI assistance.** The implementation, the tests and the linked release notes were written by Claude (Anthropic) working from my direction and review; the product decisions are mine. The same disclosure appears at the top of the linked release notes, so it reaches readers and not only reviewers.

I read the section explaining why you would rather this were human-authored, and I would rather disclose it and let you decide than have it slip through undisclosed. Entirely understood if you would prefer not to include it on that basis.

This is my only project submission this week.