### PR TITLE
CFP: HookEcho

### DIFF
--- a/draft/2026-09-02-this-week-in-rust.md
+++ b/draft/2026-09-02-this-week-in-rust.md
@@ -121,6 +121,7 @@ Some of these tasks may also have mentors available, visit the task page for mor
 
 <!-- CFPs go here, use this format: * [project name - title of issue](URL to issue) -->
 <!-- * [ - ]() -->
+* [HookEcho - High-contrast theme: colormaps and stroke widths do not respond to it](https://github.com/d4vid87/hookecho/issues/12)
 <!-- or if none - *No Calls for participation were submitted this week.* -->
 
 If you are a Rust project owner and are looking for contributors, please submit tasks [here][guidelines] or through a [PR to TWiR](https://github.com/rust-lang/this-week-in-rust) or by reaching out on [Bluesky](https://bsky.app/profile/thisweekinrust.bsky.social) or [Mastodon](https://mastodon.social/@thisweekinrust)!


### PR DESCRIPTION
Adding one Call for Participation entry for HookEcho, an MIT-licensed NEXRAD weather radar viewer written in Rust (egui/wgpu; desktop, Android and wasm).

The issue is self-contained, states its difficulty (easy) in the description, and links the project's contribution guidelines — no CLA or copyright waiver. Public issue tracker, OSI-approved license.