### PR TITLE
Add `Announcing our first Maintainers in Residence` official blog post

### DIFF
--- a/draft/2026-08-26-this-week-in-rust.md
+++ b/draft/2026-08-26-this-week-in-rust.md
@@ -39,6 +39,8 @@ and just ask the editors to select the category.
 
 ### Official
 
+- [Announcing our first Maintainers in Residence](https://blog.rust-lang.org/2026/08/26/announcing-our-first-maintainers-in-residence/)
+
 ### Foundation
 
 ### Newsletters


### PR DESCRIPTION
I know that you gather official blog posts automatically, but it happened a few times that the post slipped into next week, and since this post was released shortly before the next TWiR issue, I wanted to ensure that it gets into this week. Feel free to close this PR if you get the link in through other means!
