### PR TITLE
Add kache 0.13.0 to Project/Tooling Updates

### DIFF
--- a/draft/2026-08-05-this-week-in-rust.md
+++ b/draft/2026-08-05-this-week-in-rust.md
@@ -44,6 +44,7 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
+* [kache 0.13.0: keying the env vars proc-macros read](https://github.com/kunobi-ninja/kache/releases/tag/v0.13.0)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
Adds a Project/Tooling Updates entry for the kache 0.13.0 release.

* [kache 0.13.0: keying the env vars proc-macros read](https://github.com/kunobi-ninja/kache/releases/tag/v0.13.0)

kache is an open-source, content-addressed build cache (RUSTC_WRAPPER, and a C/C++ compiler wrapper). 0.13.0 closes a subtle cache-key soundness hole: rustc only records an env var in its dep-info when a crate reads it via env!/option_env!, but a proc macro that calls std::env::var while expanding leaves no trace — so two compiles with different env values keyed identically and the second restored the first's expansion. kache now keys the environment a proc macro can read. It also makes speculative remote prefetching opt-in and cost-aware, closes a build-coalescing race, and improves why-miss/clean/gc diagnostics. The linked release notes cover the why and how.