### PR TITLE
Add project updates for NeuralAmpModeler and tools

### DIFF
--- a/draft/2026-08-19-this-week-in-rust.md
+++ b/draft/2026-08-19-this-week-in-rust.md
@@ -45,6 +45,10 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [NeuralAmpModeler-rs](https://github.com/fabiohl/NeuralAmpModeler-rs): A pure-Rust, real-time-safe neural audio engine for executing Neural Amp Modeler models with zero dynamic allocations and SIMD optimizations.
+* [NAM-Audio-Pipe](https://github.com/fabiohl/NAM-Audio-Pipe): A lightweight, standalone low-latency host for Neural Amp Modeler running natively on PipeWire/JACK.
+* [NAM-Plug](https://github.com/fabiohl/NAM-Plug): A modern, native CLAP plugin implementation of Neural Amp Modeler for Linux DAWs.
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
This PR adds the **NeuralAmpModeler-rs** ecosystem to the *Project/Tooling Updates* section:

- **[NeuralAmpModeler-rs](https://github.com/fabiohl/NeuralAmpModeler-rs)**: Pure-Rust core DSP engine implementing WaveNet and LSTM inference for guitar amplifier neural models with zero heap allocations on the audio thread, lock-free architecture, and cross-platform SIMD vectorization.
- **[NAM-Audio-Pipe](https://github.com/fabiohl/NAM-Audio-Pipe)**: Standalone native Linux audio host for PipeWire and JACK, designed for ultra-low latency live performance without DAW overhead.
- **[NAM-Plug](https://github.com/fabiohl/NAM-Plug)**: Modern CLAP audio plugin for Linux DAWs (Bitwig, Reaper, Ardour).

### Checklist
- [x] Link text matches project/repository titles.
- [x] No tracking parameters or URL shorteners included.
- [x] Open-source project (Apache-2.0 / GPL-3.0) written in pure Rust.
- [x] Added to the active upcoming draft in `drafts/`.