### PR TITLE
Add schemaflow to Project/Tooling Updates

### DIFF
--- a/draft/2026-08-12-this-week-in-rust.md
+++ b/draft/2026-08-12-this-week-in-rust.md
@@ -45,6 +45,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [schemaflow: Pandera-style schema validation for Polars DataFrames](https://github.com/thaicn1712/schemaflow) - declarative `TableSchema`/`ColumnSchema` for validating an in-memory `polars::DataFrame` from Rust code (not a CLI or a separate DataFrame type). Every check (`not_null`, `unique`, range, regex, `is_in`, or a custom Polars `Expr`) compiles to a lazy filtered query, so validation runs at Polars speed instead of a Rust-side row loop, and the report tells you which column/check failed and how many rows.
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
Adding a link to schemaflow under Project/Tooling Updates.

schemaflow is Pandera-style declarative schema validation for an in-memory polars::DataFrame - validators exist for Polars as a CLI (verdict) or as a separate DataFrame type (dv-rs), but nothing validates the DataFrame you already have in a running Rust program. Every check compiles to a Polars boolean Expr, so validate() runs one lazy filtered query per check instead of a Rust-side row loop.

https://crates.io/crates/schemaflow