### PR TITLE
Add graphflow-stream to Project/Tooling Updates

### DIFF
--- a/draft/2026-08-12-this-week-in-rust.md
+++ b/draft/2026-08-12-this-week-in-rust.md
@@ -45,6 +45,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [graphflow-stream: token-level streaming for graph-flow agent graphs](https://github.com/thaicn1712/graphflow-stream)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs

--- a/draft/2026-08-12-this-week-in-rust.md
+++ b/draft/2026-08-12-this-week-in-rust.md
@@ -45,7 +45,7 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
-* [graphflow-stream: token-level streaming for graph-flow agent graphs](https://github.com/thaicn1712/graphflow-stream)
+* [graphflow-stream: token-level streaming for graph-flow agent graphs](https://github.com/thaicn1712/graphflow-stream) - adds ambient `emit_token()`/`emit_started()`/`emit_finished()` calls usable from inside any `graph_flow::Task::run`, so a task or full graph run can stream partial output (e.g. LLM tokens) while still in flight, without changing `graph-flow`'s `Task`/`FlowRunner` API. No new trait to implement; a no-op if nothing is listening.
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
Adding a link to graphflow-stream under Project/Tooling Updates.

graph-flow brings a LangGraph-style graph engine to Rust, but Task::run/FlowRunner::run only resolve once at the end - no way to observe partial output while a task or graph is still running. graphflow-stream adds ambient streaming (emit_token/emit_started/emit_finished from inside any Task::run, no new trait needed) plus full-graph streaming, subgraph composition, and replay/time-travel debugging over recorded events.

https://crates.io/crates/graphflow-stream