### PR TITLE
Add 'The Lint That Would Have Caught It Is Off by Default' to Observations/Thoughts

### DIFF
--- a/draft/2026-08-19-this-week-in-rust.md
+++ b/draft/2026-08-19-this-week-in-rust.md
@@ -47,6 +47,8 @@ and just ask the editors to select the category.
 
 ### Observations/Thoughts
 
+* [The Lint That Would Have Caught It Is Off by Default](https://ai2rules.dev/blog/the-lint-that-was-off-by-default/)
+
 ### Rust Walkthroughs
 
 ### Research


### PR DESCRIPTION
Submitting my own post for issue 665.

**Link:** https://ai2rules.dev/blog/the-lint-that-was-off-by-default/

`clippy::let_underscore_must_use` is a `restriction` lint, so it is not in `all`, `pedantic` or `nursery` — you only get it by naming it. The post shows a `let _ = writeln!(f, ..)` that passed `cargo clippy -- -D warnings` while silently disabling a security property, a minimal reproduction, and the measurement that decides whether the lint is practical to enable (35 hits across a 20k-line workspace). It argues against banning `let _ =`, since one of ours is deliberate and correct.

There is a shorter second section on pinning `rust-toolchain.toml` after a local `stable` drifted fifteen months behind CI.

**On the LLM policy in the README:** the post was drafted with AI assistance and says so in its own footer, as requested.

I put it under **Observations/Thoughts**; if **Rust Walkthroughs** is a better fit, please move it — happy either way.