### PR TITLE
Add hooklog on Topcoat walkthrough

### DIFF
--- a/draft/2026-08-05-this-week-in-rust.md
+++ b/draft/2026-08-05-this-week-in-rust.md
@@ -49,6 +49,8 @@ and just ask the editors to select the category.
 
 ### Rust Walkthroughs
 
+* [Building hooklog on a six-day-old framework](https://github.com/JuanMarchetto/hooklog/blob/main/ARTICLE.md)
+
 ### Research
 
 ### Miscellaneous


### PR DESCRIPTION
A build log of hooklog, a self-hosted webhook inspector, built on Topcoat six days after that framework went public. It records the commands, the compiler and runtime errors, and the measured build times, request counts and page latencies as they happened.