### PR TITLE
Add MCP browser bot-detection study to Observations/Thoughts

### DIFF
--- a/draft/2026-08-19-this-week-in-rust.md
+++ b/draft/2026-08-19-this-week-in-rust.md
@@ -47,6 +47,8 @@ and just ask the editors to select the category.
 
 ### Observations/Thoughts
 
+* [I ran two MCP browser tools against live bot detection. Here's the honest table.](https://pitiflautico.github.io/neobrowser/study.html)
+
 ### Rust Walkthroughs
 
 ### Research


### PR DESCRIPTION
Adds a reproducible study comparing two MCP browser tools (NeoBrowser, a Rust MCP server driving real Chrome via CDP, vs Playwright MCP) against live public bot-detection sites, with raw data and methodology published in the linked repo.

Entry:
* [I ran two MCP browser tools against live bot detection. Here's the honest table.](https://pitiflautico.github.io/neobrowser/study.html)