### PR TITLE
Add cordis-di v0.1.0 to Project/Tooling Updates (2026-09-09)

### DIFF
--- a/draft/2026-09-09-this-week-in-rust.md
+++ b/draft/2026-09-09-this-week-in-rust.md
@@ -46,6 +46,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [cordis-di v0.1.0 — a typed, RAII-first plugin & dependency-injection framework for Rust, inspired by Cordis](https://github.com/Ricardo-M-L/cordis-di)
+
 ### Observations/Thoughts
 
 * [What Does a Governed Data Runtime Cost? TeaQL vs Diesel and SeaORM on MusicBrainz](https://teaql.io/blog/musicbrainz-rust-orm-benchmark/)


### PR DESCRIPTION
Adds [cordis-di](https://github.com/Ricardo-M-L/cordis-di) v0.1.0 — a typed, RAII-first plugin & dependency-injection framework for Rust inspired by Cordis (MIT, CI on 3 OSes) — to the Project/Tooling Updates section of the 2026-09-09 draft.