### PR TITLE
add crux to Project/Tooling Updates

### DIFF
--- a/draft/2026-08-26-this-week-in-rust.md
+++ b/draft/2026-08-26-this-week-in-rust.md
@@ -45,6 +45,10 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [crux](https://github.com/Emran-goat/crux) finds the exact commit that changed a program's behavior, then minimizes the flip commit down to the lines that caused it
+
+* [crux](https://github.com/Emran-goat/crux) finds the exact commit that changed a program's behavior, then minimizes the flip commit down to the lines that caused it
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
Adds crux, a CLI that finds the commit which changed a program's behavior and minimizes the flip commit to the lines that caused it. Written in Rust, 2 MB binary, published on crates.io as crux-finder.