### PR TITLE
Add CFP: YantrikDB - migrate manual SAVEPOINT sites to SavepointGuard

### DIFF
--- a/draft/2026-08-19-this-week-in-rust.md
+++ b/draft/2026-08-19-this-week-in-rust.md
@@ -123,6 +123,7 @@ Some of these tasks may also have mentors available, visit the task page for mor
 * [sysknife - Export the audit chain rows, not just the verify verdict](https://github.com/lacs-project/sysknife/issues/215)
 * [sysknife - Expose the read-only actions as MCP tools without exposing AptUpdate](https://github.com/lacs-project/sysknife/issues/216)
 * [sysknife - Record a current Fedora Atomic validation run](https://github.com/lacs-project/sysknife/issues/217)
+* [YantrikDB - Migrate the 7 remaining manual SAVEPOINT sites to SavepointGuard (panic-unwind hole + 7 hand-rolled copies of the unwind rule)](https://github.com/yantrikos/yantrikdb/issues/100)
 <!-- or if none - *No Calls for participation were submitted this week.* -->
 
 If you are a Rust project owner and are looking for contributors, please submit tasks [here][guidelines] or through a [PR to TWiR](https://github.com/rust-lang/this-week-in-rust) or by reaching out on [Bluesky](https://bsky.app/profile/thisweekinrust.bsky.social) or [Mastodon](https://mastodon.social/@thisweekinrust)!


### PR DESCRIPTION
Adds one Call for Participation entry for YantrikDB, a Rust cognitive-memory
engine. I maintain it.

* [YantrikDB - Migrate the 7 remaining manual SAVEPOINT sites to SavepointGuard (panic-unwind hole + 7 hand-rolled copies of the unwind rule)](https://github.com/yantrikos/yantrikdb/issues/100)

Against the CFP - Projects guidelines in the README:

- **OSI-approved license** — Apache-2.0.
- **Public issue tracker** — yes.
- **Task described, with difficulty** — the issue names all seven call sites
  with file and approximate line, gives the fix direction, and flags the two
  that are not copy-paste. Labelled `difficulty: medium`; there is a reference
  implementation already in the tree (`SavepointGuard` plus the migrated
  `record_batch`), so the shape of the change is settled and the work is
  applying it.
- **Contribution guidelines linked in the task, with any specific
  requirements** — linked in a comment on the issue and at
  [CONTRIBUTING.md](https://github.com/yantrikos/yantrikdb/blob/main/CONTRIBUTING.md).
  There is **no CLA and no copyright assignment**; Apache-2.0 section 5 applies.
- **Still open** — yes, and unclaimed.

Happy to drop it if the entry reads too long; the issue title is used verbatim
per the link-style guideline, and I would rather you trim it than I paraphrase
it.
