### PR TITLE
Add amtr (Claude Code context monitor) to Project/Tooling Updates

### DIFF
--- a/draft/2026-08-05-this-week-in-rust.md
+++ b/draft/2026-08-05-this-week-in-rust.md
@@ -45,6 +45,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [amtr: a btop-style context-window monitor for Claude Code sessions, and the forensic autopsy of its own 153-hour build](https://github.com/arian-shamaei/anthropometer/tree/main/docs/autopsy)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
Adds a Project/Tooling Updates link: amtr, a btop-style ratatui TUI that monitors a Claude Code session's context window live, plus a forensic report it generated of its own 153-hour build session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)