### PR TITLE
Add NØNOS to Project/Tooling Updates

### DIFF
--- a/draft/2026-07-29-this-week-in-rust.md
+++ b/draft/2026-07-29-this-week-in-rust.md
@@ -44,6 +44,7 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
+* [NØNOS: from radio silence to a real IP, bringing up 802.11 on a Rust microkernel with the driver in userspace](https://nonos.software/news/wifi-stack-bringup/)
 
 ### Observations/Thoughts
 
@@ -122,6 +123,7 @@ Some of these tasks may also have mentors available, visit the task page for mor
 <!-- CFPs go here, use this format: * [project name - title of issue](URL to issue) -->
 <!-- * [ - ]() -->
 <!-- or if none - *No Calls for participation were submitted this week.* -->
+* [NØNOS - usb_msc has no USB transport: USB storage does not work](https://github.com/NON-OS/nonos-micro-kernel/issues/417)
 
 If you are a Rust project owner and are looking for contributors, please submit tasks [here][guidelines] or through a [PR to TWiR](https://github.com/rust-lang/this-week-in-rust) or by reaching out on [Bluesky](https://bsky.app/profile/thisweekinrust.bsky.social) or [Mastodon](https://mastodon.social/@thisweekinrust)!
 


### PR DESCRIPTION
Submitting NØNOS for this week's Project/Tooling Updates.

Updated after the link check: the entry now points at the WiFi bring-up writeup rather than the repo, since the guidelines ask for a writeup rather than a bare GitHub link. The article is the story of getting 802.11 working with the driver in ring 3, including the hardware quirk that nearly stopped it.

NØNOS is a microkernel built on three commitments: no ambient authority, so every capsule spawns with an explicit capability set and can reach nothing outside it; nothing runs unproven, so each program carries a proof of what it is that the kernel verifies before it will start it; and RAM-resident, so capsules live in memory with no persistent installed state between boots.

The Rust-relevant parts: `no_std` throughout on a custom x86_64 target, no libc and no runtime, and no driver in the kernel. Drivers run in ring 3 and reach hardware only through a capability broker. The Realtek Wi-Fi driver is written from scratch in userspace and completes the WPA2 handshake, holds a DHCP lease and carries real traffic on a physical laptop. A terminal, browser, text editor and wallet run on top, and a std PAL is in progress so unmodified Rust crates can run as capsules.

The proof work is public and reproducible: 1,054 machine-checked Lean theorems across 155 modules with zero `sorry`, plus 74 Kani harnesses. It is not a fully verified kernel and the verification page states what is not established.

We are genuinely looking for contributors. The hardest part is behind us, it boots on real hardware, and we think this model is going to matter. Most of what remains is work that can be picked up independently, which is why there is also a CFP entry for the USB mass storage transport.

First public beta, boots in QEMU, VirtualBox and on real x86_64 hardware. AGPL-3.0.
