### PR TITLE
Add 'The undo has to exist before the write does' to Observations/Thoughts

### DIFF
--- a/draft/2026-09-09-this-week-in-rust.md
+++ b/draft/2026-09-09-this-week-in-rust.md
@@ -49,6 +49,7 @@ and just ask the editors to select the category.
 ### Observations/Thoughts
 
 * [What Does a Governed Data Runtime Cost? TeaQL vs Diesel and SeaORM on MusicBrainz](https://teaql.io/blog/musicbrainz-rust-orm-benchmark/)
+* [The undo has to exist before the write does](https://dev.to/mahirhir/the-undo-has-to-exist-before-the-write-does-46on)
 
 ### Rust Walkthroughs
 


### PR DESCRIPTION
One line into Observations/Thoughts for the 2026-09-09 draft.

https://dev.to/mahirhir/the-undo-has-to-exist-before-the-write-does-46on

It is about an ordering invariant in a Rust engine I work on: the inverse of a write is constructed and escrowed before the write is applied, rather than reconstructed afterwards from a diff. The post covers why the after-the-fact version cannot be made sound when a crash lands between apply and record, and what the engine gives up to get the stronger ordering.

Self-submitted and my own writing. It is a design post rather than a release announcement; the crate is alpha and the post says so. Happy to move it to another section or drop it if Observations/Thoughts is not the right home.
