### PR TITLE
Add agentflow to Project/Tooling Updates

### DIFF
--- a/draft/2026-08-12-this-week-in-rust.md
+++ b/draft/2026-08-12-this-week-in-rust.md
@@ -45,6 +45,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [agentflow: AgentOps for Rust in one crate](https://github.com/thaicn1712/agentflow) - re-exports four independent crates (`graphflow-stream` for streaming graph-flow agent graphs, `guardflow` for retry-until-valid output guards, `schemaflow` for Pandera-style Polars DataFrame validation, `evalflow` for DeepEval-style graded-score test suites) under one `cargo add`, plus `AgentOpsTask` gluing the guard and evaluate steps together for a single `graph_flow::Task`.
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
Adding a link to agentflow under Project/Tooling Updates.

agentflow bundles four independent crates (graphflow-stream, guardflow, schemaflow, evalflow - each already submitted separately) under one AgentOps-themed umbrella for people who want all four without four separate cargo add commands, plus AgentOpsTask gluing guard + evaluate together for a single graph_flow::Task.

https://crates.io/crates/agentflow