### PR TITLE
Add ECQV post to Observations/Thoughts

### DIFF
--- a/draft/2026-08-12-this-week-in-rust.md
+++ b/draft/2026-08-12-this-week-in-rust.md
@@ -47,6 +47,8 @@ and just ask the editors to select the category.
 
 ### Observations/Thoughts
 
+* [ECQV: implicit certificates, and why I kept them out of the project that motivated them](https://Abdk4Moura.github.io/post.html?post=2026-08-09-ecqv.md)
+
 ### Rust Walkthroughs
 
 ### Research


### PR DESCRIPTION
Adding one link under Observations/Thoughts for the 2026-08-12 issue.

A write-up of ECQV implicit certificates: what they are, the bandwidth problem they were designed for, and why I decided against using them in the project that sent me looking for them in the first place. It includes the reasoning that led there, in particular why a signature cannot be compressed at all and what that leaves you with.

It also covers building the `ecqv` crate: a SEC 4 implementation on P-256 built over RustCrypto's `p256`, validated against independently re-derived CAMP/SCMS known-answer vectors.