### PR TITLE
Update 2026-08-05-this-week-in-rust.md

### DIFF
--- a/draft/2026-08-05-this-week-in-rust.md
+++ b/draft/2026-08-05-this-week-in-rust.md
@@ -48,6 +48,7 @@ and just ask the editors to select the category.
 ### Observations/Thoughts
 
 ### Rust Walkthroughs
+* [Why modern font metrics cannot reproduce Word pagination](https://oxi-dd65f4.gitlab.io/articles/word-pagination-gdi-rounding.html)
 
 ### Research
 


### PR DESCRIPTION
Self-submission. A walkthrough of reproducing Microsoft Word's GDI integer-pixel quantization in Rust — component-wise rounding order, context-dependent rounding direction, and where a measured coefficient replaces a formula. Includes the Word COM / Win32 GDI / PDF oracle setup used to derive the rules.

I wrote this in Japanese first and translated it myself; happy to add a note if you'd prefer disclosure of any tooling used.