### PR TITLE
Add Zynlex to Call for Participation

### DIFF
--- a/draft/2026-08-05-this-week-in-rust.md
+++ b/draft/2026-08-05-this-week-in-rust.md
@@ -120,6 +120,7 @@ Every week we highlight some tasks from the Rust community for you to pick and g
 Some of these tasks may also have mentors available, visit the task page for more information.
 
 <!-- CFPs go here, use this format: * [project name - title of issue](URL to issue) -->
+* [Zynlex - Show the hovered link's URL in the status bar](https://github.com/webtools-dotcom/Zynlex/issues/12)
 <!-- * [ - ]() -->
 <!-- or if none - *No Calls for participation were submitted this week.* -->
 


### PR DESCRIPTION
Submitting a task for the CFP - Projects section.

Zynlex is an open-source browser for web developers built with Tauri 2 and Rust. The issue linked is a self-contained one that touches the injected-script path and the frontend, and the repo has two other issues labelled good first issue alongside it.

* [Zynlex - Show the hovered link's URL in the status bar](https://github.com/webtools-dotcom/Zynlex/issues/12)

Repo: https://github.com/webtools-dotcom/Zynlex (Apache-2.0)

One submission this week, per the contributor guidelines.