### PR TITLE
Add pulse_map to Call for Participation

### DIFF
--- a/content/2026-08-12-this-week-in-rust.md
+++ b/content/2026-08-12-this-week-in-rust.md
@@ -130,7 +130,11 @@ Some of these tasks may also have mentors available, visit the task page for mor
 
 <!-- CFPs go here, use this format: * [project name - title of issue](URL to issue) -->
 * [Diesel - Improve the documentation of our derives](https://github.com/diesel-rs/diesel/issues/4840)
-<!-- * [ - ]() -->
+* [pulse_map - Add cargo-fuzz harness for insert/get/remove sequences](https://github.com/ddsha441981/pulse_map/issues/7)
+* [pulse_map - Add 24-hour soak test for ConcurrentPulseMap and ShardedPulseMap](https://github.com/ddsha441981/pulse_map/issues/8)
+* [pulse_map - Add loom tests for MetaWord AtomicU64 CAS correctness](https://github.com/ddsha441981/pulse_map/issues/9)
+* [pulse_map - Add CI job to verify no_std compilation on thumbv7m-none-eabi](https://github.com/ddsha441981/pulse_map/issues/10)
+* [pulse_map - Run Miri on test suite to detect undefined behavior in unsafe code](https://github.com/ddsha441981/pulse_map/issues/11)
 <!-- or if none - *No Calls for participation were submitted this week.* -->
 
 If you are a Rust project owner and are looking for contributors, please submit tasks [here][guidelines] or through a [PR to TWiR](https://github.com/rust-lang/this-week-in-rust) or by reaching out on [Bluesky](https://bsky.app/profile/thisweekinrust.bsky.social) or [Mastodon](https://mastodon.social/@thisweekinrust)!


### PR DESCRIPTION
## Summary

Adding [pulse_map](https://crates.io/crates/pulse_map) to the Call for Participation section.

pulse_map is a CPU cache-line aligned hash table with built-in LFU+LRU eviction, where every bucket fits in exactly one 64-byte cache line. It is published on crates.io (v0.6.3) and has open issues with `good first issue` and `help wanted` labels.

## Issues Added

| Issue | Labels |
|-------|--------|
| [#7 - Add cargo-fuzz harness](https://github.com/ddsha441981/pulse_map/issues/7) | good first issue, help wanted |
| [#8 - Add 24-hour soak test](https://github.com/ddsha441981/pulse_map/issues/8) | good first issue, help wanted |
| [#9 - Add loom tests for AtomicU64 CAS](https://github.com/ddsha441981/pulse_map/issues/9) | help wanted |
| [#10 - Add CI for bare-metal embedded target](https://github.com/ddsha441981/pulse_map/issues/10) | good first issue, help wanted |
| [#11 - Run Miri on test suite](https://github.com/ddsha441981/pulse_map/issues/11) | help wanted |

All issues follow the [CFP guidelines](https://github.com/rust-lang/this-week-in-rust?tab=readme-ov-file#call-for-participation-guidelines) — each has a clear description, acceptance criteria, and is labeled appropriately.