### PR TITLE
Tutorial to Use ESP32 as SWD Programmer for STM32

### DIFF
--- a/draft/2026-09-16-this-week-in-rust.md
+++ b/draft/2026-09-16-this-week-in-rust.md
@@ -51,6 +51,7 @@ See here for details: https://github.com/rust-lang/this-week-in-rust/issues/8575
 ### Observations/Thoughts
 
 ### Rust Walkthroughs
+* [Can You Use ESP32 as SWD Programmer for STM32 with Rust?](https://blog.implrust.com/posts/2026/09/swd-protocol-programmer-embedded-rust/)
 
 ### Research
 


### PR DESCRIPTION
This is first part of blog post that gives introduction to SWD protocol and show how to read STM32’s DP IDCODE with the help of ESP32 using Rust code. This is first part of my experiment, end goal is to flash the STM32 with ESP32. 