### PR TITLE
Add Kevat 0.4.0 to Project/Tooling Updates

### DIFF
--- a/draft/2026-08-05-this-week-in-rust.md
+++ b/draft/2026-08-05-this-week-in-rust.md
@@ -44,7 +44,7 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
-* [Kevat 0.3.0 — fast, resumable copy and move to external drives, now with a GUI on all three platforms](https://kevat.app/)
+* [Kevat 0.4.0 — fast, resumable copy and move to external drives, now with a GUI on all three platforms](https://kevat.app/)
 
 ### Observations/Thoughts
 

--- a/draft/2026-08-05-this-week-in-rust.md
+++ b/draft/2026-08-05-this-week-in-rust.md
@@ -44,6 +44,7 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
+* [Kevat 0.3.0 — fast, resumable copy and move to external drives, now with a GUI on all three platforms](https://kevat.app/)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
Adds [Kevat](https://kevat.app/) — a fast, resumable copy/move tool for external drives, written in Rust (MIT). v0.3.0 ships a GUI for Linux, macOS and Windows alongside the CLI. I'm the author. (Resubmission of #8484, which was closed at the issue-662 publish cutoff with an invitation to re-submit.)