### PR TITLE
CFP: sysknife

### DIFF
--- a/draft/2026-08-19-this-week-in-rust.md
+++ b/draft/2026-08-19-this-week-in-rust.md
@@ -120,7 +120,9 @@ Every week we highlight some tasks from the Rust community for you to pick and g
 Some of these tasks may also have mentors available, visit the task page for more information.
 
 <!-- CFPs go here, use this format: * [project name - title of issue](URL to issue) -->
-<!-- * [ - ]() -->
+* [sysknife - Export the audit chain rows, not just the verify verdict](https://github.com/lacs-project/sysknife/issues/215)
+* [sysknife - Expose the read-only actions as MCP tools without exposing AptUpdate](https://github.com/lacs-project/sysknife/issues/216)
+* [sysknife - Record a current Fedora Atomic validation run](https://github.com/lacs-project/sysknife/issues/217)
 <!-- or if none - *No Calls for participation were submitted this week.* -->
 
 If you are a Rust project owner and are looking for contributors, please submit tasks [here][guidelines] or through a [PR to TWiR](https://github.com/rust-lang/this-week-in-rust) or by reaching out on [Bluesky](https://bsky.app/profile/thisweekinrust.bsky.social) or [Mastodon](https://mastodon.social/@thisweekinrust)!


### PR DESCRIPTION
Three tasks from sysknife, an MIT-licensed Rust tool that administers Linux through typed, approval-gated actions.

Against the CFP guidelines:

- OSI-approved license: MIT
- Public issue tracker: yes
- Difficulty stated on each task, as a label and in the body: `easy`, `medium`, `tedious`
- Contribution guidelines linked from every task, with no CLA and no copyright waiver

Two are labelled `good first issue`. The third needs a Fedora Atomic machine and is labelled `help wanted`.