### PR TITLE
Add kobe 0.39.0 to Project/Tooling Updates

### DIFF
--- a/draft/2026-08-12-this-week-in-rust.md
+++ b/draft/2026-08-12-this-week-in-rust.md
@@ -44,6 +44,7 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
+* [kobe 0.39.0: hardening the cluster-lease lifecycle](https://github.com/kunobi-ninja/kobe/releases/tag/v0.39.0)
 
 * [GRIT 1.1: type-check your quantized tensors](https://singhpratech.github.io/grit-datatype/)
 * [git-cache-proxy: read-only cache for git](https://rolandsdev.blog/posts/caching-git-clones-across-a-slow-network/)


### PR DESCRIPTION
Adds a Project/Tooling Updates entry for the kobe 0.39.0 release.

* [kobe 0.39.0: hardening the cluster-lease lifecycle](https://github.com/kunobi-ninja/kobe/releases/tag/v0.39.0)

kobe is an open-source (Apache-2.0) Kubernetes operator written in Rust that leases pre-warmed ephemeral clusters to CI and developers. 0.38-0.39 harden the lease lifecycle: the connect-proxy now requires a client certificate for exec/attach/port-forward, a ClusterLease is UID-fenced to its ClusterInstance so it can't drift onto another, each cluster gets its own PostgreSQL role for blast-radius isolation, and three pool/lease reconcile races found by audit are fixed. It also adds a large test-coverage pass over the CRD wire contracts and the vcluster backend. The linked release notes cover the why and how.