### PR TITLE
Add kache 0.12.0 to Project/Tooling Updates

### DIFF
--- a/draft/2026-07-29-this-week-in-rust.md
+++ b/draft/2026-07-29-this-week-in-rust.md
@@ -44,6 +44,7 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
+* [kache 0.12.0: pluggable remotes, smarter GC, sharper diagnostics](https://github.com/kunobi-ninja/kache/releases/tag/v0.12.0)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
Adds a Project/Tooling Updates entry for the kache 0.12.0 release.

* [kache 0.12.0: pluggable remotes, smarter GC, sharper diagnostics](https://github.com/kunobi-ninja/kache/releases/tag/v0.12.0)

kache is an open-source, content-addressed build cache (RUSTC_WRAPPER, and a C/C++ compiler wrapper). 0.12.0 adds pluggable storage backends via OpenDAL (S3 and filesystem remotes, so the cache can live on a shared filesystem or a non-AWS object store), makes garbage collection cost-aware by indexing each entry's compile_time_ms (size alone is a poor proxy for rebuild cost — log-log correlation 0.73 on a real 52k-entry store), and improves diagnostics: why-miss now walks the extern chain to the crate that actually changed instead of blaming every downstream crate. It also rebuilds a corrupt index losslessly from the store and caches executables by default on Linux. The linked release notes cover the why and how.