### PR TITLE
Add MenteDB agent file write-up

### DIFF
--- a/draft/2026-07-29-this-week-in-rust.md
+++ b/draft/2026-07-29-this-week-in-rust.md
@@ -44,6 +44,7 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
+* [Infinite Context Window for AI with Memory](https://mentedb.com/blog/infinite-context-window-for-ai-with-memory)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
Adding my write-up to Project/Tooling Updates. I build MenteDB, a memory database for AI agents written in Rust. The post measures how well agents follow their instruction files (AGENTS.md) when the whole file sits in context versus when the rules are delivered from memory, on real public files with string check verification. The benchmark is public in the repo so anyone can rerun it.