### PR TITLE
Add dram write-up to Project/Tooling Updates

### DIFF
--- a/draft/2026-08-19-this-week-in-rust.md
+++ b/draft/2026-08-19-this-week-in-rust.md
@@ -45,6 +45,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [Building a Homebrew-compatible package manager in a day, with an AI](https://github.com/spoodyz/dram/blob/main/docs/building-dram.md)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
Adds a write-up on building [dram](https://github.com/spoodyz/dram), a bottle-only Homebrew-compatible package manager for macOS in Rust (Mach-O relocation and re-signing, a tokio wave-scheduled install pipeline, interpreting Homebrew's declarative post_install JSON).

Per the LLM content guidelines: most of the project's code and the article draft were written by an AI agent, and the article discloses this prominently in its byline.