### PR TITLE
Add: Safe kernels are fast kernels: tile-rs next to Mojo 1.0

### DIFF
--- a/draft/2026-08-26-this-week-in-rust.md
+++ b/draft/2026-08-26-this-week-in-rust.md
@@ -47,6 +47,8 @@ and just ask the editors to select the category.
 
 ### Observations/Thoughts
 
+* [Safe kernels are fast kernels: tile-rs next to Mojo 1.0](https://yijunyu.github.io/tile-rs-vs-mojo.html)
+
 ### Rust Walkthroughs
 
 ### Research


### PR DESCRIPTION
Suggesting a post for **Observations/Thoughts**.

[Safe kernels are fast kernels: tile-rs next to Mojo 1.0](https://yijunyu.github.io/tile-rs-vs-mojo.html)

Rust relevance: tile-rs is a Rust tile DSL for accelerator kernels with a custom `rustc` codegen backend that lowers through MLIR. The post benchmarks its generated Metal kernels against Mojo 1.0 on the same GPU — 16 kernels on an Apple M1 Ultra — and reports the method and the caveats alongside the numbers.

Self-submission, and the post is from this week.