### PR TITLE
CFP: sysknife

### DIFF
--- a/draft/2026-09-09-this-week-in-rust.md
+++ b/draft/2026-09-09-this-week-in-rust.md
@@ -123,7 +123,9 @@ Every week we highlight some tasks from the Rust community for you to pick and g
 Some of these tasks may also have mentors available, visit the task page for more information.
 
 <!-- CFPs go here, use this format: * [project name - title of issue](URL to issue) -->
-<!-- * [ - ]() -->
+* [sysknife - action_reference_doc_is_current prints two 44 KB documents instead of the line that differs](https://github.com/lacs-project/sysknife/issues/345)
+* [sysknife - packages/setup claims Node 18 support, and Node 18 has been end-of-life since 2025-04-30](https://github.com/lacs-project/sysknife/issues/327)
+* [sysknife - cargo test fails intermittently on main: a test sets a process-global env var](https://github.com/lacs-project/sysknife/issues/356)
 <!-- or if none - *No Calls for participation were submitted this week.* -->
 
 If you are a Rust project owner and are looking for contributors, please submit tasks [here][guidelines] or through a [PR to TWiR](https://github.com/rust-lang/this-week-in-rust) or by reaching out on [Bluesky](https://bsky.app/profile/thisweekinrust.bsky.social) or [Mastodon](https://mastodon.social/@thisweekinrust)!


### PR DESCRIPTION
Three tasks for the 2026-09-09 issue.

sysknife is an MIT-licensed typed-action system administration tool for Linux: an agent proposes a plan, a human approves it in a terminal, and every privileged action lands in an Ed25519-signed audit chain.

| Issue | Difficulty | What it touches |
|---|---|---|
| [#345](https://github.com/lacs-project/sysknife/issues/345) | easy | a test that prints two 44 KB documents on failure instead of the line that differs |
| [#327](https://github.com/lacs-project/sysknife/issues/327) | easy | an end-of-life Node floor that has never been tested |
| [#356](https://github.com/lacs-project/sysknife/issues/356) | medium | a test that sets a process-global env var and races the rest of the suite |

All three carry a difficulty label from the four in the guidelines, and each has a tests-first section saying what to pin before changing anything. None needs a VM, an LLM provider, or maintainer credentials, and the contribution guidelines are linked from the foot of every issue. There is no CLA.

Repository: <https://github.com/lacs-project/sysknife>
Issue tracker: <https://github.com/lacs-project/sysknife/issues>
Contribution guidelines: <https://github.com/lacs-project/sysknife/blob/main/CONTRIBUTING.md>