### PR TITLE
Add Umbral to Project/Tooling Updates

### DIFF
--- a/draft/2026-08-19-this-week-in-rust.md
+++ b/draft/2026-08-19-this-week-in-rust.md
@@ -45,6 +45,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [Umbral - plugin-first Rust web framework](https://dev.to/dalmasonto/umbral-declare-your-data-in-rust-get-migrations-an-admin-and-a-rest-api-for-free-43oh)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
Re-submitting the Umbral entry from #8566 with just the short link text and no trailing description, per the review feedback there. That PR's draft (2026-08-12) was published before the entry made it in, so this one targets the current 2026-08-19 draft.