### PR TITLE
CFP: Cordial — two issues for 2026-08-05

### DIFF
--- a/draft/2026-08-05-this-week-in-rust.md
+++ b/draft/2026-08-05-this-week-in-rust.md
@@ -121,6 +121,8 @@ Some of these tasks may also have mentors available, visit the task page for mor
 
 <!-- CFPs go here, use this format: * [project name - title of issue](URL to issue) -->
 <!-- * [ - ]() -->
+* [Cordial - Unify the two implementations of the profile lock](https://github.com/luohoa97/cordial/issues/6)
+* [Cordial - Fullscreen clips and letterboxes until the workspace is switched away and back](https://github.com/luohoa97/cordial/issues/7)
 <!-- or if none - *No Calls for participation were submitted this week.* -->
 
 If you are a Rust project owner and are looking for contributors, please submit tasks [here][guidelines] or through a [PR to TWiR](https://github.com/rust-lang/this-week-in-rust) or by reaching out on [Bluesky](https://bsky.app/profile/thisweekinrust.bsky.social) or [Mastodon](https://mastodon.social/@thisweekinrust)!


### PR DESCRIPTION
Adding two Call for Participation entries for [Cordial](https://github.com/luohoa97/cordial), a Rust runtime that loads Roblox's official Android x86-64 engine natively on Linux — a ported AOSP bionic linker, a bionic/glibc ABI shim, and a JNI VM in place of Android's ART. No emulator or container.

* [Cordial - Unify the two implementations of the profile lock](https://github.com/luohoa97/cordial/issues/6) — difficulty: easy
* [Cordial - Fullscreen clips and letterboxes until the workspace is switched away and back](https://github.com/luohoa97/cordial/issues/7) — difficulty: hard

Against the [guidelines](https://github.com/rust-lang/this-week-in-rust?tab=readme-ov-file#call-for-participation-guidelines):

- OSI-approved licence: GPL-3.0.
- Issue tracker is public.
- Difficulty is stated in each issue. The second was labelled "good first issue" and I have removed that label, because it needs Wayland configure semantics and Vulkan swapchain lifetime and it would have been a poor first task.
- Both link [CONTRIBUTING.md](https://github.com/luohoa97/cordial/blob/main/CONTRIBUTING.md) and note there is no CLA or copyright assignment.
- Neither issue requires a Roblox account to work on or to verify, which is worth saying because much of the rest of the project does.

One disclosure that seems fairer to make than to omit: the project is currently **looking for a maintainer**, and its README says so at the top. The issues are real, self-contained and reviewable, but a contributor should know the situation before starting. If that makes these unsuitable for the CFP section, please say so and I will withdraw the PR without argument.