### PR TITLE
Add magpie to Project/Tooling Updates

### DIFF
--- a/draft/2026-08-26-this-week-in-rust.md
+++ b/draft/2026-08-26-this-week-in-rust.md
@@ -44,6 +44,7 @@ and just ask the editors to select the category.
 ### Newsletters
 
 ### Project/Tooling Updates
+* [magpie: a local-first Spotlight-style launcher that searches your GitHub stars, local files, images, and bookmarks](https://github.com/newdee/magpie)
 
 ### Observations/Thoughts
 


### PR DESCRIPTION
Adds [magpie](https://github.com/newdee/magpie) — an open-source (MIT) local-first Spotlight-style desktop launcher written in Rust + Tauri v2. It searches your GitHub stars (full chunked-embedded READMEs), explicitly-added local folders (full-text incl. PDF/Office), images by content via SigLIP 2, and browser bookmarks, using hybrid FTS5 + local semantic embeddings with cross-language retrieval. Everything runs on-device.