### PR TITLE
Add BrowsePod's Wasm Rust target walkthrough to Rust Walkthroughs

### DIFF
--- a/draft/2026-08-19-this-week-in-rust.md
+++ b/draft/2026-08-19-this-week-in-rust.md
@@ -49,6 +49,8 @@ and just ask the editors to select the category.
 
 ### Rust Walkthroughs
 
++* [Beyond WASI: Running any Rust application in the browser with BrowserPod 3.0](https://labs.leaningtech.com/blog/browserpod-rust)
+
 ### Research
 
 ### Miscellaneous


### PR DESCRIPTION
Adds one link to the Rust 

Walkthroughs section of the issue 665 draft.

Link: [Beyond WASI: Running any Rust application in the browser with BrowserPod 3.0](https://labs.leaningtech.com/blog/browserpod-rust)

What it covers: 

- Write-up of building a custom Rust compiler target (wasm32-browserpod-linux-musl) so unmodified Linux Rust binaries run in a browser.

- Motivated by Yarn asking us to help run the Yarn 6 playround in the browser via Wasm, which is now live

- Covers why existing WASI targets weren't a fit (replacing std::os::unix usage, and wasm32-wasip3's cooperative threading without real parallelism), the target-spec JSON, why the target declares "arch": "wasm64" while still passing wasm32 to the LLVM backend (because arch = "wasm32" is widely used by crates to detect standalone web builds), why the wasm target family designation was dropped, the standard-library support needed for the arch/os combination, and the libc and linux-raw-sys overrides required to link against a custom musl build. It currently needs a nightly compiler.

Includes results for ripgrep (~40k SLOC), zpm (~50k), starship (~50k) and jj (~200k) building with no source changes.

I work at Leaning Technologies, so flagging the affiliation up front. I've linked the engineering write-up rather than any product page, and I've kept to one submission. Rust Walkthroughs looked like the right section per the README, since the post shows how the target was built and includes the source, but please re-file it wherever you think it fits or drop it if you'd rather not run vendor-authored posts.
