### PR TITLE
Add TeaQL MusicBrainz ORM benchmark to Observations/Thoughts

### DIFF
--- a/draft/DRAFT_TEMPLATE
+++ b/draft/DRAFT_TEMPLATE
@@ -47,6 +47,8 @@ and just ask the editors to select the category.
 
 ### Observations/Thoughts
 
+* [What Does a Governed Data Runtime Cost? TeaQL vs Diesel and SeaORM on MusicBrainz](https://teaql.io/blog/musicbrainz-rust-orm-benchmark/)
+
 ### Rust Walkthroughs
 
 ### Research


### PR DESCRIPTION
Adds a Rust ORM benchmark article to Observations/Thoughts.

The article compares TeaQL, Diesel, and SeaORM using a public MusicBrainz PostgreSQL dataset and mainstream typed APIs. It documents correctness gates, generated SQL, methodology, reproducibility limits, and non-universal performance claims.

The article also includes the required LLM-assisted authorship disclosure.