### PR TITLE
Observations/Thoughts: soft-float silently disables AVX2 on x86_64-unknown-uefi

### DIFF
--- a/draft/2026-08-05-this-week-in-rust.md
+++ b/draft/2026-08-05-this-week-in-rust.md
@@ -47,6 +47,8 @@ and just ask the editors to select the category.
 
 ### Observations/Thoughts
 
+* [Your `#[target_feature(enable = "avx2")]` does nothing on `x86_64-unknown-uefi`](https://github.com/Aefinity-AI/alice-aegis/blob/main/docs/posts/2026-08-05_uefi-soft-float-deletes-your-avx2.md)
+
 ### Rust Walkthroughs
 
 ### Research


### PR DESCRIPTION
Proposing one entry for **Observations/Thoughts**.

The stock `x86_64-unknown-uefi` target sets `+soft-float`, which lowers every `f32` op to a `compiler_builtins` call — including inside functions annotated `#[target_feature(enable = "avx2")]`. A `no_std` crate full of hand-written AVX2 kernels compiled to **zero** vector instructions (`objdump` census: `xmm=0 ymm=0 vfmadd=0`), with no warning, no link error and no SIGILL. Output stayed correct — the soft-float path preserves single-rounding semantics — it was just 217–258× slower.

The post covers why the attribute does not protect you, why the stock target sets this deliberately (UEFI does not guarantee SSE state is initialised), what the custom target spec plus `CR4`/`xsetbv` bring-up looks like, and why an `objdump` instruction census belongs in CI for SIMD-critical code — it is the only check that catches this, since benchmarks drift and correctness tests still pass.

Related to rust-lang/rust#160302, currently in FCP, which turns this into a future-compat warning. Every case discussed there is a SIGILL; this is the silent variant.

Per the LLM policy in the README: the engineering, debugging and all measurements are the author's own; the prose was drafted by an LLM from the primary logs at his direction, and that is disclosed in an Authorship note at the foot of the article itself.