### PR TITLE
Add RSigma to Project/Tooling Updates

### DIFF
--- a/draft/2026-08-05-this-week-in-rust.md
+++ b/draft/2026-08-05-this-week-in-rust.md
@@ -45,6 +45,9 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [RSigma v0.20.0 release](https://github.com/timescale/rsigma/releases/tag/v0.20.0)
+* [The State of RSigma](https://mostafa.dev/the-state-of-rsigma-7ba0a99020d9), and [Part Two: The Loop](https://mostafa.dev/the-state-of-rsigma-part-two-the-loop-c114f379dd78)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
## Summary
- Add the RSigma v0.20.0 release and two project write-ups to issue 663.
- Keep every link description to about five words, addressing [feedback on #8460](https://github.com/rust-lang/this-week-in-rust/pull/8460#issuecomment-5124493445).

## Test plan
- [x] Confirm the submission changes only the issue 663 draft.
- [x] Verify the three links and their concise descriptions.