### PR TITLE
Add git-cache-proxy to Project/Tooling Updates

### DIFF
--- a/draft/2026-08-12-this-week-in-rust.md
+++ b/draft/2026-08-12-this-week-in-rust.md
@@ -46,6 +46,7 @@ and just ask the editors to select the category.
 ### Project/Tooling Updates
 
 * [GRIT 1.1: type-check your quantized tensors](https://singhpratech.github.io/grit-datatype/)
+* [git-cache-proxy: read-only cache for git](https://rolandsdev.blog/posts/caching-git-clones-across-a-slow-network/)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
Adds [git-cache-proxy](https://github.com/rolandjitsu/git-cache-proxy) - a read-only caching proxy that serves CI git clones from an in-region mirror, so only the delta crosses the WAN - to the Project/Tooling Updates section of the next draft.