### PR TITLE
Add Rust LLM stream retry safety walkthrough

### DIFF
--- a/draft/2026-07-29-this-week-in-rust.md
+++ b/draft/2026-07-29-this-week-in-rust.md
@@ -49,6 +49,8 @@ and just ask the editors to select the category.
 
 ### Rust Walkthroughs
 
+* [No Tokens Yet Does Not Mean a Rust LLM Stream Is Safe to Retry](https://ai-router.hashnode.dev/rust-llm-stream-retry-safety)
+
 ### Research
 
 ### Miscellaneous


### PR DESCRIPTION
Adds an English Rust walkthrough to the Rust Walkthroughs section of issue 662.

The article develops a conservative retry boundary for interrupted LLM streams, includes a runnable Rust 1.75 example, covers partial tool-call output and missing terminal events, and links to the tested implementation. It is not paywalled. The article discloses both the maintainer relationship and AI assistance, in line with the repository guidelines.

The link text matches the page title and the URL has no tracking parameters.