### PR TITLE
Add 'Watching an LLM think, in ratatui' to Rust Walkthroughs

### DIFF
--- a/draft/2026-08-12-this-week-in-rust.md
+++ b/draft/2026-08-12-this-week-in-rust.md
@@ -67,6 +67,7 @@ and just ask the editors to select the category.
 
 * [Profiling Rust with hotpath-rs: The Complete Guide - From SQL Queries to CPU Sampling](https://hotpath.rs/blog/profiling-rust-guide)
 * [A chip-agnostic architecture for bare-metal embedded Rust](https://aaronqian.com/log/2026-08-01-chip-agnostic-architecture-bare-metal-rust/)
+* [Watching an LLM think, in ratatui: what building amtr taught me about terminal rendering](https://arian-shamaei.github.io/anthropometer/building-amtr.html)
 
 ### Research
 


### PR DESCRIPTION
Adds a short walkthrough on ratatui rendering techniques from building
amtr (a terminal context-monitor for Claude Code): fixed-scale block-map
layout under resize, color-vision-deficiency gates as unit tests (Machado
2009 + CIE76 floors), and validating TUIs against the real terminal cell
grid via tmux instead of typescript replays.

Per the LLM policy: the tool itself is built with LLM assistance and the
article discloses this in its text.