### PR TITLE
Add graphflow-stream 0.3.0 to Project/Tooling Updates

### DIFF
--- a/draft/2026-08-12-this-week-in-rust.md
+++ b/draft/2026-08-12-this-week-in-rust.md
@@ -45,6 +45,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [graphflow-stream 0.3.0](https://github.com/thaicn1712/graphflow-stream) - added DynamicMapTask (LangGraph's Send API: fan out over a runtime-determined list) and EnsembleTask (self-consistency voting across N concurrent runs) for graph-flow agent graphs.
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
graphflow-stream 0.3.0 adds two orchestration primitives for graph-flow agent graphs: DynamicMapTask (fan out over a list whose size is only known at runtime — what LangGraph's Send API covers in Python) and EnsembleTask (run a task N times concurrently and reduce the responses, e.g. majority vote, for self-consistency prompting).