### PR TITLE
Add agentflow to Project/Tooling Updates

### DIFF
--- a/draft/2026-08-12-this-week-in-rust.md
+++ b/draft/2026-08-12-this-week-in-rust.md
@@ -66,6 +66,7 @@ We are making changes to the Project/Tooling Updates Section - see [here](https:
 * [GRIT 1.1: type-check your quantized tensors](https://singhpratech.github.io/grit-datatype/)
 * [floDl: Introducing AMD GPU support](https://flodl.dev/blog/making-room)
 * [git-cache-proxy: read-only cache for git](https://rolandsdev.blog/posts/caching-git-clones-across-a-slow-network/)
+* [agentflow: an AgentOps stack for Rust agents](https://www.thainc.info/blog/agentflow)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
Re-adding agentflow to this week's Project/Tooling Updates -- my earlier PR (#8578) linked directly to crates.io and was removed per the section guidelines. This one links to a write-up instead: what agentflow is (9 composable Rust crates for AgentOps -- guard, evaluate, cache, trace, checkpoint, memory, etc.) and three specific things I learned building it (a semantic-cache false-hit bug only a real independence test catches, why a checkpoint has to be a genuine serialized copy rather than a clone, and a guard-retry behavior that surprised me as a user of my own crate).

https://www.thainc.info/blog/agentflow