### PR TITLE
Add Umbral to Project/Tooling Updates

### DIFF
--- a/draft/2026-08-12-this-week-in-rust.md
+++ b/draft/2026-08-12-this-week-in-rust.md
@@ -46,6 +46,7 @@ and just ask the editors to select the category.
 ### Project/Tooling Updates
 
 * [GRIT 1.1: type-check your quantized tensors](https://singhpratech.github.io/grit-datatype/)
+* [Umbral - plugin-first Rust web framework](https://dev.to/dalmasonto/umbral-declare-your-data-in-rust-get-migrations-an-admin-and-a-rest-api-for-free-43oh) - declare your data and get managed migrations, a typed ORM, an admin, a REST API, and OpenAPI, where every capability (including auth) is a plugin registered through the same trait your code uses. Early alpha on crates.io, with a runnable [examples/shop](https://github.com/dalmasonto/umbral/tree/main/examples/shop), the project site [umbral website](https://umbralrs.dev/) (built with Umbral), and a live user [pipeline.supercodehive.com](https://pipeline.supercodehive.com/) that streams Chainlink price feeds for Polymarket to surface opening and closing prices across crypto market types.
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
This adds an introduction to Umbral, a declarative, plugin-first web framework for Rust: declare your data and get managed migrations, a typed ORM, an admin, a REST API, and OpenAPI, where every capability (including auth) is a plugin registered through the same trait your code uses. It is an early alpha, published on crates.io.

The linked article is an introduction with runnable Rust examples and lessons learned building the framework, plus a runnable `examples/shop` in the repo, the project site (umbralrs.dev, itself built with Umbral), and a real-world user (pipeline.supercodehive.com, a Chainlink to Polymarket price pipeline built on Umbral).

Submitted by the project author (@dalmasonto).

Disclosure: the submission text and the linked write-up were co-authored with an AI assistant (Claude) and reviewed by @dalmasonto for correctness and usability, disclosed per TWiR's LLM-content guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)