### PR TITLE
Add kache 0.14.0 to Project/Tooling Updates

### DIFF
--- a/draft/2026-08-12-this-week-in-rust.md
+++ b/draft/2026-08-12-this-week-in-rust.md
@@ -44,6 +44,7 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
+* [kache 0.14.0: debuggable restores and cross-clone convergence](https://github.com/kunobi-ninja/kache/releases/tag/v0.14.0)
 
 * [GRIT 1.1: type-check your quantized tensors](https://singhpratech.github.io/grit-datatype/)
 * [git-cache-proxy: read-only cache for git](https://rolandsdev.blog/posts/caching-git-clones-across-a-slow-network/)


### PR DESCRIPTION
Adds a Project/Tooling Updates entry for the kache 0.14.0 release.

* [kache 0.14.0: debuggable restores and cross-clone convergence](https://github.com/kunobi-ninja/kache/releases/tag/v0.14.0)

kache is an open-source, content-addressed build cache (RUSTC_WRAPPER, and a C/C++ compiler wrapper). 0.14.0 makes restored macOS binaries debuggable again (it bakes a self-contained .dSYM with dsymutil at store time, since a restored -g binary's N_OSO records point at per-build .o files that are gone at the restore path), and converges cross-clone builds onto the same cache entries (an OUT_DIR-relative env-dep sentinel plus portable dep-info and validate-on-hit close the last divergence after rustc's own path remapping; cache key bumped to v25). It also adds adaptive incremental compilation for source-churn builds, detects arbitrary cc-compatible compilers via a -E probe, supports rustc response files, and lands a stack of store concurrency-correctness fixes. The linked release notes cover the why and how.