### PR TITLE
Add SEMAPRAX semantic identity article

### DIFF
--- a/draft/2026-08-26-this-week-in-rust.md
+++ b/draft/2026-08-26-this-week-in-rust.md
@@ -45,6 +45,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [Why Agent Edits Need Semantic Identity: Building SEMAPRAX in Rust](https://wavect.io/blog/semantic-identity-rust-agent-edits/)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
Adds the canonical Wavect article to the August 26 **Project/Tooling Updates** section.

The article is a Rust-focused compiler walkthrough covering `DeclarationId`/`ExpressionId` newtypes, checked HIR, ordered collections, deterministic graph projection, and replay-before-commit patch evidence. It identifies SEMAPRAX as pre-alpha research and includes an explicit OpenAI Codex drafting/translation disclosure.

Article: https://wavect.io/blog/semantic-identity-rust-agent-edits/

Disclosure: Wavect GmbH builds SEMAPRAX. No project CI was manually invoked.