### PR TITLE
CFP: sysknife

### DIFF
--- a/draft/2026-09-02-this-week-in-rust.md
+++ b/draft/2026-09-02-this-week-in-rust.md
@@ -120,7 +120,9 @@ Every week we highlight some tasks from the Rust community for you to pick and g
 Some of these tasks may also have mentors available, visit the task page for more information.
 
 <!-- CFPs go here, use this format: * [project name - title of issue](URL to issue) -->
-<!-- * [ - ]() -->
+* [sysknife - UfwDeleteRule needs a rule number that no action in the catalogue can produce](https://github.com/lacs-project/sysknife/issues/234)
+* [sysknife - peer_pidfd cannot tell a pre-6.5 kernel from a peer that already exited, so the PID-reuse check is off in the reuse case](https://github.com/lacs-project/sysknife/issues/250)
+* [sysknife - The signed trail names which account asked for a change, never which one approved it](https://github.com/lacs-project/sysknife/issues/249)
 <!-- or if none - *No Calls for participation were submitted this week.* -->
 
 If you are a Rust project owner and are looking for contributors, please submit tasks [here][guidelines] or through a [PR to TWiR](https://github.com/rust-lang/this-week-in-rust) or by reaching out on [Bluesky](https://bsky.app/profile/thisweekinrust.bsky.social) or [Mastodon](https://mastodon.social/@thisweekinrust)!


### PR DESCRIPTION
Three tasks from sysknife, an MIT-licensed MCP daemon that runs Linux administration actions behind a typed catalogue and a signed audit chain.

* `easy` (#234): a ufw action takes a rule number that no read action in the catalogue can produce, so the planner is pointed at a value it cannot obtain.
* `medium` (#250): the PID-reuse check on the D-Bus caller collapses two different `getsockopt` failures into one, so a peer that exited during the `/proc` read is treated the same as a kernel that never supported the pin.
* `hard` (#249): the signed trail records which account asked for a change and never which one approved it, across two storage backends.

All three are open, unassigned, carry a difficulty section, and link CONTRIBUTING.md. Public tracker, no CLA.
