### PR TITLE
2026-07-22: Remove kriyanative 404 blog

### DIFF
--- a/content/2026-07-22-this-week-in-rust.md
+++ b/content/2026-07-22-this-week-in-rust.md
@@ -76,7 +76,6 @@ and just ask the editors to select the category.
 * [video] [Livestream: Rust in Ubuntu](https://www.youtube.com/live/Doqwh1b4QyA)
 
 ### Rust Walkthroughs
-* [I hash-chained my agent's audit log. Then I found 13 breaks in it — all mine, all benign.](https://kriyanative.com/blog/13-chain-breaks/)
 * [Two tricky bugs in a Rust daemon](https://dev.to/scripthpp/two-bugs-i-only-found-by-running-my-rust-sync-daemon-against-real-infrastructure-4278)
 * [video] [Backend Concepts in Rust: Securely Managing App Secrets](https://www.youtube.com/watch?v=u91eX3J6lPU)
 * [video] [Build with Naz - Ep 21: High Performance Flat 2D Arrays in Rust (SIMD, L1 cache)](https://www.youtube.com/watch?v=tIrSvJFRxAg)


### PR DESCRIPTION
I was not able to find a related entry either under https://kriyanative.com/blog/. Raised a comment under https://github.com/rust-lang/this-week-in-rust/pull/8436#issuecomment-5115729067.