### PR TITLE
Silicon Sundays Meetup

### DIFF
--- a/draft/2026-08-12-this-week-in-rust.md
+++ b/draft/2026-08-12-this-week-in-rust.md
@@ -237,6 +237,8 @@ Rusty Events between 2026-08-12 - 2026-09-09 🦀
     * [**Sessió setmanal de codificació / Weekly coding session**](https://luma.com/arkkrcj5)
 * 2026-09-02 | Virtual (Indianapolis, IN, US) | [Indy Rust](https://www.meetup.com/indyrs/events/)
     * [**Indy.rs - with Social Distancing**](https://www.meetup.com/indyrs/events/wqzhftyjcmbdb/)
+* 2026-08-16 | Virtual (Bangalore, IN) | [Embedded Rust](https://discord.com/invite/pvYY69PvyS)
+    * [**Silicon Sundays #2**](https://discord.gg/tpsNpDHC?event=1536322186829242389)
 
 ### Africa
 * 2026-08-11 | Johannesburg, ZA | [Johannesburg Rust Meetup](https://www.meetup.com/johannesburg-rust-meetup)

--- a/draft/2026-08-12-this-week-in-rust.md
+++ b/draft/2026-08-12-this-week-in-rust.md
@@ -219,6 +219,8 @@ Rusty Events between 2026-08-12 - 2026-09-09 🦀
     * [**Rust Nürnberg online**](https://www.meetup.com/rust-noris/events/315619609/)
 * 2026-08-14 | Virtual (Girona, ES) | [Rust Girona](https://luma.com/rust-girona)
     * [**Sessió setmanal de codificació / Weekly coding session**](https://luma.com/f2hnzrug)
+* 2026-08-16 | Virtual (Bangalore, IN) | [Embedded Rust](https://discord.com/invite/pvYY69PvyS)
+    * [**Silicon Sundays #2**](https://discord.gg/tpsNpDHC?event=1536322186829242389)
 * 2026-08-18 | Virtual (Washington, DC, US) | [Rust DC](https://www.meetup.com/rustdc)
     * [**Mid-month Rustful**](https://www.meetup.com/rustdc/events/315604176/)
 * 2026-08-19 | Hybrid (Vancouver, BC, CA) | [Vancouver Rust](https://www.meetup.com/vancouver-rust)
@@ -237,8 +239,6 @@ Rusty Events between 2026-08-12 - 2026-09-09 🦀
     * [**Sessió setmanal de codificació / Weekly coding session**](https://luma.com/arkkrcj5)
 * 2026-09-02 | Virtual (Indianapolis, IN, US) | [Indy Rust](https://www.meetup.com/indyrs/events/)
     * [**Indy.rs - with Social Distancing**](https://www.meetup.com/indyrs/events/wqzhftyjcmbdb/)
-* 2026-08-16 | Virtual (Bangalore, IN) | [Embedded Rust](https://discord.com/invite/pvYY69PvyS)
-    * [**Silicon Sundays #2**](https://discord.gg/tpsNpDHC?event=1536322186829242389)
 
 ### Africa
 * 2026-08-11 | Johannesburg, ZA | [Johannesburg Rust Meetup](https://www.meetup.com/johannesburg-rust-meetup)


### PR DESCRIPTION
The [Embedded Rust Discord](https://discord.com/invite/pvYY69PvyS), is hosting it's second **Silicon Sundays** meetup on 16th August 2026.

I would love to have it featured in This Week in Rust.
