### PR TITLE
Add Rust SIMD build and disassembly walkthrough

### DIFF
--- a/draft/2026-09-09-this-week-in-rust.md
+++ b/draft/2026-09-09-this-week-in-rust.md
@@ -52,6 +52,8 @@ and just ask the editors to select the category.
 
 ### Rust Walkthroughs
 
+* [What Rust's +simd128 Actually Changed in My WebAssembly](https://www.debugdiary.dev/log/rust-simd128-what-changed-in-webassembly)
+
 ### Research
 
 ### Miscellaneous


### PR DESCRIPTION
Adds a Rust walkthrough on inspecting what `-C target-feature=+simd128` changes in emitted WebAssembly, tracing the scalar Welford loop, and measuring the generated wasm-bindgen call boundary. The article includes pinned builds, disassembly, retained timing samples, and reproduction scripts.

This is a new, separate article from the launch post submitted in #8688, with the Rust-specific code and investigation requested in that review.

Canonical article: https://www.debugdiary.dev/log/rust-simd128-what-changed-in-webassembly
