### PR TITLE
Add kobe 0.37.0 to Project/Tooling Updates

### DIFF
--- a/draft/2026-07-29-this-week-in-rust.md
+++ b/draft/2026-07-29-this-week-in-rust.md
@@ -44,6 +44,7 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
+* [kobe 0.37.0: easier to deploy and install](https://github.com/kunobi-ninja/kobe/releases/tag/v0.37.0)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
Adds a Project/Tooling Updates entry for the kobe 0.37.0 release.

* [kobe 0.37.0: easier to deploy and install](https://github.com/kunobi-ninja/kobe/releases/tag/v0.37.0)

kobe is an open-source (Apache-2.0) Kubernetes operator written in Rust that leases pre-warmed ephemeral clusters (k3s, k0s, vcluster, CAPI) to CI and developers. 0.37.0 focuses on deployment and installation: the kobe Helm chart is now published as an OCI artifact versioned together with the operator (so `helm install` pulls a chart matching the running image), and kobe is now installable via Scoop and Chocolatey (Windows) and the AUR, alongside cargo binstall, mise, and Homebrew. It also preserves node tokens across recycles and gates topology readiness for steadier cluster bring-up. The linked release notes cover the why and how.