### PR TITLE
Add worbrow 0.2.1 to Project/Tooling Updates

### DIFF
--- a/draft/2026-08-05-this-week-in-rust.md
+++ b/draft/2026-08-05-this-week-in-rust.md
@@ -44,6 +44,7 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
+* [worbrow 0.2.1](https://github.com/noisystreet/worbrow/releases/tag/v0.2.1) - Agent search CLI driving local headless browsers (self-built CDP/Marionette protocols, no API key) with a stable JSON contract and native MCP tools (web_search / fetch_page)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
## Summary

Add [worbrow 0.2.1](https://github.com/noisystreet/worbrow/releases/tag/v0.2.1) to Project/Tooling Updates.

worbrow is an agent search CLI that drives local headless browsers (hand-written CDP for Chrome/Edge and Marionette for Firefox, no chromiumoxide/playwright deps), outputs a stable JSON contract, and ships native MCP tools (`web_search` / `fetch_page` for body fetching + structured extraction). No API key, no subscription, data stays on the machine.