### PR TITLE
Add evalflow to Project/Tooling Updates

### DIFF
--- a/draft/2026-08-12-this-week-in-rust.md
+++ b/draft/2026-08-12-this-week-in-rust.md
@@ -45,6 +45,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [evalflow: DeepEval-style graded-score test suites for LLM output](https://github.com/thaicn1712/evalflow) - `TestSuite`/`TestCase`/`Metric` for scoring LLM output 0.0-1.0 instead of just pass/fail: `ExactMatch`/`Contains`/`F1Score` need no network call, and `CustomAsyncMetric` wraps an async closure for LLM-as-judge checks (answer relevancy, RAG faithfulness, toxicity) without assuming a provider. Aggregates a report with pass rate and per-metric averages across a whole test suite.
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
Adding a link to evalflow under Project/Tooling Updates.

evalflow adds graded (0.0-1.0) scoring for LLM output test suites, the DeepEval/RAGAS-style half that guardflow (a companion crate for blocking bad output in production) doesn't cover. ExactMatch/Contains/F1Score are free local metrics; CustomAsyncMetric wraps an async closure for LLM-as-judge checks (answer relevancy, RAG faithfulness against retrieved context, toxicity) without assuming a specific provider.

https://crates.io/crates/evalflow