### PR TITLE
Add notepatra-mcp to Project/Tooling Updates

### DIFF
--- a/draft/2026-08-12-this-week-in-rust.md
+++ b/draft/2026-08-12-this-week-in-rust.md
@@ -45,6 +45,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [notepatra-mcp v0.1.127: your editor, readable by your AI](https://notepatra.org/mcp.html)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
Adds **[notepatra-mcp](https://notepatra.org/mcp.html)** to *Project/Tooling Updates* for issue 664.

### What it is

A Rust [Model Context Protocol](https://notepatra.org/mcp.html) server that lets an AI assistant drive a **running native text editor** — not a file tree, not a language server, the actual Qt/C++ editor with your unsaved buffers in it. It speaks MCP over stdio to the client and a local socket to the editor, and exposes 49 tools in three tiers: 24 read, 14 act, 11 write. Every write puts an approval card on the user's screen and does nothing until they click it (120 s auto-deny, no headless bypass). Nothing touches the network.

It is on crates.io as [`notepatra-mcp`](https://crates.io/crates/notepatra-mcp) (`cargo install notepatra-mcp`) for anyone who wants to build it themselves; the editor also ships a prebuilt signed sidecar so no Rust toolchain is needed. Note the sidecar is a bridge — on its own, with no `--socket`, it serves a clearly-labelled mock editor.

### Why it might interest Rust readers

The whole thing is **two dependencies** — `serde` and `serde_json`. No async runtime, no `.await` anywhere in the crate, no MCP SDK, no `windows-sys`, and `grep -r unsafe src/` returns nothing. MCP stdio is one request per line from one peer, so there is genuinely nothing to overlap.

The interesting case was Windows. The editor exposes a named pipe; `std::fs::File` on `\\.\pipe\<name>` is a fine client for one, except `File` has no per-read timeout, so a bridge that never answers hangs the assistant forever. The usual reach is an async runtime, or `windows-sys` plus overlapped I/O plus `unsafe`. What actually shipped is a reader thread and `mpsc::recv_timeout` — one thread, one channel, std only, and the timeout expressed where it can be enforced.

A few other things the project learned the hard way, all visible in the shipped tree:

- **serde's default permissiveness is a silent-drift machine on a wire you own both ends of.** The C++ side started sending two new fields; the Rust struct didn't declare them; serde dropped them; the release notes announced a feature that was a no-op. `deny_unknown_fields` is the reflex and would have made it worse — it would have hard-errored every old client against the new editor. The fix that works is a test asserting the value *crosses the boundary*.
- **`serde_json::from_str::<serde::de::IgnoredAny>`** for strict RFC 8259 validation with no `Value` tree allocated. This replaced a `format_json` tool that was wired to the editor's JSON auto-*fixer*: `[1,2` came back as `[1,2]` with `isError: false`. Fine for a human who can see the repair; over MCP it is fabricated data flagged as success.
- **A `const &str` cannot describe a runtime quantity.** `const TRUNCATION_MARKER: &str = "\n[truncated at 5 MB]"` survived four releases, then `read_tab` gained a caller-supplied `max_bytes` and started telling people their 100-byte read was truncated at 5 MB. It read like documentation, so nobody read it like an assertion.
- **`#![cfg(windows)]` test files are a configuration your local `cargo test` never builds.** A green local suite, then CI failed 8 minutes later on an `E0061` in a file that compiles to nothing on Linux. `cargo check --tests --target x86_64-pc-windows-gnu` reproduces the exact rustc error in about a second and is now a release gate. Same hole shape as `required-features` test targets and non-default `#[cfg(feature)]` blocks.
- **The same credential leak shipped three times.** v0.1.125 taught the project-search filesystem walk to refuse SSH keys, `.env`, `*.pem`, Terraform state. v0.1.126 found it was the only place the check ran and added it to four more verbs. A retest found doors five and six. Enumerating callers does not converge, so v0.1.127 moved the check to the two functions that fetch buffer text and pinned it with a source lint. The Rust-flavoured punchline: in Rust that lint wouldn't need to exist — make the raw accessor private to a module and the chokepoint is a compile error instead of a convention. It took the C++ half of the codebase to make the pattern visible.

The three releases described on that page — v0.1.125, v0.1.126, v0.1.127 — contain **no new editor features at all**. They exist because someone sat down with a real editor and a real assistant and tried to break the bridge, three times, and each round found what the previous round's fix hadn't covered.

### Notes for the editors

- **Link text.** The style guide asks for the page title; the page's own title/tagline is *"Your editor, readable by your AI"*, which is opaque without the project name, so I've prefixed `notepatra-mcp v0.1.127:` per the `FooBar 1.0: adding support for Baz` example. Happy to change it to whatever you prefer.
- **Deliberately not linking crates.io.** The style guide excludes submissions that are solely a repo or crate page, so the entry points at the project's documentation instead; the crate is mentioned above only for readers who want `cargo install`.
- **Not a bare repo link.** The target is the project's own documentation page on notepatra.org — tool reference, the security/approval model, per-client setup, a "New in v0.1.127" section with the reasoning behind each change, and a limitations section that states what is *not* covered. Free software, GPL-3.0, no paywall, no email capture.
- **Fair warning on fit:** that page is a tool reference rather than a Rust walkthrough. Most of the Rust-specific material above lives in the source and the release notes rather than on the linked page. If you'd rather have a long-form write-up of the Rust side before including it, say so and I'll publish one and re-point this PR at it.
- My other open PR (#8548) targets the 2026-08-05 draft, so this is the only project I'm submitting for this issue.
- **LLM disclosure**, per the repo's policy: this PR description and the linked page were drafted with an LLM working from the project's own source and release notes, then reviewed and published by the maintainer. Every code detail cited above was read out of the shipped tree rather than recalled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W6BGY2dFUSujZeS3vTDikq
