### PR TITLE
Add guardflow to Project/Tooling Updates

### DIFF
--- a/draft/2026-08-12-this-week-in-rust.md
+++ b/draft/2026-08-12-this-week-in-rust.md
@@ -45,6 +45,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [guardflow: validators and a retry-until-valid guard for LLM output](https://github.com/thaicn1712/guardflow) - the Guardrails AI pattern for Rust. `Validator`/`AsyncValidator` cover both free format checks (length, regex, JSON schema) and checks needing a model/API call (an LLM-as-judge, a moderation endpoint), running the async ones only after the free checks pass. `Guard::fix()` gives `on_fail="fix"` semantics (auto-repair instead of reject), and rules can be loaded from a YAML/JSON file instead of Rust code.
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
Adding a link to guardflow under Project/Tooling Updates.

guardflow brings the Guardrails AI pattern to Rust: validators (sync, for free checks like length/regex/JSON schema) and async validators (for checks needing a model or API call - an LLM-as-judge, a moderation endpoint), with the async ones only running once the free checks pass. Guard::fix() adds on_fail="fix" semantics (auto-repair instead of reject), and a rule set can be loaded from YAML/JSON instead of Rust code.

https://crates.io/crates/guardflow