### PR TITLE
Add PDF fixture line-ending debugging note

### DIFF
--- a/draft/2026-09-09-this-week-in-rust.md
+++ b/draft/2026-09-09-this-week-in-rust.md
@@ -56,6 +56,8 @@ and just ask the editors to select the category.
 
 ### Miscellaneous
 
+* [Why an ASCII-looking PDF broke only on Windows](https://github.com/Prem5123/BookMCP/blob/main/docs/launch/pdf-line-endings.md)
+
 ## Crate of the Week
 
 <!-- COTW goes here -->


### PR DESCRIPTION
Suggests “Why an ASCII-looking PDF broke only on Windows” for Miscellaneous.

The note reproduces a Git checkout conversion that changed a Rust CLI's PDF fixture from 795 to 840 bytes, shifted its xref table while retaining the old byte offset, and caused PDF extraction to fail. It includes isolated reproduction commands and the .gitattributes fix.

The article explicitly discloses OpenAI Codex authorship. Its measurements and commands were reproduced locally. It focuses on Git/PDF fixture handling and contains little Rust-specific source, so Miscellaneous is a proposal for editorial judgment; please decline or recategorize if it falls outside the newsletter's scope. It is not a project release announcement.
