### PR TITLE
Add GRIT to Project/Tooling Updates

### DIFF
--- a/draft/2026-08-12-this-week-in-rust.md
+++ b/draft/2026-08-12-this-week-in-rust.md
@@ -45,7 +45,7 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
-* [GRIT 1.1: a checkable 64-byte descriptor and boundary check for block-scaled quantized tensors](https://singhpratech.github.io/grit-datatype/)
+* [GRIT 1.1: a checkable 64-byte descriptor and O(1) boundary check for block-scaled quantized tensors (MXFP4/GPTQ/AWQ-style), with a zero-dependency Rust crate and a GGUF/safetensors scanner](https://singhpratech.github.io/grit-datatype/)
 
 ### Observations/Thoughts
 

--- a/draft/2026-08-12-this-week-in-rust.md
+++ b/draft/2026-08-12-this-week-in-rust.md
@@ -45,6 +45,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [GRIT 1.1: a checkable 64-byte descriptor and boundary check for block-scaled quantized tensors](https://singhpratech.github.io/grit-datatype/)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
Adds [GRIT](https://singhpratech.github.io/grit-datatype/) to Project/Tooling Updates — a checkable 64-byte descriptor and O(1) boundary check for block-scaled quantized tensors (MXFP4/GPTQ/AWQ-style). The Rust crate ([grit-datatype](https://crates.io/crates/grit-datatype)) is zero-dependency, differentially fuzzed with 200k cases, and agrees bit-for-bit with four sibling implementations (C, C++, Python, TypeScript) on 96/96 cross-language fingerprints. Spec, conformance vectors, and a GGUF/safetensors scanner are in the same repo.