### PR TITLE
Add favi-child property tests post to Rust Walkthroughs

### DIFF
--- a/draft/2026-09-02-this-week-in-rust.md
+++ b/draft/2026-09-02-this-week-in-rust.md
@@ -49,7 +49,7 @@ and just ask the editors to select the category.
 
 ### Rust Walkthroughs
 
-* [Software That Must Not Be Wrong: Property Tests for a Pediatric Dosing Calculator](https://rust-blog.github.io/post/favi-child-property-tests) - how a pediatric dosing calculator turns medical requirements into invariants, and why exhaustive enumeration beat proptest
+* [Software That Must Not Be Wrong: Property Tests for a Pediatric Dosing Calculator](https://rust-blog.github.io/post/favi-child-property-tests)
 
 ### Research
 

--- a/draft/2026-09-02-this-week-in-rust.md
+++ b/draft/2026-09-02-this-week-in-rust.md
@@ -49,6 +49,8 @@ and just ask the editors to select the category.
 
 ### Rust Walkthroughs
 
+* [Software That Must Not Be Wrong: Property Tests for a Pediatric Dosing Calculator](https://rust-blog.github.io/post/favi-child-property-tests) - how a pediatric dosing calculator turns medical requirements into invariants, and why exhaustive enumeration beat proptest
+
 ### Research
 
 ### Miscellaneous


### PR DESCRIPTION
## About the post

[Software That Must Not Be Wrong: Property Tests for a Pediatric Dosing Calculator](https://rust-blog.github.io/post/favi-child-property-tests) is a walkthrough of building a pediatric Favipiravir suspension dosing calculator in Rust (Leptos, compiled to WASM), where a wrong output is not a bug but a dose error a caregiver would follow.

The post covers:

- Turning medical requirements into domain invariants
- Writing the plan as an enumerative search over `(tablets, diluent volume)` pairs instead of a closed-form formula
- Why exhaustive enumeration over 1,500 inputs was chosen over `proptest` for this input space
- An optimality test that re-derives the search to prove no better candidate was skipped
- Keeping the domain core as pure Rust with zero framework dependencies, so `cargo test` runs without a wasm build

The article includes the actual source from [favi-child](https://github.com/suradet-ps/favi-child) and is written from my own experience building the project.
