### PR TITLE
Add Foremerge to Project/Tooling Updates

### DIFF
--- a/draft/2026-09-09-this-week-in-rust.md
+++ b/draft/2026-09-09-this-week-in-rust.md
@@ -46,6 +46,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+* [Foremerge: a coordination protocol for parallel coding agents, above Git](https://github.com/naw103/foremerge)
+
 ### Observations/Thoughts
 
 * [What Does a Governed Data Runtime Cost? TeaQL vs Diesel and SeaORM on MusicBrainz](https://teaql.io/blog/musicbrainz-rust-orm-benchmark/)


### PR DESCRIPTION
Adding Foremerge, an open source (Apache-2.0) Rust coordination protocol for parallel coding agents that sits above Git. Resubmission of #8672, which targeted the 2026-09-02 draft and closed when that issue shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)