### PR TITLE
Add mirador 1.0.0 to Project/Tooling Updates

### DIFF
--- a/draft/2026-08-05-this-week-in-rust.md
+++ b/draft/2026-08-05-this-week-in-rust.md
@@ -44,6 +44,7 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
+* [mirador 1.0.0: a personal terminal dashboard](https://github.com/jchultarsky/mirador/releases/tag/v1.0.0)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
Re-submitting after #8471, which was closed with an invitation to try a future
issue once the link text was shortened.

The description is now four words, down from thirty:

> mirador 1.0.0: a personal terminal dashboard

This is also a newer release than the one in #8471 — 1.0.0 rather than 0.7.0,
published today. mirador is a terminal information dashboard built on ratatui:
clock, calendar, weather, tasks, notes, an offline `.ics` agenda, news, and live
system metrics in a config-driven grid.

Thanks for the earlier review, and sorry for the length last time.