### PR TITLE
Added cargo-storage too tooling updates

### DIFF
--- a/draft/2026-09-09-this-week-in-rust.md
+++ b/draft/2026-09-09-this-week-in-rust.md
@@ -46,6 +46,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [`cargo storage` A CLI/TUI tool for managing Cargo's target/build dirs](https://github.com/ranger-ross/cargo-storage)
+
 ### Observations/Thoughts
 
 * [What Does a Governed Data Runtime Cost? TeaQL vs Diesel and SeaORM on MusicBrainz](https://teaql.io/blog/musicbrainz-rust-orm-benchmark/)


### PR DESCRIPTION
Hey, this weekend I put together a cargo subcommand (`cargo storage`) for managing Cargo target and build dirs.
It seems pretty popular among my friend group so I figured I'd share it in twir.