### PR TITLE
Add renew 0.1.1 to Project/Tooling Updates

### DIFF
--- a/draft/2026-08-12-this-week-in-rust.md
+++ b/draft/2026-08-12-this-week-in-rust.md
@@ -47,6 +47,7 @@ and just ask the editors to select the category.
 
 * [GRIT 1.1: type-check your quantized tensors](https://singhpratech.github.io/grit-datatype/)
 * [git-cache-proxy: read-only cache for git](https://rolandsdev.blog/posts/caching-git-clones-across-a-slow-network/)
+* [renew 0.1.1: a deterministic, code-first game engine](https://github.com/renew-engine/renew/releases/tag/v0.1.1)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
Adds one line to Project/Tooling Updates in the current draft, linking the first release of [renew](https://github.com/renew-engine/renew).

renew is a game engine in Rust whose simulation core is bit-deterministic by construction: a fixed timestep over integer nanoseconds, arithmetic in Q47.16 fixed point rather than floating point, no wall-clock reads, no unseeded randomness, and component storage whose iteration order is defined by slot. Each platform emits its simulation digests in CI and a final job compares them against one another, so the cross-platform claim is discharged by targets agreeing with each other rather than against a committed constant.

0.1.1 is the first release: 27 crates on crates.io under the `renew-` prefix, Apache-2.0, documentation on docs.rs. Five crates are core; the rest are optional and removable, and CI builds and tests one configuration per removed crate.

It is in early development, with no module yet at `stable` maturity, and the linked release says so plainly rather than overselling.

This is a project submission rather than an article, and it is my only project submission this week.