### PR TITLE
Add blog post about the performance of crypto libraries

### DIFF
--- a/draft/2026-08-12-this-week-in-rust.md
+++ b/draft/2026-08-12-this-week-in-rust.md
@@ -50,6 +50,8 @@ and just ask the editors to select the category.
 
 ### Observations/Thoughts
 
+* [TLS Handshakes: Measuring the Performance of 4 Cryptography Libraries](https://c410-f3r.github.io/thoughts/tls-handshakes-measuring-the-performance-of-4-cryptography-libraries/)
+
 ### Rust Walkthroughs
 
 ### Research


### PR DESCRIPTION
Adds a blog post that measures the performance of different cryptography libraries when associated with TLS 1.3 handshakes.