### PR TITLE
Add local Rust memory walkthrough and agent-memory contribution tasks

### DIFF
--- a/draft/2026-09-09-this-week-in-rust.md
+++ b/draft/2026-09-09-this-week-in-rust.md
@@ -52,6 +52,8 @@ and just ask the editors to select the category.
 
 ### Rust Walkthroughs
 
+* [Keeping changed facts inspectable in a local Rust memory layer](https://github.com/Ricardo-M-L/agent-memory/blob/main/docs/fact-history.md)
+
 ### Research
 
 ### Miscellaneous
@@ -123,6 +125,8 @@ Every week we highlight some tasks from the Rust community for you to pick and g
 Some of these tasks may also have mentors available, visit the task page for more information.
 
 <!-- CFPs go here, use this format: * [project name - title of issue](URL to issue) -->
+* [agent-memory - exercise offline examples on Windows and macOS (easy–medium)](https://github.com/Ricardo-M-L/agent-memory/issues/1)
+* [agent-memory - document rule-extraction case, punctuation and Unicode behavior (easy)](https://github.com/Ricardo-M-L/agent-memory/issues/2)
 <!-- * [ - ]() -->
 <!-- or if none - *No Calls for participation were submitted this week.* -->
 


### PR DESCRIPTION
Proposes one Rust walkthrough and two bounded contributor tasks for issue 668. The walkthrough explains explicit memory supersession, graph replacement, transaction boundaries and a three-process SQLite persistence test. The linked MIT project has a public issue tracker; both tasks state difficulty, acceptance criteria and contribution instructions. Authorship disclosure: the article and this submission were written by an AI coding assistant at the project maintainer’s request; the article itself discloses this. The repository contains runnable examples and CI evidence. This does not add a plain Project/Tooling Updates entry. Please feel free to select the appropriate section or omit the article if it does not fit the editorial criteria.