### PR TITLE
Add pulse_map 0.6.4 to Project/Tooling Updates

### DIFF
--- a/draft/2026-09-02-this-week-in-rust.md
+++ b/draft/2026-09-02-this-week-in-rust.md
@@ -45,6 +45,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [pulse_map 0.6.4: cache-line hash table now runs on wasm32 and embedded 32-bit targets](https://github.com/ddsha441981/pulse_map/releases/tag/v0.6.4)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
## Summary

Adding the [pulse_map](https://crates.io/crates/pulse_map) 0.6.4 release to Project/Tooling Updates.

pulse_map is a CPU cache-line hash table with embedded LFU+LRU eviction — every bucket fits in exactly one 64-byte cache line. 0.6.4 replaces `AtomicU64` with `portable-atomic`, which makes the crate compile and run on targets without native 64-bit atomics: wasm32, ARMv7-M / thumbv7m, and 32-bit targets generally. No API changes.

Release notes: https://github.com/ddsha441981/pulse_map/releases/tag/v0.6.4
