### PR TITLE
Add Pinning Down Rust's Pin

### DIFF
--- a/draft/2026-09-02-this-week-in-rust.md
+++ b/draft/2026-09-02-this-week-in-rust.md
@@ -49,6 +49,8 @@ and just ask the editors to select the category.
 
 ### Rust Walkthroughs
 
+* [Pinning Down Rust’s Pin](https://gmcgoldr.github.io/2026/08/27/pin-in-rust.html)
+
 ### Research
 
 ### Miscellaneous


### PR DESCRIPTION
Adds [Pinning Down Rust’s Pin](https://gmcgoldr.github.io/2026/08/27/pin-in-rust.html) to the Rust Walkthroughs section of issue 667.

The post develops a conceptual model of `Pin` and `Unpin`, then connects it to self-referential futures and `Future::poll`.

Checks run locally:
- `tools/inspect_links.py`
- `tools/inspect_markdown.py`
- `git diff --check`