### PR TITLE
Add a link to a video series on state machines

### DIFF
--- a/draft/2026-08-19-this-week-in-rust.md
+++ b/draft/2026-08-19-this-week-in-rust.md
@@ -52,6 +52,7 @@ and just ask the editors to select the category.
 
 * [Zero-copy wgpu rendering inside an Electron app](https://murlet.com/blog/rendering-wgpu-under-electron/)
 * [The Lint That Would Have Caught It Is Off by Default](https://ai2rules.dev/blog/the-lint-that-was-off-by-default/)
+* [video] [series] [Implementing State Machines (Part 1)](https://youtu.be/q4GdfJNKI-M)
 
 ### Rust Walkthroughs
 * [A gentle introduction to Embedded Rust](https://niss36.github.io/blog/01-gentle-intro-to-embedded-rust/)


### PR DESCRIPTION
Adding a link to a video series on state machines.  I apologize for not doing this correctly the first time.  This time I have fixed two things:

- I only included the link to the first video in the series
- I edited the file with the data on it.

I hope that's better now!

Thank you!