### PR TITLE
Add Proxelar 0.5.0 to Project/Tooling Updates

### DIFF
--- a/draft/2026-07-29-this-week-in-rust.md
+++ b/draft/2026-07-29-this-week-in-rust.md
@@ -53,6 +53,7 @@ and just ask the editors to select the category.
 * [kobe 0.37.0: easier to deploy and install](https://github.com/kunobi-ninja/kobe/releases/tag/v0.37.0) <!-- url=https://github.com/rust-lang/this-week-in-rust/pull/8482 submerge-pr=8482 sha=2c20ea05be7070d96e800743e4220e31ffa2166a author=emmanuelm41 title=Add kobe 0.37.0 to Project/Tooling Updates -->
 * [kache 0.12.0: pluggable remotes, smarter GC, sharper diagnostics](https://github.com/kunobi-ninja/kache/releases/tag/v0.12.0) <!-- url=https://github.com/rust-lang/this-week-in-rust/pull/8483 submerge-pr=8483 sha=1e093f8b34b76e663c5ea069b90a81bc4f0efc01 author=emmanuelm41 title=Add kache 0.12.0 to Project/Tooling Updates -->
 * [Progress toward compiling Linux with gccrs](https://lwn.net/SubscriberLink/1083202/f1ba926cd57ac5c5/) <!-- url=https://github.com/rust-lang/this-week-in-rust/pull/8489 submerge-pr=8489 sha=a17d21ae028fa949bba3cb2c829085eea8c050e7 author=ojeda title=Rust LWN articles -->
+* [Proxelar 0.5.0: sessions, rules, and more ways to capture traffic](https://micheletti.io/proxelar-050/)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
Proxelar is a single-binary MITM proxy / local traffic workbench written in Rust (TUI, web GUI, Lua scripting).

0.5.0 is the biggest release so far: persistent sessions with HAR/curl export and automatic secret redaction, a shared boolean filter language across TUI/GUI/API, privilege-free WireGuard/SOCKS5/DNS/UDP capture modes (phones onboard by scanning a QR code), declarative mock/redirect rules, and SHA-256-verified Lua addon packages.

The linked post walks through the actual workflows these enable rather than just restating the changelog. Happy to move this to the next issue's draft if 662 is already closed. Thanks!