### PR TITLE
Add post on cargo-semver-checks use in Rust stdlib CI

### DIFF
--- a/draft/2026-08-19-this-week-in-rust.md
+++ b/draft/2026-08-19-this-week-in-rust.md
@@ -44,6 +44,7 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
+- [Protecting the Rust standard library from accidental breakage](https://predr.ag/blog/protecting-the-rust-stdlib-from-breakage/)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
Rust's CI now runs `cargo-semver-checks` to catch and prevent accidental breakage in `core`, `std`, and `alloc`. This post explains why that matters, and how it works.

Thank you for running TWiR 🦀