### PR TITLE
Add article on compile-time work with Rust const fn

### DIFF
--- a/draft/2026-09-02-this-week-in-rust.md
+++ b/draft/2026-09-02-this-week-in-rust.md
@@ -47,6 +47,8 @@ and just ask the editors to select the category.
 
 ### Observations/Thoughts
 
+* [Nine Rules for Compile-Time Work with Rust const fn: Parse files, build tables, and catch mistakes … without a build script  (Part 1)](https://medium.com/@carlmkadie/nine-rules-for-compile-time-work-with-rust-const-fn-part-1-a29f7dd62b2f)
+
 ### Rust Walkthroughs
 
 ### Research


### PR DESCRIPTION
Added a new article link about compile-time work with Rust const fn.