### PR TITLE
Add Rust walkthrough: the 22 errors every beginner hits

### DIFF
--- a/draft/2026-08-19-this-week-in-rust.md
+++ b/draft/2026-08-19-this-week-in-rust.md
@@ -49,6 +49,8 @@ and just ask the editors to select the category.
 
 ### Rust Walkthroughs
 
+* [The 22 Rust errors every beginner hits, in the order they hit them](https://dev.to/yetmike/the-22-rust-errors-every-beginner-hits-in-the-order-they-hit-them-13gi)
+
 ### Research
 
 ### Miscellaneous


### PR DESCRIPTION
A walkthrough of the 22 rustc errors a beginner hits in their first week, with the real diagnostic for each, what it's actually saying, and the fix.

Every diagnostic was captured from rustc 1.96.0 compiling a real broken program rather than written from memory. LLM involvement is disclosed in the article, per CONTRIBUTING.

Section: Rust Walkthroughs.