### PR TITLE
Add kobe 101 blog post to Project/Tooling Updates

### DIFF
--- a/draft/2026-08-05-this-week-in-rust.md
+++ b/draft/2026-08-05-this-week-in-rust.md
@@ -44,6 +44,7 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
+* [kobe 101: lease a Kubernetes cluster, don't create one](https://kunobi.ninja/blog/kobe-101-leasing-kubernetes-clusters)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
Adds a Project/Tooling Updates entry linking a blog post that introduces kobe.

* [kobe 101: lease a Kubernetes cluster, don't create one](https://kunobi.ninja/blog/kobe-101-leasing-kubernetes-clusters)

kobe is an open-source (Apache-2.0) Kubernetes operator written in Rust (on kube-rs and axum) that manages pools of pre-warmed clusters you lease instead of creating from scratch — claim a fully configured, isolated cluster in seconds with automatic TTL expiry, then release it. This post introduces the model, with ClusterPool / AccessPolicy examples and the lease workflow.