### PR TITLE
Add Zynlex to Call for Participation

### DIFF
--- a/draft/2026-09-02-this-week-in-rust.md
+++ b/draft/2026-09-02-this-week-in-rust.md
@@ -120,6 +120,7 @@ Every week we highlight some tasks from the Rust community for you to pick and g
 Some of these tasks may also have mentors available, visit the task page for more information.
 
 <!-- CFPs go here, use this format: * [project name - title of issue](URL to issue) -->
+* [Zynlex - Add case-sensitive and whole-word toggles to find-in-page](https://github.com/webtools-dotcom/Zynlex/issues/13)
 <!-- * [ - ]() -->
 <!-- or if none - *No Calls for participation were submitted this week.* -->
 


### PR DESCRIPTION
Submitting a task for the CFP - Projects section.

Zynlex is an open-source browser for web developers built with Tauri 2 and Rust. The linked issue adds case-sensitive and whole-word toggles to find-in-page. It touches both the Rust side and the injected script, and the surrounding code is small enough to read in one sitting.

* [Zynlex - Add case-sensitive and whole-word toggles to find-in-page](https://github.com/webtools-dotcom/Zynlex/issues/13)

Repo: https://github.com/webtools-dotcom/Zynlex (Apache-2.0)

Note: I submitted a task in #8531 that was correctly closed because the linked issue had been resolved before the newsletter went out. This one is open and unassigned, and there is a second open task (#14) if a spare is useful.