### PR TITLE
Rust Melbourne: use Luma instead of Meetup

### DIFF
--- a/content/2026-08-05-this-week-in-rust.md
+++ b/content/2026-08-05-this-week-in-rust.md
@@ -383,8 +383,8 @@ Rusty Events between 2026-08-05 - 2026-09-02 🦀
     * [**Rust-Atl**](https://www.meetup.com/rust-atl/events/313539331/)
 
 ### Oceania
-* 2026-08-27 | Melbourne, AU | [Rust Melbourne](https://www.meetup.com/rust-melbourne/events/)
-    * [**Rust Melbourne August 2026**](https://www.meetup.com/rust-melbourne/events/315039490/)
+* 2026-08-27 | Melbourne, AU | [Rust Melbourne](https://luma.com/rustmelbourne)
+    * [**Rust Melbourne Meetup**](https://luma.com/d0rndgyv)
 
 ### South America
 * 2026-08-08 | São Paulo, SP | [Rust-SP](https://luma.com/calendar/cal-bif2oHITU1aVvsr)

--- a/draft/2026-08-12-this-week-in-rust.md
+++ b/draft/2026-08-12-this-week-in-rust.md
@@ -301,8 +301,8 @@ Rusty Events between 2026-08-12 - 2026-09-09 🦀
     * [**Rust-Atl**](https://www.meetup.com/rust-atl/events/313539331/)
 
 ### Oceania
-* 2026-08-27 | Melbourne, AU | [Rust Melbourne](https://www.meetup.com/rust-melbourne/events/)
-    * [**Rust Melbourne August 2026**](https://www.meetup.com/rust-melbourne/events/315039490/)
+* 2026-08-27 | Melbourne, AU | [Rust Melbourne](https://luma.com/rustmelbourne)
+    * [**Rust Melbourne Meetup**](https://luma.com/d0rndgyv)
 
 ### South America
 * 2026-08-08 | São Paulo, SP | [Rust-SP](https://luma.com/calendar/cal-bif2oHITU1aVvsr)

--- a/tools/events/rust-meetups.json
+++ b/tools/events/rust-meetups.json
@@ -73,7 +73,6 @@
     "https://www.meetup.com/rust-medellin/events/",
     "https://www.meetup.com/rust-meetup-augsburg/events/",
     "https://www.meetup.com/rust-meetup-hamburg/events/",
-    "https://www.meetup.com/rust-melbourne/events/",
     "https://www.meetup.com/rust-modern-systems-programming-in-leipzig/events/",
     "https://www.meetup.com/rust-montreal/events/",
     "https://www.meetup.com/rust-moravia/events/",


### PR DESCRIPTION
## Summary
Rust Melbourne has moved event registration from Meetup to Luma.

- Draft + latest issue Oceania entries now link to:
  - Calendar: https://luma.com/rustmelbourne
  - August meetup: https://luma.com/d0rndgyv
- Removed `https://www.meetup.com/rust-melbourne/events/` from `tools/events/rust-meetups.json` so the Meetup automation does not keep re-injecting Meetup URLs (that tooling only supports `meetup.com` hostnames).

## Note
Historical issues are left unchanged. Future Melbourne events can be added in the draft the same way other Luma groups are listed (e.g. Rust Girona / Rust SP).

## Test plan
- [x] Confirm Luma calendar and August event URLs resolve
- [x] `rust-meetups.json` still valid JSON
- [ ] TWiR editor review