### PR TITLE
Add PolterType Wayland article to Project/Tooling Updates

### DIFF
--- a/draft/2026-08-05-this-week-in-rust.md
+++ b/draft/2026-08-05-this-week-in-rust.md
@@ -45,6 +45,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [Auto-correcting wrong-layout typing on Wayland is nearly impossible. We did it anyway](https://poltertype.com/blog/wrong-layout-typing-on-wayland/)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
Adds one link to **Project/Tooling Updates**:

[Auto-correcting wrong-layout typing on Wayland is nearly impossible. We did it anyway](https://poltertype.com/blog/wrong-layout-typing-on-wayland/) — how an open-source (MIT) pure-Rust tray app listens, types and draws next to the caret on Wayland: evdev, uinput, layer-shell, AT-SPI, and an EVIOCGRAB gate that has to survive input remappers.

If this week's issue is already closed, happy to have it moved to the next draft. Category call is yours, of course.