### PR TITLE
CFP: sysknife

### DIFF
--- a/draft/2026-08-26-this-week-in-rust.md
+++ b/draft/2026-08-26-this-week-in-rust.md
@@ -120,7 +120,9 @@ Every week we highlight some tasks from the Rust community for you to pick and g
 Some of these tasks may also have mentors available, visit the task page for more information.
 
 <!-- CFPs go here, use this format: * [project name - title of issue](URL to issue) -->
-<!-- * [ - ]() -->
+* [sysknife - Split the Ubuntu-only actions out of DEBIAN_ONLY_ACTIONS](https://github.com/lacs-project/sysknife/issues/237)
+* [sysknife - Make Debian eligible: a version floor of 12, and a reason in is_supported](https://github.com/lacs-project/sysknife/issues/238)
+* [sysknife - Debian's default firewall is nftables, and the catalogue has no nftables vocabulary](https://github.com/lacs-project/sysknife/issues/239)
 <!-- or if none - *No Calls for participation were submitted this week.* -->
 
 If you are a Rust project owner and are looking for contributors, please submit tasks [here][guidelines] or through a [PR to TWiR](https://github.com/rust-lang/this-week-in-rust) or by reaching out on [Bluesky](https://bsky.app/profile/thisweekinrust.bsky.social) or [Mastodon](https://mastodon.social/@thisweekinrust)!


### PR DESCRIPTION
Three tasks from sysknife, an MCP server that turns plain-language sysadmin requests into typed, approval-gated actions on Linux. All three widen distro support, which is where the project needs help most.

- [Split the Ubuntu-only actions out of DEBIAN_ONLY_ACTIONS](https://github.com/lacs-project/sysknife/issues/237)
- [Make Debian eligible: a version floor of 12, and a reason in is_supported](https://github.com/lacs-project/sysknife/issues/238)
- [Debian's default firewall is nftables, and the catalogue has no nftables vocabulary](https://github.com/lacs-project/sysknife/issues/239)

Each carries a difficulty label (all three are `medium`), a description of the work, and a link to CONTRIBUTING.md. MIT licensed, public tracker, no CLA and no copyright waiver.