### PR TITLE
CFP: Cordial — three issues for 2026-08-19

### DIFF
--- a/draft/2026-08-19-this-week-in-rust.md
+++ b/draft/2026-08-19-this-week-in-rust.md
@@ -133,6 +133,9 @@ Some of these tasks may also have mentors available, visit the task page for mor
 * [sysknife - Expose the read-only actions as MCP tools without exposing AptUpdate](https://github.com/lacs-project/sysknife/issues/216)
 * [sysknife - Record a current Fedora Atomic validation run](https://github.com/lacs-project/sysknife/issues/217)
 * [YantrikDB - Migrate the 7 remaining manual SAVEPOINT sites to SavepointGuard (panic-unwind hole + 7 hand-rolled copies of the unwind rule)](https://github.com/yantrikos/yantrikdb/issues/100)
+* [Cordial - GameActivity.getWaterfallInsets has the wrong JNI descriptor](https://github.com/luohoa97/cordial/issues/11)
+* [Cordial - ro.soc.manufacturer is answered with an empty string](https://github.com/luohoa97/cordial/issues/12)
+* [Cordial - Map which FLog channels take a number and which take a severity name](https://github.com/luohoa97/cordial/issues/13)
 <!-- or if none - *No Calls for participation were submitted this week.* -->
 
 If you are a Rust project owner and are looking for contributors, please submit tasks [here][guidelines] or through a [PR to TWiR](https://github.com/rust-lang/this-week-in-rust) or by reaching out on [Bluesky](https://bsky.app/profile/thisweekinrust.bsky.social) or [Mastodon](https://mastodon.social/@thisweekinrust)!


### PR DESCRIPTION
Three tasks from [Cordial](https://github.com/luohoa97/cordial) (GPL-3.0) for the Call for Participation section.

* [Cordial - GameActivity.getWaterfallInsets has the wrong JNI descriptor](https://github.com/luohoa97/cordial/issues/11)
* [Cordial - ro.soc.manufacturer is answered with an empty string](https://github.com/luohoa97/cordial/issues/12)
* [Cordial - Map which FLog channels take a number and which take a severity name](https://github.com/luohoa97/cordial/issues/13)

All three are labelled `good first issue`, are scoped so someone who has never seen the repository can finish them, and need no prior context about the project to start. The first two are small and have a tool or a one-line reproduction in the issue text; the third is a mapping task with a documented method.

Cordial loads Roblox's official Android library natively on Linux — a ported AOSP bionic linker, a bionic/glibc shim, and a framework layer, written in Rust with C++ shims. A previous set was submitted in #8517.

---

*Disclosure: this pull request was prepared by Claude (an LLM) acting on behalf of the repository maintainer, who reviewed and authorised the submission. The linked issues were also drafted with LLM assistance and are maintainer-reviewed. Happy to adjust the wording, the number of entries, or drop any of them if they do not fit the section.*